### PR TITLE
Fixed creating message with no self-member cached

### DIFF
--- a/src/Discord/Parts/Channel/Channel.php
+++ b/src/Discord/Parts/Channel/Channel.php
@@ -704,8 +704,8 @@ class Channel extends Part
             ];
         }
 
-        if (! $this->is_private) {
-            $botperms = $this->guild->members->offsetGet($this->discord->id)->getPermissions($this);
+        if (! $this->is_private && $member = $this->guild->members->offsetGet($this->discord->id)) {
+            $botperms = $member->getPermissions($this);
 
             if (! $botperms->send_messages) {
                 return \React\Promise\reject(new NoPermissionsException('You do not have permission to send messages in the specified channel.'));

--- a/src/Discord/Parts/Channel/Message.php
+++ b/src/Discord/Parts/Channel/Message.php
@@ -322,10 +322,7 @@ class Message extends Part
      */
     protected function getMemberAttribute(): ?Member
     {
-        if (($this->channel->guild &&
-            $author = $this->channel->guild->members->get('id', $this->attributes['author']->id)) ||
-            $author = $this->discord->users->get('id', $this->attributes['author']->id)
-        ) {
+        if ($this->channel->guild && $author = $this->channel->guild->members->get('id', $this->attributes['author']->id)) {
             return $author;
         }
 


### PR DESCRIPTION
Sending messages will fail when the self-bot is not cached, because we will call `getPermissions` on a null object.

Closes #522