### PR TITLE
Make `Message::author` only return `User`

### DIFF
--- a/docs/src/pages/api/05_parts/03_member.md
+++ b/docs/src/pages/api/05_parts/03_member.md
@@ -9,7 +9,9 @@ A member object can also be serialised into a mention string. For example:
 ```php
 $discord->on(Event::MESSAGE_CREATE, function (Message $message) {
     // Hello <@member_id>!
-    $message->channel->sendMessage('Hello '.$message->author.'!');
+    // Note: `$message->member` will be `null` if the message originated from
+    // a private message, or if the member object was not cached.
+    $message->channel->sendMessage('Hello '.$message->member.'!');
 });
 ```
 

--- a/src/Discord/Builders/Components/Button.php
+++ b/src/Discord/Builders/Components/Button.php
@@ -88,7 +88,7 @@ class Button extends Component
     /**
      * Creates a new button.
      *
-     * @param int $style Style of the button.
+     * @param int         $style     Style of the button.
      * @param string|null $custom_id custom ID of the button. If not given, an UUID will be used
      */
     public function __construct(int $style, ?string $custom_id)
@@ -112,7 +112,7 @@ class Button extends Component
     /**
      * Creates a new button.
      *
-     * @param int $style Style of the button.
+     * @param int         $style     Style of the button.
      * @param string|null $custom_id custom ID of the button.
      *
      * @return self

--- a/src/Discord/Builders/Components/SelectMenu.php
+++ b/src/Discord/Builders/Components/SelectMenu.php
@@ -83,19 +83,19 @@ class SelectMenu extends Component
 
     /**
      * Creates a new select menu.
-     * 
+     *
      * @param string|null $custom_id The custom ID of the select menu. If not given, an UUID will be used
      */
     public function __construct(?string $custom_id)
     {
-        $this->setCustomId($custom_id ?? $this->generateUuid()); 
+        $this->setCustomId($custom_id ?? $this->generateUuid());
     }
 
     /**
      * Creates a new select menu.
      *
      * @param string|null $custom_id The custom ID of the select menu.
-     * 
+     *
      * @return self
      */
     public static function new(?string $custom_id = null): self
@@ -104,10 +104,9 @@ class SelectMenu extends Component
     }
 
     /**
-     * Sets the custom ID for the select menu
-     * 
-     * @param string $custom_id
-     
+     * Sets the custom ID for the select menu.
+     *
+     * @param  string $custom_id
      * @return $this
      */
     public function setCustomId($custom_id): self

--- a/src/Discord/DiscordCommandClient.php
+++ b/src/Discord/DiscordCommandClient.php
@@ -184,8 +184,7 @@ class DiscordCommandClient extends Discord
                 }
                 // Use embed fields in case commands count is below limit
                 if (count($embedfields) <= 25) {
-                    foreach ($embedfields as $field)
-                    {
+                    foreach ($embedfields as $field) {
                         $embed->addField($field);
                     }
                     $commandsDescription = '';

--- a/src/Discord/Helpers/Collection.php
+++ b/src/Discord/Helpers/Collection.php
@@ -16,7 +16,6 @@ use ArrayIterator;
 use Countable;
 use IteratorAggregate;
 use JsonSerializable;
-use Serializable;
 use Traversable;
 
 /**

--- a/src/Discord/Parts/Channel/Message.php
+++ b/src/Discord/Parts/Channel/Message.php
@@ -45,9 +45,8 @@ use function React\Promise\reject;
  * @property string               $content                The content of the message if it is a normal message.
  * @property int                  $type                   The type of message.
  * @property Collection|User[]    $mentions               A collection of the users mentioned in the message.
- * @property Member|User|null     $author                 The author of the message.
+ * @property User|null            $author                 The author of the message. Will be a webhook if sent from one.
  * @property Member|null          $member                 The member that sent this message, or null if it was in a private message.
- * @property User|null            $user                   The user that sent this message. Will be a webhook if sent from one.
  * @property string               $user_id                The user id of the author.
  * @property bool                 $mention_everyone       Whether the message contained an @everyone mention.
  * @property Carbon               $timestamp              A timestamp of when the message was sent.
@@ -338,18 +337,16 @@ class Message extends Part
     /**
      * Returns the author attribute.
      *
-     * @return User|Member|null The member that sent the message. Will return a User object if it is a PM.
-     *
-     * @deprecated 6.0.0 Use `Message::member` or `Message:user` instead.
+     * @return User|null The author of the message.
      */
-    protected function getAuthorAttribute(): ?Part
+    protected function getAuthorAttribute(): ?User
     {
-        if ($this->member) {
-            return $this->member;
-        }
+        if (isset($this->attributes['author'])) {
+            if ($user = $this->discord->users->get('id', $this->attributes['author']->id)) {
+                return $user;
+            }
 
-        if ($this->user) {
-            return $this->user;
+            return $this->factory->create(User::class, $this->attributes['author'], true);
         }
 
         return null;
@@ -371,24 +368,6 @@ class Message extends Part
                 'user' => $this->attributes['author'],
                 'guild_id' => $this->guild_id,
             ]), true);
-        }
-
-        return null;
-    }
-
-    /**
-     * Returns the user attribute.
-     *
-     * @return User|null The user that sent the message. Can also be a webhook.
-     */
-    protected function getUserAttribute(): ?User
-    {
-        if (isset($this->attributes['author'])) {
-            if ($user = $this->discord->users->get('id', $this->attributes['author']->id)) {
-                return $user;
-            }
-
-            return $this->factory->create(User::class, $this->attributes['author'], true);
         }
 
         return null;

--- a/src/Discord/Parts/WebSockets/MessageReaction.php
+++ b/src/Discord/Parts/WebSockets/MessageReaction.php
@@ -213,7 +213,7 @@ class MessageReaction extends Part
     }
     
     /**
-     * Delete this reaction
+     * Delete this reaction.
      *
      * @param int|null $type The type of deletion to perform.
      *

--- a/src/Discord/functions.php
+++ b/src/Discord/functions.php
@@ -249,8 +249,8 @@ function normalizePartId($id_field = 'id')
  * _Italics_, **Bold**, __Underline__, ~~Strikethrough~~, ||spoiler||
  * `Code`, ```Code block```, > Quotes, >>> Block quotes
  * #Channel @User
- * A backslash will be added before the each formatting symbol
- * 
+ * A backslash will be added before the each formatting symbol.
+ *
  * @return string the escaped string unformatted as plain text
  */
 function escapeMarkdown(string $text): string


### PR DESCRIPTION
This is effectively the same as the `user` attribute which was added
earlier (and has now been removed). To access the member object, use the
`member` attribute, which will return `null` in a private channel (or
when the member is not cached).

Also ran `php-cs-fixer`.

See: #628