### PR TITLE
Added ability to delete a message directly

### DIFF
--- a/src/Discord/Parts/Channel/Message.php
+++ b/src/Discord/Parts/Channel/Message.php
@@ -284,7 +284,7 @@ class Message extends Part
     {
         $deferred = new Deferred();
 
-        $this->http->delete("channels/{$this->channel->id}/messages/{$this->id}")->then(
+        $this->http->delete("channels/{$this->channel_id}/messages/{$this->id}")->then(
             \React\Partial\bind_right($this->resolve, $deferred),
             \React\Partial\bind_right($this->reject, $deferred)
         );


### PR DESCRIPTION
Ability to use `$message->delete()` instead of using `$message->channel->deleteMessages($messages)`.
May be redundant, but might as well come in handy.