### PR TITLE
Update Sticker & Add Guild Sticker manageability

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     "require": {
         "php": "^7.4|^8.0",
         "nesbot/carbon": "^2.38",
-        "ratchet/pawl": "0.3.*",
+        "ratchet/pawl": "^0.4.1",
         "react/datagram": "1.5.*",
         "symfony/options-resolver": "^5.1.3",
         "trafficcophp/bytebuffer": "^0.3",

--- a/src/Discord/Builders/MessageBuilder.php
+++ b/src/Discord/Builders/MessageBuilder.php
@@ -372,6 +372,10 @@ class MessageBuilder implements JsonSerializable
      */
     public function removeSticker($sticker): self
     {
+        if ($sticker instanceof Sticker) {
+            $sticker = $sticker->id;
+        }
+
         if (($idx = array_search($sticker, $this->sticker_ids)) !== null) {
             array_splice($this->sticker_ids, $idx, 1);
         }
@@ -398,7 +402,7 @@ class MessageBuilder implements JsonSerializable
     }
 
     /**
-     * Returns all the stickers in the message.
+     * Returns all the sticker IDs in the message.
      *
      * @return Sticker[]
      */

--- a/src/Discord/Builders/MessageBuilder.php
+++ b/src/Discord/Builders/MessageBuilder.php
@@ -18,6 +18,7 @@ use Discord\Exceptions\FileNotFoundException;
 use Discord\Helpers\Multipart;
 use Discord\Http\Exceptions\RequestFailedException;
 use Discord\Parts\Channel\Message;
+use Discord\Parts\Channel\Sticker;
 use Discord\Parts\Embed\Embed;
 use InvalidArgumentException;
 use JsonSerializable;
@@ -37,7 +38,7 @@ class MessageBuilder implements JsonSerializable
      * @var string|null
      */
     private $content;
-    
+
     /**
      * Whether the message is text-to-speech.
      *
@@ -86,6 +87,13 @@ class MessageBuilder implements JsonSerializable
      * @var array|null
      */
     private $allowed_mentions;
+
+    /**
+     * IDs of up to 3 stickers in the server to send in the message
+     *
+     * @var array|null
+     */
+    private $sticker_ids = [];
 
     /**
      * Creates a new message builder.
@@ -329,8 +337,74 @@ class MessageBuilder implements JsonSerializable
     public function setAllowedMentions(array $allowed_mentions)
     {
         $this->allowed_mentions = $allowed_mentions;
-        
+
         return $this;
+    }
+
+    /**
+     * Adds a sticker to the message.
+     *
+     * @param string|Sticker $sticker Sticker to add.
+     *
+     * @return $this
+     */
+    public function addSticker($sticker): self
+    {
+        if ($sticker instanceof Sticker) {
+            $sticker = $sticker->id;
+        }
+
+        if (count($this->sticker_ids) >= 3) {
+            throw new InvalidArgumentException('You can only add 3 stickers to a message');
+        }
+
+        $this->sticker_ids[] = $sticker;
+
+        return $this;
+    }
+
+    /**
+     * Removes a sticker from the message.
+     *
+     * @param string|Sticker $sticker Sticker to remove.
+     *
+     * @return $this
+     */
+    public function removeSticker($sticker): self
+    {
+        if (($idx = array_search($sticker, $this->sticker_ids)) !== null) {
+            array_splice($this->sticker_ids, $idx, 1);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Sets the stickers of the message. Removes the existing stickers in the process.
+     *
+     * @param array $stickers New message stickers.
+     *
+     * @return $this
+     */
+    public function setStickers(array $stickers): self
+    {
+        $this->sticker_ids = [];
+
+        foreach ($stickers as $sticker) {
+            $this->addSticker($sticker);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Returns all the stickers in the message.
+     *
+     * @return Sticker[]
+     */
+    public function getStickers(): array
+    {
+        return $this->sticker_ids;
     }
 
     /**
@@ -423,6 +497,11 @@ class MessageBuilder implements JsonSerializable
 
         if (count($this->embeds) > 0) {
             $content['embeds'] = $this->embeds;
+            $empty = false;
+        }
+
+        if (count($this->sticker_ids) > 0) {
+            $content['sticker_ids'] = $this->sticker_ids;
             $empty = false;
         }
 

--- a/src/Discord/Builders/MessageBuilder.php
+++ b/src/Discord/Builders/MessageBuilder.php
@@ -435,7 +435,7 @@ class MessageBuilder implements JsonSerializable
      */
     public function requiresMultipart(): bool
     {
-        return count($this->files) > 0;
+        return count($this->files);
     }
 
     /**
@@ -499,12 +499,12 @@ class MessageBuilder implements JsonSerializable
             $content['allowed_mentions'] = $this->allowed_mentions;
         }
 
-        if (count($this->embeds) > 0) {
+        if (count($this->embeds)) {
             $content['embeds'] = $this->embeds;
             $empty = false;
         }
 
-        if (count($this->sticker_ids) > 0) {
+        if (count($this->sticker_ids)) {
             $content['sticker_ids'] = $this->sticker_ids;
             $empty = false;
         }

--- a/src/Discord/Parts/Channel/Message.php
+++ b/src/Discord/Parts/Channel/Message.php
@@ -71,7 +71,7 @@ use function React\Promise\reject;
  * @property bool                 $suppress_embeds        Do not include embeds when serializing message.
  * @property bool                 $source_message_deleted Source message for this message has been deleted.
  * @property bool                 $urgent                 Message is urgent.
- * @property Collection|Sticker[] $stickers               Stickers attached to the message.
+ * @property Collection|Sticker[] $sticker_items          Stickers attached to the message.
  * @property object|null          $interaction            The interaction which triggered the message (slash commands).
  * @property string|null          $link                   Returns a link to the message.
  */
@@ -134,6 +134,7 @@ class Message extends Part
         'message_reference',
         'referenced_message',
         'flags',
+        'sticker_items',
         'stickers',
         'interaction',
     ];
@@ -466,19 +467,19 @@ class Message extends Part
     }
 
     /**
-     * Returns the stickers attribute.
+     * Returns the sticker_items attribute.
      *
      * @return Sticker[]|Collection
      */
-    protected function getStickersAttribute(): Collection
+    protected function getStickerItemsAttribute(): Collection
     {
-        $stickers = Collection::for(Sticker::class);
+        $sticker_items = Collection::for(Sticker::class);
 
-        foreach ($this->attributes['stickers'] ?? [] as $sticker) {
-            $stickers->push($this->factory->create(Sticker::class, $sticker, true));
+        foreach ($this->attributes['sticker_items'] ?? [] as $sticker) {
+            $sticker_items->push($this->factory->create(Sticker::class, $sticker, true));
         }
 
-        return $stickers;
+        return $sticker_items;
     }
     
     /**

--- a/src/Discord/Parts/Channel/Sticker.php
+++ b/src/Discord/Parts/Channel/Sticker.php
@@ -11,24 +11,32 @@
 
 namespace Discord\Parts\Channel;
 
+use Discord\Parts\Guild\Guild;
 use Discord\Parts\Part;
 
 /**
  * A sticker that can be sent in a Discord message.
  *
- * @link https://discord.com/developers/docs/resources/channel#message-object-message-sticker-structure
+ * @link https://discord.com/developers/docs/resources/sticker#sticker-object-sticker-structure
  *
- * @property string      $id
- * @property string      $pack_id
- * @property string      $name
- * @property string      $description
- * @property array       $tags
- * @property string      $asset
- * @property string|null $preview_asset
- * @property int         $format_type
+ * @property string      $id          The identifier for the sticker.
+ * @property string|null $pack_id     For standard stickers, id of the pack the sticker is from.
+ * @property string      $name        The name of the sticker.
+ * @property string      $description The description of the sticker.
+ * @property array       $tags        Autocomplete/suggestion tags for the sticker (max 200 characters).
+ * @property int         $type        The type of sticker.
+ * @property int         $format_type The type of sticker format.
+ * @property bool|null   $available   Whether this guild sticker can be used, may be false due to loss of Server Boosts.
+ * @property string|null $guild_id    The identifier of the guild that owns the sticker.
+ * @property Guild|null  $guild       The guild that owns the sticker.
+ * @property User|null   $user        The user that uploaded the guild sticker.
+ * @property int|null    $sort_value  The standard sticker's sort order within its pack.
  */
 class Sticker extends Part
 {
+    public const TYPE_STANDARD = 1;
+    public const TYPE_GUILD = 2;
+
     public const FORMAT_TYPE_PNG = 1;
     public const FORMAT_TYPE_APNG = 2;
     public const FORMAT_TYPE_LOTTIE = 3;
@@ -36,7 +44,61 @@ class Sticker extends Part
     /**
      * @inheritdoc
      */
-    protected $fillable = ['id', 'pack_id', 'name', 'description', 'tags', 'asset', 'preview_asset', 'format_type'];
+    protected $fillable = [
+        'id',
+        'pack_id',
+        'name',
+        'description',
+        'tags',
+        'asset',
+        'preview_asset',
+        'type',
+        'format_type',
+        'available',
+        'guild_id',
+        'user',
+        'sort_value',
+    ];
+
+    /**
+     * @inheritdoc
+     */
+    public function isPartial(): bool
+    {
+        return array_keys($this->attributes) == ['id', 'name', 'format_type'];
+    }
+
+    /**
+     * Returns the guild attribute.
+     *
+     * @return Guild|null The guild the sticker belongs to.
+     */
+    protected function getGuildAttribute(): ?Guild
+    {
+        if (! isset($this->attributes['guild_id'])) {
+            return null;
+        }
+
+        return $this->discord->guilds->get('id', $this->guild_id);
+    }
+
+    /**
+     * Gets the user that created the sticker.
+     *
+     * @return User|null
+     */
+    protected function getUserAttribute(): ?Part
+    {
+        if (! isset($this->attributes['user'])) {
+            return null;
+        }
+
+        if ($user = $this->discord->users->get('id', $this->attributes['user']->id)) {
+            return $user;
+        }
+
+        return $this->factory->part(User::class, $this->attributes['user'], true);
+    }
 
     /**
      * Returns the tags attribute.
@@ -50,5 +112,37 @@ class Sticker extends Part
         }
 
         return [];
+    }
+
+    /**
+     * Returns the URL for the sticker
+     *
+     * @return string The URL to the sticker.
+     */
+    public function __toString(): string
+    {
+        $format = 'png';
+
+        if ($this->attributes['format_type'] == self::FORMAT_TYPE_LOTTIE) {
+            $format = 'lottie';
+        }
+
+        return "https://cdn.discordapp.com/stickers/{$this->id}.{$format}";
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getRepositoryAttributes(): array
+    {
+        if ($this->type == self::TYPE_GUILD) {
+            return [
+                'id' => $this->id,
+                'guild_id' => $this->guild_id
+            ];
+        }
+        return [
+            'id' => $this->id
+        ];
     }
 }

--- a/src/Discord/Parts/Channel/Sticker.php
+++ b/src/Discord/Parts/Channel/Sticker.php
@@ -51,7 +51,6 @@ class Sticker extends Part
         'description',
         'tags',
         'asset',
-        'preview_asset',
         'type',
         'format_type',
         'available',

--- a/src/Discord/Parts/Channel/Sticker.php
+++ b/src/Discord/Parts/Channel/Sticker.php
@@ -64,7 +64,12 @@ class Sticker extends Part
      */
     public function isPartial(): bool
     {
-        return array_keys($this->attributes) == ['id', 'name', 'format_type'];
+        $partial = array_filter($this->attributes, function ($var) {
+            return isset($var);
+        });
+
+        sort($partial);
+        return array_keys($partial) == ['format_type', 'name', 'id'];
     }
 
     /**
@@ -136,12 +141,12 @@ class Sticker extends Part
     {
         if ($this->type == self::TYPE_GUILD) {
             return [
-                'id' => $this->id,
+                'sticker_id' => $this->id,
                 'guild_id' => $this->guild_id
             ];
         }
         return [
-            'id' => $this->id
+            'sticker_id' => $this->id
         ];
     }
 }

--- a/src/Discord/Parts/Guild/AuditLog/Entry.php
+++ b/src/Discord/Parts/Guild/AuditLog/Entry.php
@@ -65,6 +65,9 @@ class Entry extends Part
     public const INTEGRATION_CREATE = 80;
     public const INTEGRATION_UPDATE = 81;
     public const INTEGRATION_DELETE = 82;
+    public const STICKER_CREATE = 90;
+    public const STICKER_UPDATE = 91;
+    public const STICKER_DELETE = 92;
     // AUDIT LOG ENTRY TYPES
 
     /**

--- a/src/Discord/Parts/Guild/Guild.php
+++ b/src/Discord/Parts/Guild/Guild.php
@@ -168,6 +168,7 @@ class Guild extends Part
         'approximate_member_count',
         'approximate_presence_count',
         'nsfw_level',
+        'stickers',
         'premium_progress_bar_enabled',
     ];
 

--- a/src/Discord/Parts/Guild/Guild.php
+++ b/src/Discord/Parts/Guild/Guild.php
@@ -25,6 +25,7 @@ use Discord\Repository\Guild\MemberRepository;
 use Discord\Repository\Guild\RoleRepository;
 use Discord\Parts\Guild\AuditLog\AuditLog;
 use Discord\Parts\Guild\AuditLog\Entry;
+use Discord\Repository\Guild\StickerRepository;
 use Exception;
 use React\Promise\ExtendedPromiseInterface;
 use ReflectionClass;
@@ -208,6 +209,7 @@ class Guild extends Part
         'bans' => BanRepository::class,
         'invites' => InviteRepository::class,
         'emojis' => EmojiRepository::class,
+        'stickers' => StickerRepository::class,
     ];
 
     /**

--- a/src/Discord/Parts/Guild/Guild.php
+++ b/src/Discord/Parts/Guild/Guild.php
@@ -102,6 +102,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  * @property InviteRepository  $invites
  * @property BanRepository     $bans
  * @property EmojiRepository   $emojis
+ * @property StickerRepository $stickers
  */
 class Guild extends Part
 {

--- a/src/Discord/Repository/Guild/StickerRepository.php
+++ b/src/Discord/Repository/Guild/StickerRepository.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is a part of the DiscordPHP project.
+ *
+ * Copyright (c) 2015-present David Cole <david.cole1340@gmail.com>
+ *
+ * This file is subject to the MIT license that is bundled
+ * with this source code in the LICENSE.md file.
+ */
+
+namespace Discord\Repository\Guild;
+
+use Discord\Http\Endpoint;
+use Discord\Parts\Guild\Sticker;
+use Discord\Repository\AbstractRepository;
+
+/**
+ * Contains stickers that belong to guilds.
+ *
+ * @see \Discord\Parts\Guild\Sticker
+ * @see \Discord\Parts\Guild\Guild
+ *
+ * @method Sticker|null get(string $discrim, $key)  Gets an item from the collection.
+ * @method Sticker|null first()                     Returns the first element of the collection.
+ * @method Sticker|null pull($key, $default = null) Pulls an item from the repository, removing and returning the item.
+ * @method Sticker|null find(callable $callback)    Runs a filter callback over the repository.
+ */
+class StickerRepository extends AbstractRepository
+{
+    /**
+     * @inheritdoc
+     */
+    protected $endpoints = [
+        'all' => Endpoint::GUILD_STICKERS,
+        'get' => Endpoint::GUILD_STICKER,
+        'create' => Endpoint::GUILD_STICKERS,
+        'delete' => Endpoint::GUILD_STICKER,
+        'update' => Endpoint::GUILD_STICKER,
+    ];
+
+    /**
+     * @inheritdoc
+     */
+    protected $class = Sticker::class;
+}

--- a/src/Discord/Repository/Guild/StickerRepository.php
+++ b/src/Discord/Repository/Guild/StickerRepository.php
@@ -12,7 +12,7 @@
 namespace Discord\Repository\Guild;
 
 use Discord\Http\Endpoint;
-use Discord\Parts\Guild\Sticker;
+use Discord\Parts\Channel\Sticker;
 use Discord\Repository\AbstractRepository;
 
 /**

--- a/src/Discord/WebSockets/Event.php
+++ b/src/Discord/WebSockets/Event.php
@@ -44,6 +44,8 @@ abstract class Event
     public const GUILD_BAN_ADD = 'GUILD_BAN_ADD';
     public const GUILD_BAN_REMOVE = 'GUILD_BAN_REMOVE';
 
+    public const GUILD_STICKERS_UPDATE = 'GUILD_STICKERS_UPDATE';
+
     public const GUILD_MEMBER_ADD = 'GUILD_MEMBER_ADD';
     public const GUILD_MEMBER_REMOVE = 'GUILD_MEMBER_REMOVE';
     public const GUILD_MEMBER_UPDATE = 'GUILD_MEMBER_UPDATE';

--- a/src/Discord/WebSockets/Events/GuildStickersUpdate.php
+++ b/src/Discord/WebSockets/Events/GuildStickersUpdate.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is a part of the DiscordPHP project.
+ *
+ * Copyright (c) 2015-present David Cole <david.cole1340@gmail.com>
+ *
+ * This file is subject to the MIT license that is bundled
+ * with this source code in the LICENSE.md file.
+ */
+
+namespace Discord\WebSockets\Events;
+
+use Discord\WebSockets\Event;
+use Discord\Helpers\Deferred;
+use Discord\Parts\Channel\Sticker;
+
+class GuildStickersUpdate extends Event
+{
+    /**
+     * @inheritdoc
+     */
+    public function handle(Deferred &$deferred, $data): void
+    {
+        $adata = (array) $data->stickers;
+        $adata['guild_id'] = $data->guild_id;
+
+        $stickerPart = $this->factory->create(Sticker::class, $adata, true);
+
+        if ($guild = $this->discord->guilds->get('id', $stickerPart->guild_id)) {
+            $old = $guild->stickers->get('id', $stickerPart->id);
+            $guild->stickers->push($stickerPart);
+
+            $this->discord->guilds->push($guild);
+        } else {
+            $old = null;
+        }
+
+        $deferred->resolve([$stickerPart, $old]);
+    }
+}

--- a/src/Discord/WebSockets/Events/GuildStickersUpdate.php
+++ b/src/Discord/WebSockets/Events/GuildStickersUpdate.php
@@ -30,8 +30,6 @@ class GuildStickersUpdate extends Event
         if ($guild = $this->discord->guilds->get('id', $stickerPart->guild_id)) {
             $old = $guild->stickers->get('id', $stickerPart->id);
             $guild->stickers->push($stickerPart);
-
-            $this->discord->guilds->push($guild);
         } else {
             $old = null;
         }

--- a/src/Discord/WebSockets/Handlers.php
+++ b/src/Discord/WebSockets/Handlers.php
@@ -55,6 +55,9 @@ class Handlers
         $this->addHandler(Event::GUILD_BAN_ADD, \Discord\WebSockets\Events\GuildBanAdd::class);
         $this->addHandler(Event::GUILD_BAN_REMOVE, \Discord\WebSockets\Events\GuildBanRemove::class);
 
+        // Guild Sticker Event handler
+        $this->addHandler(Event::GUILD_STICKERS_UPDATE, \Discord\WebSockets\Events\GuildStickersUpdate::class);
+
         // Message handlers
         $this->addHandler(Event::MESSAGE_CREATE, \Discord\WebSockets\Events\MessageCreate::class, ['message']);
         $this->addHandler(Event::MESSAGE_DELETE, \Discord\WebSockets\Events\MessageDelete::class);

--- a/src/Discord/WebSockets/Intents.php
+++ b/src/Discord/WebSockets/Intents.php
@@ -50,7 +50,7 @@ class Intents
     public const GUILD_BANS = (1 << 2);
 
     /**
-     * Guild emoji and sitcker events:.
+     * Guild emoji and sticker events:.
      *
      * - GUILD_EMOJIS_UPDATE
      * - GUILD_STICKERS_UPDATE

--- a/src/Discord/WebSockets/Intents.php
+++ b/src/Discord/WebSockets/Intents.php
@@ -47,11 +47,12 @@ class Intents
     public const GUILD_BANS = (1 << 2);
 
     /**
-     * Guild emoji events:.
+     * Guild emoji and sitcker events:.
      *
      * - GUILD_EMOJIS_UPDATE
+     * - GUILD_STICKERS_UPDATE
      */
-    public const GUILD_EMOJIS = (1 << 3);
+    public const GUILD_EMOJIS_AND_STICKERS = (1 << 3);
 
     /**
      * Guild integration events:.


### PR DESCRIPTION
This PR is an exclusive improvement of [Sticker API](https://discord.com/developers/docs/resources/sticker).
- Updated [Sticker Part structure](https://discord.com/developers/docs/resources/sticker#sticker-object-sticker-structure)
- Add [Guild Sticker Repository](https://discord.com/developers/docs/resources/sticker#list-guild-stickers)
- Add sticker in [Message Builder](https://discord.com/developers/docs/resources/channel#create-message-jsonform-params)
- Add Guild Sticker in [Audit Log Entry](https://discord.com/developers/docs/resources/audit-log#audit-log-entry-object-audit-log-events)
- Add [Guild Sticker Update event](https://discord.com/developers/docs/topics/gateway#guild-stickers-update) handler

To be noted that I have not tested guild sticker events, need to do it on a boosted server.

- [ ] Add documentation