### PR TITLE
Fix threads being inserted into channel repository

### DIFF
--- a/src/Discord/WebSockets/Events/MessageUpdate.php
+++ b/src/Discord/WebSockets/Events/MessageUpdate.php
@@ -31,11 +31,6 @@ class MessageUpdate extends Event
             }
 
             $channel->messages->offsetSet($messagePart->id, $messagePart);
-
-            if ($guild = $this->discord->guilds->get('id', $channel->guild_id)) {
-                $guild->channels->offsetSet($channel->id, $channel);
-                $this->discord->guilds->offsetSet($guild->id, $guild);
-            }
         }
 
         $deferred->resolve([$messagePart, $oldMessage]);


### PR DESCRIPTION
When a message was updated, the channel was re-inserted back into the
channel repository, but that happened for messages edited in threads as
well. We don't actually need to reinsert the thread anyway.