### PR TITLE
Add delete method in MessageReaction

### DIFF
--- a/src/Discord/Parts/WebSockets/MessageReaction.php
+++ b/src/Discord/Parts/WebSockets/MessageReaction.php
@@ -229,29 +229,24 @@ class MessageReaction extends Part
             }
         }
 
-        $types = [Message::REACT_DELETE_ALL, Message::REACT_DELETE_ME, Message::REACT_DELETE_ID, Message::REACT_DELETE_EMOJI];
-
         $emoticon = $this->emoji->toReactionString();
 
-        if (in_array($type, $types)) {
-            switch ($type) {
-                case Message::REACT_DELETE_ALL:
-                    $url = Endpoint::bind(Endpoint::MESSAGE_REACTION_ALL, $this->channel_id, $this->message_id);
-                    break;
-                case Message::REACT_DELETE_ME:
-                    $url = Endpoint::bind(Endpoint::OWN_MESSAGE_REACTION, $this->channel_id, $this->message_id, $emoticon);
-                    break;
-                case Message::REACT_DELETE_ID:
-                    $url = Endpoint::bind(Endpoint::USER_MESSAGE_REACTION, $this->channel_id, $this->message_id, $emoticon, $this->user_id);
-                    break;
-                case Message::REACT_DELETE_EMOJI:
-                    $url = Endpoint::bind(Endpoint::MESSAGE_REACTION_EMOJI, $this->channel_id, $this->message_id, $emoticon);
-                    break;
-            }
-
-            return $this->http->delete($url);
+        switch ($type) {
+            case Message::REACT_DELETE_ALL:
+                $url = Endpoint::bind(Endpoint::MESSAGE_REACTION_ALL, $this->channel_id, $this->message_id);
+                break;
+            case Message::REACT_DELETE_ME:
+                $url = Endpoint::bind(Endpoint::OWN_MESSAGE_REACTION, $this->channel_id, $this->message_id, $emoticon);
+                break;
+            case Message::REACT_DELETE_EMOJI:
+                $url = Endpoint::bind(Endpoint::MESSAGE_REACTION_EMOJI, $this->channel_id, $this->message_id, $emoticon);
+                break;
+            case Message::REACT_DELETE_ID:
+            default:
+                $url = Endpoint::bind(Endpoint::USER_MESSAGE_REACTION, $this->channel_id, $this->message_id, $emoticon, $this->user_id);
+                break;
         }
 
-        return \React\Promise\reject();
+        return $this->http->delete($url);
     }
 }

--- a/src/Discord/Parts/WebSockets/MessageReaction.php
+++ b/src/Discord/Parts/WebSockets/MessageReaction.php
@@ -211,4 +211,47 @@ class MessageReaction extends Part
 
         return null;
     }
+    
+    /**
+     * Delete this reaction
+     *
+     * @param int|null $type The type of deletion to perform.
+     *
+     * @return ExtendedPromiseInterface
+     */
+    public function delete(?int $type = null): ExtendedPromiseInterface
+    {
+        if (is_null($type)) {
+            if ($this->user_id == $this->discord->id) {
+                $type = Message::REACT_DELETE_ME;
+            } else {
+                $type = Message::REACT_DELETE_ID;
+            }
+        }
+
+        $types = [Message::REACT_DELETE_ALL, Message::REACT_DELETE_ME, Message::REACT_DELETE_ID, Message::REACT_DELETE_EMOJI];
+
+        $emoticon = $this->emoji->toReactionString();
+
+        if (in_array($type, $types)) {
+            switch ($type) {
+                case Message::REACT_DELETE_ALL:
+                    $url = Endpoint::bind(Endpoint::MESSAGE_REACTION_ALL, $this->channel_id, $this->message_id);
+                    break;
+                case Message::REACT_DELETE_ME:
+                    $url = Endpoint::bind(Endpoint::OWN_MESSAGE_REACTION, $this->channel_id, $this->message_id, $emoticon);
+                    break;
+                case Message::REACT_DELETE_ID:
+                    $url = Endpoint::bind(Endpoint::USER_MESSAGE_REACTION, $this->channel_id, $this->message_id, $emoticon, $this->user_id);
+                    break;
+                case Message::REACT_DELETE_EMOJI:
+                    $url = Endpoint::bind(Endpoint::MESSAGE_REACTION_EMOJI, $this->channel_id, $this->message_id, $emoticon);
+                    break;
+            }
+
+            return $this->http->delete($url);
+        }
+
+        return \React\Promise\reject();
+    }
 }


### PR DESCRIPTION
Useful to delete reaction on message reaction events that might have partial data

Example:
Prevents reaction being added
```php
$discord->on(Event::MESSAGE_REACTION_ADD, function (MessageReaction $reaction, Discord $discord) {
    $discord->getChannel($reaction->channel_id)->getMessage($reaction->message_id)->done(function (Message $message) use ($reaction) {
        $message->deleteReaction(Message::REACT_DELETE_ID, $reaction->emoji->name, $reaction->user_id);
    });
});
```

Can be just:
```php
$discord->on(Event::MESSAGE_REACTION_ADD, function (MessageReaction $reaction, Discord $discord) {
    $reaction->delete();
});
```