### PR TITLE
Fix URL typo getSplashAttribute() on Guild.php

### DIFF
--- a/src/Discord/Parts/Guild/Guild.php
+++ b/src/Discord/Parts/Guild/Guild.php
@@ -309,7 +309,7 @@ class Guild extends Part
             $format = 'jpg';
         }
 
-        return "https://cdn.discordapp.com/slashes/{$this->id}/{$this->attributes['splash']}.{$format}?size={$size}";
+        return "https://cdn.discordapp.com/splashes/{$this->id}/{$this->attributes['splash']}.{$format}?size={$size}";
     }
 
     /**


### PR DESCRIPTION
Noticed this when looking around for "slash" where it is supposed to be "s**p**lash", I double checked the server that has invite background and it is correct:
https://cdn.discordapp.com/splashes/305281346455207936/0eb527e88251cab6145ecb8ee7b49bfa.jpg?size=1024