### PR TITLE
Fix PHP 8.1 deprecations

### DIFF
--- a/src/Discord/Helpers/Collection.php
+++ b/src/Discord/Helpers/Collection.php
@@ -22,7 +22,7 @@ use Traversable;
 /**
  * Collection of items. Inspired by Laravel Collections.
  */
-class Collection implements ArrayAccess, Serializable, JsonSerializable, IteratorAggregate, Countable
+class Collection implements ArrayAccess, JsonSerializable, IteratorAggregate, Countable
 {
     /**
      * The collection discriminator.
@@ -369,6 +369,7 @@ class Collection implements ArrayAccess, Serializable, JsonSerializable, Iterato
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->items[$offset] ?? null;
@@ -400,19 +401,19 @@ class Collection implements ArrayAccess, Serializable, JsonSerializable, Iterato
      *
      * @return string
      */
-    public function serialize(): string
+    public function __serialize(): array
     {
-        return json_encode($this->items);
+        return $this->items;
     }
 
     /**
      * Unserializes the collection.
      *
-     * @param string $serialized
+     * @param array $serialized
      */
-    public function unserialize($serialized): void
+    public function __unserialize(array $serialized): void
     {
-        $this->items = json_decode($serialized);
+        $this->items = $serialized;
     }
 
     /**

--- a/src/Discord/Helpers/Collection.php
+++ b/src/Discord/Helpers/Collection.php
@@ -401,9 +401,29 @@ class Collection implements ArrayAccess, JsonSerializable, IteratorAggregate, Co
      *
      * @return string
      */
+    public function serialize(): string
+    {
+        return json_encode($this->items);
+    }
+
+    /**
+     * Returns the string representation of the collection.
+     *
+     * @return string
+     */
     public function __serialize(): array
     {
         return $this->items;
+    }
+
+    /**
+     * Unserializes the collection.
+     *
+     * @param string $serialized
+     */
+    public function unserialize(string $serialized): void
+    {
+        $this->items = json_decode($serialized);
     }
 
     /**

--- a/src/Discord/Parts/Part.php
+++ b/src/Discord/Parts/Part.php
@@ -25,7 +25,7 @@ use Serializable;
  * This class is the base of all objects that are returned. All "Parts" extend off this
  * base class.
  */
-abstract class Part implements ArrayAccess, Serializable, JsonSerializable
+abstract class Part implements ArrayAccess, JsonSerializable
 {
     /**
      * The HTTP client.
@@ -261,6 +261,7 @@ abstract class Part implements ArrayAccess, Serializable, JsonSerializable
      * @throws \Exception
      * @see self::getAttribute() This function forwards onto getAttribute.
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($key)
     {
         return $this->getAttribute($key);
@@ -273,7 +274,7 @@ abstract class Part implements ArrayAccess, Serializable, JsonSerializable
      *
      * @return bool Whether the offset exists.
      */
-    public function offsetExists($key)
+    public function offsetExists($key): bool
     {
         return isset($this->attributes[$key]);
     }
@@ -287,7 +288,7 @@ abstract class Part implements ArrayAccess, Serializable, JsonSerializable
      *
      * @see self::setAttribute() This function forwards onto setAttribute.
      */
-    public function offsetSet($key, $value)
+    public function offsetSet($key, $value): void
     {
         $this->setAttribute($key, $value);
     }
@@ -297,7 +298,7 @@ abstract class Part implements ArrayAccess, Serializable, JsonSerializable
      *
      * @param string $key The attribute key.
      */
-    public function offsetUnset($key)
+    public function offsetUnset($key): void
     {
         if (isset($this->attributes[$key])) {
             unset($this->attributes[$key]);
@@ -309,7 +310,7 @@ abstract class Part implements ArrayAccess, Serializable, JsonSerializable
      *
      * @return string A string of serialized data.
      */
-    public function serialize()
+    public function __serialize()
     {
         return serialize($this->attributes);
     }
@@ -321,7 +322,7 @@ abstract class Part implements ArrayAccess, Serializable, JsonSerializable
      *
      * @see self::setAttribute() The unserialized data is stored with setAttribute.
      */
-    public function unserialize($data)
+    public function __unserialize($data)
     {
         $data = unserialize($data);
 
@@ -339,7 +340,7 @@ abstract class Part implements ArrayAccess, Serializable, JsonSerializable
      * @throws \Exception
      * @see self::getPublicAttributes() This function forwards onto getPublicAttributes.
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return $this->getPublicAttributes();
     }

--- a/src/Discord/Voice/Buffer.php
+++ b/src/Discord/Voice/Buffer.php
@@ -141,6 +141,7 @@ class Buffer extends BaseBuffer implements ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($key)
     {
         return $this->buffer[$key];


### PR DESCRIPTION
Mostly backwards-compatible PHP 8.1 deprecation fixes.  See https://wiki.php.net/rfc/internal_method_return_types and https://wiki.php.net/rfc/phase_out_serializable

On src/Discord/Helpers/Collection.php, `serialize()` serialized to a JSON string, which is not allowed by `__serialize` (which handles the serialization itself) so that is a (potential?) BC break.  From my understanding this is currently being used incorrectly anyways (you would end up getting a PHP-serialized JSON-encoded string on a call to `serialize()`) and the proper way to do that is JSONSerializable.