### PR TITLE
Remove 'region' from being creatable & updatable

### DIFF
--- a/src/Discord/Parts/Guild/Guild.php
+++ b/src/Discord/Parts/Guild/Guild.php
@@ -653,7 +653,6 @@ class Guild extends Part
     {
         return [
             'name' => $this->name,
-            'region' => $this->region,
             'icon' => $this->attributes['icon'],
             'verification_level' => $this->verification_level,
             'default_message_notifications' => $this->default_message_notifications,
@@ -671,7 +670,6 @@ class Guild extends Part
     {
         return [
             'name' => $this->name,
-            'region' => $this->region,
             'verification_level' => $this->verification_level,
             'default_message_notifications' => $this->default_message_notifications,
             'explicit_content_filter' => $this->explicit_content_filter,


### PR DESCRIPTION
"region" attribute from Guild seems only have value "deprecated". The field is still sent by Discord but not removed yet.

Attempts to fix #629 