### PR TITLE
Avoid hexdec deprecated warning (PHP 7.4+)

### DIFF
--- a/src/Discord/Parts/Embed/Embed.php
+++ b/src/Discord/Parts/Embed/Embed.php
@@ -481,7 +481,7 @@ class Embed extends Part
         }
 
         if (! is_array($color)) {
-            return hexdec(((string) $color));
+            return hexdec((preg_replace('/[^0-9a-fA-FxX]/', '', (string) $color)));
         }
 
         if (count($color) < 1) {

--- a/src/Discord/Parts/Embed/Embed.php
+++ b/src/Discord/Parts/Embed/Embed.php
@@ -481,7 +481,7 @@ class Embed extends Part
         }
 
         if (! is_array($color)) {
-            return hexdec((preg_replace('/[^0-9a-fA-FxX]/', '', (string) $color)));
+            return hexdec((str_replace('#', '', (string) $color)));
         }
 
         if (count($color) < 1) {


### PR DESCRIPTION
Avoid deprecated warning, and possible future error:
```
Deprecated: Invalid characters passed for attempted conversion, these have been ignored in ***/vendor/team-reflex/discord-php/src/Discord/Parts/Embed/Embed.php on line 484
```

This happens when the color is passed as:
```PHP
$embed = new Embed($discord, [
        "type" => Embed::TYPE_RICH,
        "description" => $desc,
        "color" => '#2c2c2c'
    ]);
```

Simple sanitization performed before parse to conversion.