### PR TITLE
Add Welcome Screen Channels in Guild.php

### DIFF
--- a/src/Discord/Parts/Guild/Guild.php
+++ b/src/Discord/Parts/Guild/Guild.php
@@ -665,7 +665,7 @@ class Guild extends Part
     {
         return $this->http->get(Endpoint::bind(Endpoint::GUILD_WELCOME_SCREEN, $this->id))->then(function ($response) {
             $welcome_screen = $this->discord->factory(WelcomeScreen::class, $response, true);
-            $this->welcome_screen = $welcome_screen;
+            $this->attributes['welcome_screen'] = $welcome_screen;
 
             return $welcome_screen;
         });
@@ -697,7 +697,7 @@ class Guild extends Part
 
         return $this->http->patch(Endpoint::bind(Endpoint::GUILD_WELCOME_SCREEN, $this->id), $options)->then(function ($response) {
             $welcome_screen = $this->discord->factory(WelcomeScreen::class, $response, true);
-            $this->welcome_screen = $welcome_screen;
+            $this->attributes['welcome_screen'] = $welcome_screen;
 
             return $welcome_screen;
         });

--- a/src/Discord/Parts/Guild/Guild.php
+++ b/src/Discord/Parts/Guild/Guild.php
@@ -657,12 +657,18 @@ class Guild extends Part
     }
 
     /**
-     * Returns the Welcome Screen object for the guild.
+     * Get the Welcome Screen for the guild.
+     *
+     * @param bool $fresh Whether we should skip checking the cache.
      *
      * @return ExtendedPromiseInterface
      */
-    public function getWelcomeScreen(): ExtendedPromiseInterface
+    public function getWelcomeScreen(bool $fresh = false): ExtendedPromiseInterface
     {
+        if (! $fresh && isset($this->attributes['welcome_screen'])) {
+            return \React\Promise\resolve($this->attributes['welcome_screen']);
+        }
+
         return $this->http->get(Endpoint::bind(Endpoint::GUILD_WELCOME_SCREEN, $this->id))->then(function ($response) {
             $welcome_screen = $this->discord->factory(WelcomeScreen::class, $response, true);
             $this->attributes['welcome_screen'] = $welcome_screen;

--- a/src/Discord/Parts/Guild/Guild.php
+++ b/src/Discord/Parts/Guild/Guild.php
@@ -705,6 +705,16 @@ class Guild extends Part
     }
 
     /**
+     * Returns the Welcome Screen object for the guild.
+     *
+     * @return WelcomeScreen|null
+     */
+    public function getWelcomeScreenAttribute(): ?WelcomeScreen
+    {
+        return $this->attributes['welcome_screen'] ?? null;
+    }
+
+    /**
      * @inheritdoc
      */
     public function getCreatableAttributes(): array

--- a/src/Discord/Parts/Guild/Guild.php
+++ b/src/Discord/Parts/Guild/Guild.php
@@ -72,7 +72,6 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  * @property int                $max_video_channel_users                  Maximum amount of users allowed in a video channel.
  * @property int                $approximate_member_count
  * @property int                $approximate_presence_count
- * @property WelcomeScreen|null $welcome_screen                           The welcome screen of a Community guild, shown to new members, returned in an Invite's guild object.
  * @property int                $nsfw_level                               The guild NSFW level.
  * @property bool               $premium_progress_bar_enabled             Whether the guild has the boost progress bar enabled.
  * @property bool               $feature_animated_icon                    guild has access to set an animated guild icon.

--- a/src/Discord/Parts/Guild/Guild.php
+++ b/src/Discord/Parts/Guild/Guild.php
@@ -33,75 +33,76 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * A Guild is Discord's equivalent of a server. It contains all the Members, Channels, Roles, Bans etc.
  *
- * @property string            $id                                       The unique identifier of the guild.
- * @property string            $name                                     The name of the guild.
- * @property string            $icon                                     The URL to the guild icon.
- * @property string            $icon_hash                                The icon hash for the guild.
- * @property string            $region                                   The region the guild's voice channels are hosted in.
- * @property User              $owner                                    The owner of the guild.
- * @property string            $owner_id                                 The unique identifier of the owner of the guild.
- * @property Carbon            $joined_at                                A timestamp of when the current user joined the guild.
- * @property string            $afk_channel_id                           The unique identifier of the AFK channel ID.
- * @property int               $afk_timeout                              How long you will remain in the voice channel until you are moved into the AFK channel.
- * @property string[]          $features                                 An array of features that the guild has.
- * @property string            $splash                                   The URL to the guild splash.
- * @property string            $discovery_splash                         Discovery splash hash. Only for discoverable guilds.
- * @property string            $splash_hash                              The splash hash for the guild.
- * @property bool              $large                                    Whether the guild is considered 'large' (over 250 members).
- * @property int               $verification_level                       The verification level used for the guild.
- * @property int               $member_count                             How many members are in the guild.
- * @property int               $default_message_notifications            Default notification level.
- * @property int               $explicit_content_filter                  Explicit content filter level.
- * @property int               $mfa_level                                MFA level required to join.
- * @property string            $application_id                           Application that made the guild, if made by one.
- * @property bool              $widget_enabled                           Is server widget enabled.
- * @property string            $widget_channel_id                        Channel that the widget will create an invite to.
- * @property string            $system_channel_id                        Channel that system notifications are posted in.
- * @property int               $system_channel_flags                     Flags for the system channel.
- * @property string            $rules_channel_id                         Channel that the rules are in.
- * @property object[]          $voice_states                             Array of voice states.
- * @property int               $max_presences                            Maximum amount of presences allowed in the guild.
- * @property int               $max_members                              Maximum amount of members allowed in the guild.
- * @property string            $vanity_url_code                          Vanity URL code for the guild.
- * @property string            $description                              Guild description if it is discoverable.
- * @property string            $banner                                   Banner hash.
- * @property int               $premium_tier                             Server boost level.
- * @property int               $premium_subscription_count               Number of boosts in the guild.
- * @property string            $preferred_locale                         Preferred locale of the guild.
- * @property string            $public_updates_channel_id                Notice channel id.
- * @property int               $max_video_channel_users                  Maximum amount of users allowed in a video channel.
- * @property int               $approximate_member_count
- * @property int               $approximate_presence_count
- * @property int               $nsfw_level                               The guild NSFW level
- * @property bool              $premium_progress_bar_enabled             Whether the guild has the boost progress bar enabled
- * @property bool              $feature_animated_icon                    guild has access to set an animated guild icon.
- * @property bool              $feature_banner                           guild has access to set a guild banner image.
- * @property bool              $feature_commerce                         guild has access to use commerce features (create store channels).
- * @property bool              $feature_community                        guild can enable welcome screen, Membership Screening, stage channels and discovery, and receives community updates.
- * @property bool              $feature_discoverable                     guild is able to be discovered in the directory.
- * @property bool              $feature_featurable                       guild is able to be featured in the directory.
- * @property bool              $feature_invite_splash                    guild has access to set an invite splash background.
- * @property bool              $feature_member_verification_gate_enabled guild has enabled membership screening.
- * @property bool              $feature_news                             guild has access to create news channels.
- * @property bool              $feature_partnered                        guild is partnered.
- * @property bool              $feature_preview_enabled                  guild can be previewed before joining via membership screening or the directory.
- * @property bool              $feature_vanity_url                       guild has access to set a vanity url.
- * @property bool              $feature_verified                         guild is verified.
- * @property bool              $feature_vip_regions                      guild has access to set 384kbps bitrate in voice.
- * @property bool              $feature_welcome_screen_enabled           guild has enabled the welcome screen.
- * @property bool              $feature_ticketed_events_enabled          guild has enabled ticketed events.
- * @property bool              $feature_monetization_enabled             guild has enabled monetization.
- * @property bool              $feature_more_stickers                    guild has increased custom sticker slots.
- * @property bool              $feature_three_day_thread_archive         guild has access to the three day archive time for threads.
- * @property bool              $feature_seven_day_thread_archive         guild has access to the seven day archive time for threads.
- * @property bool              $feature_private_threads                  guild has access to create private threads.
- * @property bool              $feature_role_icons                       guild is able to set role icons.
- * @property RoleRepository    $roles
- * @property ChannelRepository $channels
- * @property MemberRepository  $members
- * @property InviteRepository  $invites
- * @property BanRepository     $bans
- * @property EmojiRepository   $emojis
+ * @property string             $id                                       The unique identifier of the guild.
+ * @property string             $name                                     The name of the guild.
+ * @property string             $icon                                     The URL to the guild icon.
+ * @property string             $icon_hash                                The icon hash for the guild.
+ * @property string             $region                                   The region the guild's voice channels are hosted in.
+ * @property User               $owner                                    The owner of the guild.
+ * @property string             $owner_id                                 The unique identifier of the owner of the guild.
+ * @property Carbon             $joined_at                                A timestamp of when the current user joined the guild.
+ * @property string             $afk_channel_id                           The unique identifier of the AFK channel ID.
+ * @property int                $afk_timeout                              How long you will remain in the voice channel until you are moved into the AFK channel.
+ * @property string[]           $features                                 An array of features that the guild has.
+ * @property string             $splash                                   The URL to the guild splash.
+ * @property string             $discovery_splash                         Discovery splash hash. Only for discoverable guilds.
+ * @property string             $splash_hash                              The splash hash for the guild.
+ * @property bool               $large                                    Whether the guild is considered 'large' (over 250 members).
+ * @property int                $verification_level                       The verification level used for the guild.
+ * @property int                $member_count                             How many members are in the guild.
+ * @property int                $default_message_notifications            Default notification level.
+ * @property int                $explicit_content_filter                  Explicit content filter level.
+ * @property int                $mfa_level                                MFA level required to join.
+ * @property string             $application_id                           Application that made the guild, if made by one.
+ * @property bool               $widget_enabled                           Is server widget enabled.
+ * @property string             $widget_channel_id                        Channel that the widget will create an invite to.
+ * @property string             $system_channel_id                        Channel that system notifications are posted in.
+ * @property int                $system_channel_flags                     Flags for the system channel.
+ * @property string             $rules_channel_id                         Channel that the rules are in.
+ * @property object[]           $voice_states                             Array of voice states.
+ * @property int                $max_presences                            Maximum amount of presences allowed in the guild.
+ * @property int                $max_members                              Maximum amount of members allowed in the guild.
+ * @property string             $vanity_url_code                          Vanity URL code for the guild.
+ * @property string             $description                              Guild description if it is discoverable.
+ * @property string             $banner                                   Banner hash.
+ * @property int                $premium_tier                             Server boost level.
+ * @property int                $premium_subscription_count               Number of boosts in the guild.
+ * @property string             $preferred_locale                         Preferred locale of the guild.
+ * @property string             $public_updates_channel_id                Notice channel id.
+ * @property int                $max_video_channel_users                  Maximum amount of users allowed in a video channel.
+ * @property int                $approximate_member_count
+ * @property int                $approximate_presence_count
+ * @property WelcomeScreen|null $welcome_screen                           The welcome screen of a Community guild, shown to new members, returned in an Invite's guild object.
+ * @property int                $nsfw_level                               The guild NSFW level.
+ * @property bool               $premium_progress_bar_enabled             Whether the guild has the boost progress bar enabled.
+ * @property bool               $feature_animated_icon                    guild has access to set an animated guild icon.
+ * @property bool               $feature_banner                           guild has access to set a guild banner image.
+ * @property bool               $feature_commerce                         guild has access to use commerce features (create store channels).
+ * @property bool               $feature_community                        guild can enable welcome screen, Membership Screening, stage channels and discovery, and receives community updates.
+ * @property bool               $feature_discoverable                     guild is able to be discovered in the directory.
+ * @property bool               $feature_featurable                       guild is able to be featured in the directory.
+ * @property bool               $feature_invite_splash                    guild has access to set an invite splash background.
+ * @property bool               $feature_member_verification_gate_enabled guild has enabled membership screening.
+ * @property bool               $feature_news                             guild has access to create news channels.
+ * @property bool               $feature_partnered                        guild is partnered.
+ * @property bool               $feature_preview_enabled                  guild can be previewed before joining via membership screening or the directory.
+ * @property bool               $feature_vanity_url                       guild has access to set a vanity url.
+ * @property bool               $feature_verified                         guild is verified.
+ * @property bool               $feature_vip_regions                      guild has access to set 384kbps bitrate in voice.
+ * @property bool               $feature_welcome_screen_enabled           guild has enabled the welcome screen.
+ * @property bool               $feature_ticketed_events_enabled          guild has enabled ticketed events.
+ * @property bool               $feature_monetization_enabled             guild has enabled monetization.
+ * @property bool               $feature_more_stickers                    guild has increased custom sticker slots.
+ * @property bool               $feature_three_day_thread_archive         guild has access to the three day archive time for threads.
+ * @property bool               $feature_seven_day_thread_archive         guild has access to the seven day archive time for threads.
+ * @property bool               $feature_private_threads                  guild has access to create private threads.
+ * @property bool               $feature_role_icons                       guild is able to set role icons.
+ * @property RoleRepository     $roles
+ * @property ChannelRepository  $channels
+ * @property MemberRepository   $members
+ * @property InviteRepository   $invites
+ * @property BanRepository      $bans
+ * @property EmojiRepository    $emojis
  */
 class Guild extends Part
 {
@@ -165,6 +166,7 @@ class Guild extends Part
         'max_video_channel_users',
         'approximate_member_count',
         'approximate_presence_count',
+        'welcome_screen',
         'nsfw_level',
         'premium_progress_bar_enabled',
     ];
@@ -384,7 +386,7 @@ class Guild extends Part
     {
         return in_array('PREVIEW_ENABLED', $this->features);
     }
-    
+
     protected function getFeatureVanityUrlAttribute(): bool
     {
         return in_array('VANITY_URL', $this->features);
@@ -652,6 +654,53 @@ class Guild extends Part
             }
 
             return $members;
+        });
+    }
+
+    /**
+     * Returns the Welcome Screen object for the guild.
+     *
+     * @return ExtendedPromiseInterface
+     */
+    public function getWelcomeScreen(): ExtendedPromiseInterface
+    {
+        return $this->http->get(Endpoint::bind(Endpoint::GUILD_WELCOME_SCREEN, $this->id))->then(function ($response) {
+            $welcome_screen = $this->discord->factory(WelcomeScreen::class, $response, true);
+            $this->welcome_screen = $welcome_screen;
+
+            return $welcome_screen;
+        });
+    }
+
+    /**
+     * Modify the guild's Welcome Screen. Requires the MANAGE_GUILD permission. Returns the updated Welcome Screen object.
+     *
+     * @param array $options An array of options.
+     *                       enabled => whether the welcome screen is enabled
+     *                       welcome_channels => channels linked in the welcome screen and their display options (maximum 5)
+     *                       description => the server description to show in the welcome screen (maximum 140)
+     *
+     * @return ExtendedPromiseInterface
+     */
+    public function updateWelcomeScreen(array $options): ExtendedPromiseInterface
+    {
+        $resolver = new OptionsResolver();
+        $resolver->setDefined([
+            'enabled',
+            'welcome_channels',
+            'description'
+        ])
+        ->setAllowedTypes('enabled', 'string')
+        ->setAllowedTypes('welcome_channels', ['array', WelcomeScreen::class])
+        ->setAllowedTypes('description', 'string');
+
+        $options = $resolver->resolve($options);
+
+        return $this->http->patch(Endpoint::bind(Endpoint::GUILD_WELCOME_SCREEN, $this->id), $options)->then(function ($response) {
+            $welcome_screen = $this->discord->factory(WelcomeScreen::class, $response, true);
+            $this->welcome_screen = $welcome_screen;
+
+            return $welcome_screen;
         });
     }
 

--- a/src/Discord/Parts/Guild/WelcomeChannel.php
+++ b/src/Discord/Parts/Guild/WelcomeChannel.php
@@ -11,6 +11,7 @@
 
 namespace Discord\Parts\Guild;
 
+use Discord\Parts\Channel\Channel;
 use Discord\Parts\Part;
 
 /**
@@ -18,10 +19,11 @@ use Discord\Parts\Part;
  *
  * @link https://discord.com/developers/docs/resources/guild#welcome-screen-object-welcome-screen-channel-structure
  *
- * @property string $channel_id  The channel's id.
- * @property string $description The description shown for the channel.
- * @property string $emoji_id    The emoji id, if the emoji is custom.
- * @property string $emoji_name  The emoji name if custom, the unicode character if standard, or null if no emoji is set.
+ * @property string       $channel_id  The channel's id.
+ * @property Channel|null $channel     The channel object.
+ * @property string       $description The description shown for the channel.
+ * @property string       $emoji_id    The emoji id, if the emoji is custom.
+ * @property string       $emoji_name  The emoji name if custom, the unicode character if standard, or null if no emoji is set.
  */
 class WelcomeChannel extends Part
 {
@@ -29,4 +31,14 @@ class WelcomeChannel extends Part
      * @inheritdoc
      */
     protected $fillable = ['channel_id', 'description', 'emoji_id', 'emoji_name'];
+
+    /**
+     * Returns the Channel object for the Welcome Screen.
+     *
+     * @return Channel|null
+     */
+    public function getChannelAttribute(): ?Channel
+    {
+        return $this->discord->getChannel($this->channel_id);
+    }
 }

--- a/src/Discord/Parts/Guild/WelcomeChannel.php
+++ b/src/Discord/Parts/Guild/WelcomeChannel.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is a part of the DiscordPHP project.
+ *
+ * Copyright (c) 2015-present David Cole <david.cole1340@gmail.com>
+ *
+ * This file is subject to the MIT license that is bundled
+ * with this source code in the LICENSE.md file.
+ */
+
+namespace Discord\Parts\Guild;
+
+use Discord\Parts\Part;
+
+/**
+ * A Welcome Channel of a Guild
+ *
+ * @link https://discord.com/developers/docs/resources/guild#welcome-screen-object-welcome-screen-channel-structure
+ *
+ * @property string $channel_id  The channel's id.
+ * @property string $description The description shown for the channel.
+ * @property string $emoji_id    The emoji id, if the emoji is custom.
+ * @property string $emoji_name  The emoji name if custom, the unicode character if standard, or null if no emoji is set.
+ */
+class WelcomeChannel extends Part
+{
+    /**
+     * @inheritdoc
+     */
+    protected $fillable = ['channel_id', 'description', 'emoji_id', 'emoji_name'];
+}

--- a/src/Discord/Parts/Guild/WelcomeScreen.php
+++ b/src/Discord/Parts/Guild/WelcomeScreen.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is a part of the DiscordPHP project.
+ *
+ * Copyright (c) 2015-present David Cole <david.cole1340@gmail.com>
+ *
+ * This file is subject to the MIT license that is bundled
+ * with this source code in the LICENSE.md file.
+ */
+
+namespace Discord\Parts\Guild;
+
+use Discord\Parts\Part;
+
+/**
+ * A Welcome Screen of a Guild
+ *
+ * @link https://discord.com/developers/docs/resources/guild#welcome-screen-object-welcome-screen-structure
+ * 
+ * @property string                      $description      The server description shown in the welcome screen.
+ * @property Collection|WelcomeChannel[] $welcome_channels The channels shown in the welcome screen, up to 5.
+ */
+class WelcomeScreen extends Part
+{
+    /**
+     * @inheritdoc
+     */
+    protected $fillable = ['description', 'welcome_channels'];
+}

--- a/src/Discord/Parts/Guild/WelcomeScreen.php
+++ b/src/Discord/Parts/Guild/WelcomeScreen.php
@@ -11,6 +11,7 @@
 
 namespace Discord\Parts\Guild;
 
+use Discord\Helpers\Collection;
 use Discord\Parts\Part;
 
 /**
@@ -27,4 +28,20 @@ class WelcomeScreen extends Part
      * @inheritdoc
      */
     protected $fillable = ['description', 'welcome_channels'];
+
+    /**
+     * Returns the Welcome Channel object of the Welcome Screen
+     *
+     * @return Collection|WelcomeChannel[] The channels of welcome screen.
+     */
+    public function getWelcomeChannelsAttribute(): Collection
+    {
+        $collection = Collection::for(WelcomeScreen::class, 'channel_id');
+
+        foreach ($this->attributes['welcome_channels'] ?? [] as $welcome_channel) {
+            $collection->push($this->factory->create(WelcomeScreen::class, $welcome_channel, true));
+        }
+
+        return $collection;
+    }
 }

--- a/src/Discord/Parts/Guild/WelcomeScreen.php
+++ b/src/Discord/Parts/Guild/WelcomeScreen.php
@@ -30,7 +30,7 @@ class WelcomeScreen extends Part
     protected $fillable = ['description', 'welcome_channels'];
 
     /**
-     * Returns the Welcome Channel object of the Welcome Screen
+     * Returns the Welcome Channels of the Welcome Screen
      *
      * @return Collection|WelcomeChannel[] The channels of welcome screen.
      */

--- a/src/Discord/Parts/Guild/WelcomeScreen.php
+++ b/src/Discord/Parts/Guild/WelcomeScreen.php
@@ -36,10 +36,10 @@ class WelcomeScreen extends Part
      */
     public function getWelcomeChannelsAttribute(): Collection
     {
-        $collection = Collection::for(WelcomeScreen::class, 'channel_id');
+        $collection = Collection::for(WelcomeChannel::class, 'channel_id');
 
         foreach ($this->attributes['welcome_channels'] ?? [] as $welcome_channel) {
-            $collection->push($this->factory->create(WelcomeScreen::class, $welcome_channel, true));
+            $collection->push($this->factory->create(WelcomeChannel::class, $welcome_channel, true));
         }
 
         return $collection;


### PR DESCRIPTION
Add the missing [welcome screen](https://discord.com/developers/docs/resources/guild#welcome-screen-object) field in Guild, as well the methods to get & update it.

- [ ] Add documentation