### PR TITLE
Declare and Implement getFillableAttributes()

### DIFF
--- a/src/Discord/Parts/OAuth/Application.php
+++ b/src/Discord/Parts/OAuth/Application.php
@@ -32,7 +32,23 @@ class Application extends Part
     /**
      * @inheritdoc
      */
-    protected $fillable = ['id', 'name', 'description', 'icon', 'rpc_origins', 'flags', 'owner'];
+     protected static $fillable = ['id', 'name', 'description', 'icon', 'rpc_origins', 'flags', 'owner'];
+	/**
+     * Returns the fillable attributes.
+     *
+     * @return array
+     */
+
+    public static function getFillableAttributes($context = '')
+	{
+		$fillable = array();
+		foreach (self::$fillable as $attr) {
+			if (!$context || in_array($context, $attrContexts)) {
+				$fillable[] = $attr;
+			}
+		}
+		return $fillable;
+	}
 
     /**
      * Returns the owner of the application.

--- a/src/Discord/Parts/OAuth/Application.php
+++ b/src/Discord/Parts/OAuth/Application.php
@@ -43,7 +43,7 @@ class Application extends Part
 	{
 		$fillable = array();
 		foreach (self::$fillable as $attr) {
-			if (!$context || in_array($context, $attrContexts)) {
+			if (!$context || in_array($context, self::$fillable)) {
 				$fillable[] = $attr;
 			}
 		}

--- a/src/Discord/Parts/OAuth/Application.php
+++ b/src/Discord/Parts/OAuth/Application.php
@@ -39,17 +39,6 @@ class Application extends Part
      * @return array
      */
 
-    public static function getFillableAttributes($context = '')
-	{
-		$fillable = array();
-		foreach (self::$fillable as $attr) {
-			if (!$context || in_array($context, self::$fillable)) {
-				$fillable[] = $attr;
-			}
-		}
-		return $fillable;
-	}
-
     /**
      * Returns the owner of the application.
      *

--- a/src/Discord/Parts/Part.php
+++ b/src/Discord/Parts/Part.php
@@ -193,7 +193,7 @@ abstract class Part implements ArrayAccess, JsonSerializable
 	{
 		$fillable = array();
 		foreach (self::$fillable as $attr) {
-			if (!$context || in_array($context, $attrContexts)) {
+			if (!$context || in_array($context, self::$fillable)) {
 				$fillable[] = $attr;
 			}
 		}

--- a/src/Discord/Parts/Part.php
+++ b/src/Discord/Parts/Part.php
@@ -61,7 +61,7 @@ abstract class Part implements ArrayAccess, JsonSerializable
      *
      * @var array The array of attributes that can be mass-assigned.
      */
-    protected $fillable = [];
+    protected static $fillable = [];
 
     /**
      * The parts attributes.
@@ -178,11 +178,27 @@ abstract class Part implements ArrayAccess, JsonSerializable
     public function fill(array $attributes): void
     {
         foreach ($attributes as $key => $value) {
-            if (in_array($key, $this->fillable)) {
+            if (in_array($key, $this::getFillableAttributes())) {
                 $this->setAttribute($key, $value);
             }
         }
     }
+
+	/**
+     * Returns the fillable attributes.
+     *
+     * @return array
+     */
+    public static function getFillableAttributes($context = '')
+	{
+		$fillable = array();
+		foreach (self::$fillable as $attr) {
+			if (!$context || in_array($context, $attrContexts)) {
+				$fillable[] = $attr;
+			}
+		}
+		return $fillable;
+	}	
 
     /**
      * Checks if there is a mutator present.
@@ -246,7 +262,7 @@ abstract class Part implements ArrayAccess, JsonSerializable
             return;
         }
 
-        if (array_search($key, $this->fillable) !== false) {
+        if (array_search($key, $this::getFillableAttributes()) !== false) {
             $this->attributes[$key] = $value;
         }
     }
@@ -355,7 +371,7 @@ abstract class Part implements ArrayAccess, JsonSerializable
     {
         $data = [];
 
-        foreach (array_merge($this->fillable, $this->visible) as $key) {
+        foreach (array_merge($this::getFillableAttributes(), $this->visible) as $key) {
             if (in_array($key, $this->hidden)) {
                 continue;
             }

--- a/src/Discord/Parts/User/Client.php
+++ b/src/Discord/Parts/User/Client.php
@@ -42,7 +42,23 @@ class Client extends Part
     /**
      * @inheritdoc
      */
-    protected $fillable = ['id', 'username', 'email', 'verified', 'avatar', 'discriminator', 'bot', 'user', 'application'];
+    protected static $fillable = ['id', 'username', 'email', 'verified', 'avatar', 'discriminator', 'bot', 'user', 'application'];
+
+	/**
+     * Returns the fillable attributes.
+     *
+     * @return array
+     */
+    public static function getFillableAttributes($context = '')
+	{
+		$fillable = array();
+		foreach (self::$fillable as $attr) {
+			if (!$context || in_array($context, $attrContexts)) {
+				$fillable[] = $attr;
+			}
+		}
+		return $fillable;
+	}
 
     /**
      * @inheritdoc

--- a/src/Discord/Parts/User/Client.php
+++ b/src/Discord/Parts/User/Client.php
@@ -44,22 +44,6 @@ class Client extends Part
      */
     protected static $fillable = ['id', 'username', 'email', 'verified', 'avatar', 'discriminator', 'bot', 'user', 'application'];
 
-	/**
-     * Returns the fillable attributes.
-     *
-     * @return array
-     */
-    public static function getFillableAttributes($context = '')
-	{
-		$fillable = array();
-		foreach (self::$fillable as $attr) {
-			if (!$context || in_array($context, self::$fillable)) {
-				$fillable[] = $attr;
-			}
-		}
-		return $fillable;
-	}
-
     /**
      * @inheritdoc
      */

--- a/src/Discord/Parts/User/Client.php
+++ b/src/Discord/Parts/User/Client.php
@@ -53,7 +53,7 @@ class Client extends Part
 	{
 		$fillable = array();
 		foreach (self::$fillable as $attr) {
-			if (!$context || in_array($context, $attrContexts)) {
+			if (!$context || in_array($context, self::$fillable)) {
 				$fillable[] = $attr;
 			}
 		}


### PR DESCRIPTION
There wasn't a way to get a part's $fillable array from outside of the class, which can make it tricky to dynamically create an object in certain use-cases. This resolve it by allowing the fillable property to be retrieved with a function. The main downside to this method is that the function has to be redeclared in every part that has a non-empty fillable array because of the usage of reflection, but I think that's a small price to pay for future maintainability.