### PR TITLE
Disable HappyEyeballsConnector Algorithm

### DIFF
--- a/src/Discord/Discord.php
+++ b/src/Discord/Discord.php
@@ -1334,6 +1334,8 @@ class Discord
                 $options['intents'] = $intentVal;
             }
         }
+        
+        $options['socket_options']['happy_eyeballs'] = false; //Discord doesn't use IPv6
 
         return $options;
     }


### PR DESCRIPTION
It's specifically used for IPv6, which Discord does not support. This will stop the connector from throwing exceptions constantly.