### PR TITLE
Add get endpoint for single ban in BanRepository.php

### DIFF
--- a/src/Discord/Repository/Guild/BanRepository.php
+++ b/src/Discord/Repository/Guild/BanRepository.php
@@ -41,6 +41,7 @@ class BanRepository extends AbstractRepository
      */
     protected $endpoints = [
         'all' => Endpoint::GUILD_BANS,
+        'get' => Endpoint::GUILD_BAN,
         'delete' => Endpoint::GUILD_BAN,
     ];
 


### PR DESCRIPTION
It is possible to fetch a single ban
https://discord.com/developers/docs/resources/guild#get-guild-ban

Should fix error `PHP Fatal error:  Uncaught Exception: You cannot get this part. /discord-php/src/Discord/Repository/AbstractRepository.php` when trying to do:
```php
$guild->bans->fetch('user id here', true);
``` 