### PR TITLE
added customizeable custom_id feature

### DIFF
--- a/src/Discord/Builders/Components/SelectMenu.php
+++ b/src/Discord/Builders/Components/SelectMenu.php
@@ -125,16 +125,6 @@ class SelectMenu extends Component
     }
 
     /**
-     * Creates a new select menu.
-     *
-     * @return self
-     */
-    public static function new(): self
-    {
-        return new self();
-    }
-
-    /**
      * Adds an option to the select menu. Maximum 25 options.
      *
      * @param Option $option Option to add.

--- a/src/Discord/Builders/Components/SelectMenu.php
+++ b/src/Discord/Builders/Components/SelectMenu.php
@@ -81,10 +81,47 @@ class SelectMenu extends Component
 
     /**
      * Creates a new select menu.
+     * 
+     * @param string $customId The custom_id for this SelectMenu. If no $customID given, a generic $custom_id is set
      */
-    public function __construct()
+    public function __construct(string $customId = null)
     {
-        $this->custom_id = $this->generateUuid();
+        $this->custom_id = $customId ?? $this->generateUuid(); 
+    }
+
+    /**
+     * Creates a new select menu.
+     *
+     * @param string $customId The custom_id for this Selectmenu
+     * 
+     * @return self
+     */
+    public static function new($customId = null): self
+    {
+        return new self($customId);
+    }
+
+    /**
+     * Returns the custom_id of the SelectMenu
+     * 
+     * @return string
+     */
+    public function getCustomId()
+    {
+        return $this->custom_id;
+    }
+
+    /**
+     * Sets the custom ID of this SelectMenu
+     * 
+     * @param string $customId
+     * @return $this
+     */
+    public function setCustomId($customId)
+    {
+        $this->custom_id = $customId;
+
+        return $this;
     }
 
     /**


### PR DESCRIPTION
Discord\Builders\Components\SelectMenu

Changed the constructor to expect a nullable param $customId. If the param is given, the custom_id is set to the given $customId. Otherwise its set with $this->generateUuid()
Added getter and setter for the custom_id to read and write them with the object instance.