### PR TITLE
Allow old syntax of string argument in sendMessage [develop v7.0.0-rc0]

### DIFF
--- a/src/Discord/Parts/Channel/Channel.php
+++ b/src/Discord/Parts/Channel/Channel.php
@@ -740,7 +740,7 @@ class Channel extends Part
     /**
      * Sends a message to the channel.
      *
-     * @param MessageBuilder|string $message The message builder that should be converted into a message.
+     * @param MessageBuilder|string $message The message text or message builder that should be converted into a message.
      *
      * @return ExtendedPromiseInterface<Message>
      */

--- a/src/Discord/Parts/Channel/Channel.php
+++ b/src/Discord/Parts/Channel/Channel.php
@@ -740,12 +740,16 @@ class Channel extends Part
     /**
      * Sends a message to the channel.
      *
-     * @param MessageBuilder $message The message builder that should be converted into a message.
+     * @param MessageBuilder|string $message The message builder that should be converted into a message.
      *
      * @return ExtendedPromiseInterface<Message>
      */
-    public function sendMessage(MessageBuilder $message): ExtendedPromiseInterface
+    public function sendMessage($message): ExtendedPromiseInterface
     {
+        if (is_string($message)) {
+            $message = MessageBuilder::new()->setContent($message);
+        }
+        
         if (! $this->allowText()) {
             return reject(new InvalidArgumentException('You can only send messages to text channels.'));
         }

--- a/src/Discord/Parts/Channel/Channel.php
+++ b/src/Discord/Parts/Channel/Channel.php
@@ -745,15 +745,15 @@ class Channel extends Part
      * @return ExtendedPromiseInterface<Message>
      */
     public function sendMessage($message): ExtendedPromiseInterface
-    {
+    {   
+        if (! $this->allowText()) {
+            return reject(new InvalidArgumentException('You can only send messages to text channels.'));
+        }
+        
         if (is_string($message)) {
             $message = MessageBuilder::new()->setContent($message);
         }
         
-        if (! $this->allowText()) {
-            return reject(new InvalidArgumentException('You can only send messages to text channels.'));
-        }
-
         if (! $this->is_private && $member = $this->guild->members->get('id', $this->discord->id)) {
             $botperms = $member->getPermissions($this);
 


### PR DESCRIPTION
Upgrading from older version to **dev-develop** can be a pain when you have so many existing `sendMessage` codes that just simply send the message content string, and would be difficult to refactor to convert them all with `MessageBuilder`