### PR TITLE
Fix duplicated getter for customId, add auto generated custom id for Button on constructor

### DIFF
--- a/src/Discord/Builders/Components/Button.php
+++ b/src/Discord/Builders/Components/Button.php
@@ -89,8 +89,9 @@ class Button extends Component
      * Creates a new button.
      *
      * @param int $style Style of the button.
+     * @param string|null $custom_id custom ID of the button. If not given, an UUID will be used
      */
-    public function __construct(int $style)
+    public function __construct(int $style, ?string $custom_id = null)
     {
         if (! in_array($style, [
             self::STYLE_PRIMARY,
@@ -103,18 +104,20 @@ class Button extends Component
         }
 
         $this->style = $style;
+        $this->setCustomId($custom_id ?? $this->generateUuid()); 
     }
 
     /**
      * Creates a new button.
      *
      * @param int $style Style of the button.
+     * @param string|null $custom_id custom ID of the button.
      *
      * @return self
      */
-    public static function new(int $style): self
+    public static function new(int $style, ?string $custom_id = null): self
     {
-        return new self($style);
+        return new self($style, $custom_id);
     }
 
     /**
@@ -376,7 +379,7 @@ class Button extends Component
     }
 
     /**
-     * Returns the Custom ID of the button.
+     * Returns the custom ID of the button.
      *
      * @return string|null
      */

--- a/src/Discord/Builders/Components/Button.php
+++ b/src/Discord/Builders/Components/Button.php
@@ -91,7 +91,7 @@ class Button extends Component
      * @param int $style Style of the button.
      * @param string|null $custom_id custom ID of the button. If not given, an UUID will be used
      */
-    public function __construct(int $style, ?string $custom_id = null)
+    public function __construct(int $style, ?string $custom_id)
     {
         if (! in_array($style, [
             self::STYLE_PRIMARY,

--- a/src/Discord/Builders/Components/SelectMenu.php
+++ b/src/Discord/Builders/Components/SelectMenu.php
@@ -19,6 +19,8 @@ use Exception;
 use InvalidArgumentException;
 use React\Promise\PromiseInterface;
 
+use function Discord\poly_strlen;
+
 class SelectMenu extends Component
 {
     /**
@@ -82,44 +84,39 @@ class SelectMenu extends Component
     /**
      * Creates a new select menu.
      * 
-     * @param string $customId The custom_id for this SelectMenu. If no $customID given, a generic $custom_id is set
+     * @param string $custom_id The custom_id for this SelectMenu. If no $custom_id given, a generic $custom_id is set
      */
-    public function __construct(string $customId = null)
+    public function __construct(string $custom_id = null)
     {
-        $this->custom_id = $customId ?? $this->generateUuid(); 
+        $this->setCustomId($custom_id ?? $this->generateUuid()); 
     }
 
     /**
      * Creates a new select menu.
      *
-     * @param string $customId The custom_id for this Selectmenu
+     * @param string $custom_id The custom_id for this Selectmenu
      * 
      * @return self
      */
-    public static function new($customId = null): self
+    public static function new($custom_id = null): self
     {
-        return new self($customId);
+        return new self($custom_id);
     }
 
     /**
-     * Returns the custom_id of the SelectMenu
+     * Sets the custom ID for the select menu
      * 
-     * @return string
-     */
-    public function getCustomId()
-    {
-        return $this->custom_id;
-    }
-
-    /**
-     * Sets the custom ID of this SelectMenu
-     * 
-     * @param string $customId
+     * @param string $custom_id
+     
      * @return $this
      */
-    public function setCustomId($customId)
+    public function setCustomId($custom_id): self
     {
-        $this->custom_id = $customId;
+        if (poly_strlen($custom_id) > 100) {
+            throw new InvalidArgumentException('Custom ID must be maximum 100 characters.');
+        }
+        
+        $this->custom_id = $custom_id;
 
         return $this;
     }

--- a/src/Discord/Builders/Components/SelectMenu.php
+++ b/src/Discord/Builders/Components/SelectMenu.php
@@ -84,9 +84,9 @@ class SelectMenu extends Component
     /**
      * Creates a new select menu.
      * 
-     * @param string $custom_id The custom_id for this SelectMenu. If no $custom_id given, a generic $custom_id is set
+     * @param string|null $custom_id The custom ID of the select menu. If not given, an UUID will be used
      */
-    public function __construct(string $custom_id = null)
+    public function __construct(?string $custom_id)
     {
         $this->setCustomId($custom_id ?? $this->generateUuid()); 
     }
@@ -94,11 +94,11 @@ class SelectMenu extends Component
     /**
      * Creates a new select menu.
      *
-     * @param string $custom_id The custom_id for this Selectmenu
+     * @param string|null $custom_id The custom ID of the select menu.
      * 
      * @return self
      */
-    public static function new($custom_id = null): self
+    public static function new(?string $custom_id = null): self
     {
         return new self($custom_id);
     }


### PR DESCRIPTION
Fix duplicated getter for customId that was accidentally added together with merge of #584 
Added custom ID length checking for Select Menu (copied from Button.php)
Added optional custom id for Button constructor to auto generate UUID by default
Also matching the rest of coding with existing structure from Button.php and Option.php

Sorry for the accidental branch deletion, github was lagging (again) for me