### PR TITLE
Add reason parameter to some endpoint methods

### DIFF
--- a/src/Discord/Parts/Channel/Channel.php
+++ b/src/Discord/Parts/Channel/Channel.php
@@ -246,13 +246,14 @@ class Channel extends Part
     /**
      * Sets permissions in a channel.
      *
-     * @param Part  $part  A role or member.
-     * @param array $allow An array of permissions to allow.
-     * @param array $deny  An array of permissions to deny.
+     * @param Part        $part   A role or member.
+     * @param array       $allow  An array of permissions to allow.
+     * @param array       $deny   An array of permissions to deny.
+     * @param string|null $reason Reason for Audit Log.
      *
      * @return ExtendedPromiseInterface
      */
-    public function setPermissions(Part $part, array $allow = [], array $deny = []): ExtendedPromiseInterface
+    public function setPermissions(Part $part, array $allow = [], array $deny = [], ?string $reason = null): ExtendedPromiseInterface
     {
         if ($part instanceof Member) {
             $type = Overwrite::TYPE_MEMBER;
@@ -276,18 +277,19 @@ class Channel extends Part
             'deny' => $denyPart->bitwise,
         ]);
 
-        return $this->setOverwrite($part, $overwrite);
+        return $this->setOverwrite($part, $overwrite, $reason);
     }
 
     /**
      * Sets an overwrite to the channel.
      *
-     * @param Part      $part      A role or member.
-     * @param Overwrite $overwrite An overwrite object.
+     * @param Part        $part      A role or member.
+     * @param Overwrite   $overwrite An overwrite object.
+     * @param string|null $reason    Reason for Audit Log.
      *
      * @return ExtendedPromiseInterface
      */
-    public function setOverwrite(Part $part, Overwrite $overwrite): ExtendedPromiseInterface
+    public function setOverwrite(Part $part, Overwrite $overwrite, ?string $reason = null): ExtendedPromiseInterface
     {
         if (! $this->is_private) {
             $botperms = $this->guild->members->offsetGet($this->discord->id)->getPermissions($this);
@@ -318,7 +320,12 @@ class Channel extends Part
             return \React\Promise\resolve();
         }
 
-        return $this->http->put(Endpoint::bind(Endpoint::CHANNEL_PERMISSIONS, $this->id, $part->id), $payload);
+        $headers = [];
+        if (isset($reason)) {
+            $headers['X-Audit-Log-Reason'] = $reason;
+        }
+
+        return $this->http->put(Endpoint::bind(Endpoint::CHANNEL_PERMISSIONS, $this->id, $part->id), $payload, $headers);
     }
 
     /**
@@ -338,11 +345,12 @@ class Channel extends Part
     /**
      * Moves a member to another voice channel.
      *
-     * @param Member|string The member to move. (either a Member part or the member ID)
+     * @param Member|string $member The member to move. (either a Member part or the member ID)
+     * @param string|null   $reason Reason for Audit Log.
      *
      * @return ExtendedPromiseInterface
      */
-    public function moveMember($member): ExtendedPromiseInterface
+    public function moveMember($member, ?string $reason = null): ExtendedPromiseInterface
     {
         if (! $this->allowVoice()) {
             return reject(new \Exception('You cannot move a member in a text channel.'));
@@ -360,17 +368,23 @@ class Channel extends Part
             $member = $member->id;
         }
 
-        return $this->http->patch(Endpoint::bind(Endpoint::GUILD_MEMBER, $this->guild_id, $member), ['channel_id' => $this->id]);
+        $headers = [];
+        if (isset($reason)) {
+            $headers['X-Audit-Log-Reason'] = $reason;
+        }
+
+        return $this->http->patch(Endpoint::bind(Endpoint::GUILD_MEMBER, $this->guild_id, $member), ['channel_id' => $this->id], $headers);
     }
 
     /**
      * Mutes a member on a voice channel.
      *
-     * @param Member|string The member to mute. (either a Member part or the member ID)
+     * @param Member|string $member The member to mute. (either a Member part or the member ID)
+     * @param string|null   $reason Reason for Audit Log.
      *
      * @return ExtendedPromiseInterface
      */
-    public function muteMember($member): ExtendedPromiseInterface
+    public function muteMember($member, ?string $reason = null): ExtendedPromiseInterface
     {
         if (! $this->allowVoice()) {
             return reject(new \Exception('You cannot mute a member in a text channel.'));
@@ -388,17 +402,23 @@ class Channel extends Part
             $member = $member->id;
         }
 
-        return $this->http->patch(Endpoint::bind(Endpoint::GUILD_MEMBER, $this->guild_id, $member), ['mute' => true]);
+        $headers = [];
+        if (isset($reason)) {
+            $headers['X-Audit-Log-Reason'] = $reason;
+        }
+
+        return $this->http->patch(Endpoint::bind(Endpoint::GUILD_MEMBER, $this->guild_id, $member), ['mute' => true], $headers);
     }
 
     /**
      * Unmutes a member on a voice channel.
      *
-     * @param Member|string The member to unmute. (either a Member part or the member ID)
+     * @param Member|string $member The member to unmute. (either a Member part or the member ID)
+     * @param string|null   $reason Reason for Audit Log.
      *
      * @return ExtendedPromiseInterface
      */
-    public function unmuteMember($member): ExtendedPromiseInterface
+    public function unmuteMember($member, ?string $reason = null): ExtendedPromiseInterface
     {
         if (! $this->allowVoice()) {
             return \React\Promise\reject(new \Exception('You cannot unmute a member in a text channel.'));
@@ -416,7 +436,12 @@ class Channel extends Part
             $member = $member->id;
         }
 
-        return $this->http->patch(Endpoint::bind(Endpoint::GUILD_MEMBER, $this->guild_id, $member), ['mute' => false]);
+        $headers = [];
+        if (isset($reason)) {
+            $headers['X-Audit-Log-Reason'] = $reason;
+        }
+
+        return $this->http->patch(Endpoint::bind(Endpoint::GUILD_MEMBER, $this->guild_id, $member), ['mute' => false], $headers);
     }
 
     /**
@@ -467,10 +492,11 @@ class Channel extends Part
      * Bulk deletes an array of messages.
      *
      * @param array|Traversable $messages An array of messages to delete.
+     * @param string|null       $reason   Reason for Audit Log.
      *
      * @return ExtendedPromiseInterface
      */
-    public function deleteMessages($messages): ExtendedPromiseInterface
+    public function deleteMessages($messages, ?string $reason = null): ExtendedPromiseInterface
     {
         if (! is_array($messages) && ! ($messages instanceof Traversable)) {
             return reject(new \Exception('$messages must be an array or implement Traversable.'));
@@ -480,7 +506,14 @@ class Channel extends Part
 
         if ($count == 0) {
             return resolve();
-        } elseif ($count == 1 || $this->is_private) {
+        }
+
+        $headers = [];
+        if (isset($reason)) {
+            $headers['X-Audit-Log-Reason'] = $reason;
+        }
+
+        if ($count == 1 || $this->is_private) {
             foreach ($messages as $message) {
                 if ($message instanceof Message ||
                     $message = $this->messages->get('id', $message)
@@ -488,7 +521,7 @@ class Channel extends Part
                     return $message->delete();
                 }
 
-                return $this->http->delete(Endpoint::bind(Endpoint::CHANNEL_MESSAGE, $this->id, $message));
+                return $this->http->delete(Endpoint::bind(Endpoint::CHANNEL_MESSAGE, $this->id, $message), null, $headers);
             }
         } else {
             $messageID = [];
@@ -504,7 +537,7 @@ class Channel extends Part
             $promises = [];
 
             while (! empty($messageID)) {
-                $promises[] = $this->http->post(Endpoint::bind(Endpoint::CHANNEL_MESSAGES_BULK_DELETE, $this->id), ['messages' => array_slice($messageID, 0, 100)]);
+                $promises[] = $this->http->post(Endpoint::bind(Endpoint::CHANNEL_MESSAGES_BULK_DELETE, $this->id), ['messages' => array_slice($messageID, 0, 100)], $headers);
                 $messageID = array_slice($messageID, 100);
             }
 
@@ -515,14 +548,15 @@ class Channel extends Part
     /**
      * Deletes a given number of messages, in order of time sent.
      *
-     * @param int $value
+     * @param int         $value
+     * @param string|null $reason Reason for Audit Log.
      *
      * @return ExtendedPromiseInterface
      */
-    public function limitDelete(int $value): ExtendedPromiseInterface
+    public function limitDelete(int $value, ?string $reason = null): ExtendedPromiseInterface
     {
-        return $this->getMessageHistory(['limit' => $value])->then(function ($messages) {
-            return $this->deleteMessages($messages);
+        return $this->getMessageHistory(['limit' => $value])->then(function ($messages) use ($reason) {
+            return $this->deleteMessages($messages, $reason);
         });
     }
 
@@ -588,11 +622,12 @@ class Channel extends Part
     /**
      * Adds a message to the channels pinboard.
      *
-     * @param Message $message The message to pin.
+     * @param Message     $message The message to pin.
+     * @param string|null $reason  Reason for Audit Log.
      *
      * @return ExtendedPromiseInterface<Message>
      */
-    public function pinMessage(Message $message): ExtendedPromiseInterface
+    public function pinMessage(Message $message, ?string $reason = null): ExtendedPromiseInterface
     {
         if (! $this->is_private) {
             $botperms = $this->guild->members->offsetGet($this->discord->id)->getPermissions($this);
@@ -610,7 +645,12 @@ class Channel extends Part
             return reject(new \Exception('You cannot pin a message to a different channel.'));
         }
 
-        return $this->http->put(Endpoint::bind(Endpoint::CHANNEL_PIN, $this->id, $message->id))->then(function () use (&$message) {
+        $headers = [];
+        if (isset($reason)) {
+            $headers['X-Audit-Log-Reason'] = $reason;
+        }
+
+        return $this->http->put(Endpoint::bind(Endpoint::CHANNEL_PIN, $this->id, $message->id), null, $headers)->then(function () use (&$message) {
             $message->pinned = true;
 
             return $message;
@@ -620,11 +660,12 @@ class Channel extends Part
     /**
      * Removes a message from the channels pinboard.
      *
-     * @param Message $message The message to un-pin.
+     * @param Message     $message The message to un-pin.
+     * @param string|null $reason  Reason for Audit Log.
      *
      * @return ExtendedPromiseInterface
      */
-    public function unpinMessage(Message $message): ExtendedPromiseInterface
+    public function unpinMessage(Message $message, ?string $reason = null): ExtendedPromiseInterface
     {
         if (! $this->is_private) {
             $botperms = $this->guild->members->offsetGet($this->discord->id)->getPermissions($this);
@@ -642,7 +683,12 @@ class Channel extends Part
             return reject(new \Exception('You cannot un-pin a message from a different channel.'));
         }
 
-        return $this->http->delete(Endpoint::bind(Endpoint::CHANNEL_PIN, $this->id, $message->id))->then(function () use (&$message) {
+        $headers = [];
+        if (isset($reason)) {
+            $headers['X-Audit-Log-Reason'] = $reason;
+        }
+
+        return $this->http->delete(Endpoint::bind(Endpoint::CHANNEL_PIN, $this->id, $message->id), null, $headers)->then(function () use (&$message) {
             $message->pinned = false;
 
             return $message;
@@ -690,13 +736,14 @@ class Channel extends Part
     /**
      * Starts a thread in the channel.
      *
-     * @param string $name                  the name of the thread.
-     * @param bool   $private               whether the thread should be private. cannot start a private thread in a news channel.
-     * @param int    $auto_archive_duration number of minutes of inactivity until the thread is auto-archived. one of 60, 1440, 4320, 10080.
+     * @param string      $name                  the name of the thread.
+     * @param bool        $private               whether the thread should be private. cannot start a private thread in a news channel.
+     * @param int         $auto_archive_duration number of minutes of inactivity until the thread is auto-archived. one of 60, 1440, 4320, 10080.
+     * @param string|null $reason                Reason for Audit Log.
      *
      * @return ExtendedPromiseInterface<Thread>
      */
-    public function startThread(string $name, bool $private = false, int $auto_archive_duration = 1440): ExtendedPromiseInterface
+    public function startThread(string $name, bool $private = false, int $auto_archive_duration = 1440, ?string $reason = null): ExtendedPromiseInterface
     {
         if ($private && ! $this->guild->feature_private_threads) {
             return reject(new RuntimeException('Guild does not have access to private threads.'));
@@ -731,11 +778,16 @@ class Channel extends Part
                 break;
         }
 
+        $headers = [];
+        if (isset($reason)) {
+            $headers['X-Audit-Log-Reason'] = $reason;
+        }
+
         return $this->http->post(Endpoint::bind(Endpoint::CHANNEL_THREADS, $this->id), [
             'name' => $name,
             'auto_archive_duration' => $auto_archive_duration,
             'type' => $type,
-        ])->then(function ($response) {
+        ], $headers)->then(function ($response) {
             return $this->factory->create(Thread::class, $response, true);
         });
     }

--- a/src/Discord/Parts/Channel/Message.php
+++ b/src/Discord/Parts/Channel/Message.php
@@ -496,12 +496,13 @@ class Message extends Part
     /**
      * Starts a public thread from the message.
      *
-     * @param string $name                  The name of the thread.
-     * @param int    $auto_archive_duration Number of minutes of inactivity until the thread is auto-archived. One of 60, 1440, 4320, 10080.
+     * @param string      $name                  The name of the thread.
+     * @param int         $auto_archive_duration Number of minutes of inactivity until the thread is auto-archived. One of 60, 1440, 4320, 10080.
+     * @param string|null $reason                Reason for Audit Log.
      *
      * @return ExtendedPromiseInterface<Thread>
      */
-    public function startThread(string $name, int $auto_archive_duration = 1440): ExtendedPromiseInterface
+    public function startThread(string $name, int $auto_archive_duration = 1440, ?string $reason = null): ExtendedPromiseInterface
     {
         if (! $this->guild) {
             return reject(new RuntimeException('You can only start threads on guild text channels.'));
@@ -524,10 +525,15 @@ class Message extends Part
                 break;
         }
 
+        $headers = [];
+        if (isset($reason)) {
+            $headers['X-Audit-Log-Reason'] = $reason;
+        }
+
         return $this->http->post(Endpoint::bind(Endpoint::CHANNEL_MESSAGE_THREADS, $this->channel_id, $this->id), [
             'name' => $name,
             'auto_archive_duration' => $auto_archive_duration,
-        ])->then(function ($response) {
+        ], $headers)->then(function ($response) {
             return $this->factory->create(Thread::class, $response, true);
         });
     }

--- a/src/Discord/Parts/Guild/Guild.php
+++ b/src/Discord/Parts/Guild/Guild.php
@@ -500,17 +500,23 @@ class Guild extends Part
      * Transfers ownership of the guild to
      * another member.
      *
-     * @param Member|int $member The member to transfer ownership to.
+     * @param Member|int  $member The member to transfer ownership to.
+     * @param string|null $reason Reason for Audit Log.
      *
      * @return ExtendedPromiseInterface
      */
-    public function transferOwnership($member): ExtendedPromiseInterface
+    public function transferOwnership($member, ?string $reason = null): ExtendedPromiseInterface
     {
         if ($member instanceof Member) {
             $member = $member->id;
         }
 
-        return $this->http->patch(Endpoint::bind(Endpoint::GUILD), ['owner_id' => $member])->then(function ($response) use ($member) {
+        $headers = [];
+        if (isset($reason)) {
+            $headers['X-Audit-Log-Reason'] = $reason;
+        }
+
+        return $this->http->patch(Endpoint::bind(Endpoint::GUILD), ['owner_id' => $member], $headers)->then(function ($response) use ($member) {
             if ($response->owner_id != $member) {
                 throw new Exception('Ownership was not transferred correctly.');
             }
@@ -599,10 +605,11 @@ class Guild extends Part
      * and the RHS value is a `Role` object or a string ID, e.g. [1 => 'role_id_1', 3 => 'role_id_3'].
      *
      * @param array $roles
+     * @param string|null  $reason Reason for Audit Log.
      *
      * @return ExtendedPromiseInterface
      */
-    public function updateRolePositions(array $roles): ExtendedPromiseInterface
+    public function updateRolePositions(array $roles, ?string $reason = null): ExtendedPromiseInterface
     {
         $payload = [];
 
@@ -613,7 +620,12 @@ class Guild extends Part
             ];
         }
 
-        return $this->http->patch(Endpoint::bind(Endpoint::GUILD_ROLES, $this->id), $payload)
+        $headers = [];
+        if (isset($reason)) {
+            $headers['X-Audit-Log-Reason'] = $reason;
+        }
+
+        return $this->http->patch(Endpoint::bind(Endpoint::GUILD_ROLES, $this->id), $payload, $headers)
             ->then(function () {
                 return $this;
             });

--- a/src/Discord/Parts/Guild/Guild.php
+++ b/src/Discord/Parts/Guild/Guild.php
@@ -605,11 +605,10 @@ class Guild extends Part
      * and the RHS value is a `Role` object or a string ID, e.g. [1 => 'role_id_1', 3 => 'role_id_3'].
      *
      * @param array $roles
-     * @param string|null  $reason Reason for Audit Log.
      *
      * @return ExtendedPromiseInterface
      */
-    public function updateRolePositions(array $roles, ?string $reason = null): ExtendedPromiseInterface
+    public function updateRolePositions(array $roles): ExtendedPromiseInterface
     {
         $payload = [];
 
@@ -620,12 +619,7 @@ class Guild extends Part
             ];
         }
 
-        $headers = [];
-        if (isset($reason)) {
-            $headers['X-Audit-Log-Reason'] = $reason;
-        }
-
-        return $this->http->patch(Endpoint::bind(Endpoint::GUILD_ROLES, $this->id), $payload, $headers)
+        return $this->http->patch(Endpoint::bind(Endpoint::GUILD_ROLES, $this->id), $payload)
             ->then(function () {
                 return $this;
             });

--- a/src/Discord/Parts/Thread/Thread.php
+++ b/src/Discord/Parts/Thread/Thread.php
@@ -330,7 +330,7 @@ class Thread extends Part
      * Bulk deletes an array of messages.
      *
      * @param array|Traversable $messages
-     * @param string|null       $reason   Reason for Audit Log.
+     * @param string|null       $reason   Reason for Audit Log (only for bulk messages).
      *
      * @return ExtendedPromiseInterface
      */
@@ -344,21 +344,19 @@ class Thread extends Part
 
         if ($count == 0) {
             return \React\Promise\resolve();
-        }
-
-        $headers = [];
-        if (isset($reason)) {
-            $headers['X-Audit-Log-Reason'] = $reason;
-        }
-        
-        if ($count == 1) {
+        } elseif ($count == 1) {
             foreach ($messages as $message) {
                 if ($message instanceof Message) {
                     $message = $message->id;
                 }
 
-                return $this->http->delete(Endpoint::bind(Endpoint::CHANNEL_MESSAGE, $this->id, $message), null, $headers);
+                return $this->http->delete(Endpoint::bind(Endpoint::CHANNEL_MESSAGE, $this->id, $message));
             }
+        }
+
+        $headers = [];
+        if (isset($reason)) {
+            $headers['X-Audit-Log-Reason'] = $reason;
         }
 
         $promises = [];

--- a/src/Discord/Parts/Thread/Thread.php
+++ b/src/Discord/Parts/Thread/Thread.php
@@ -330,10 +330,11 @@ class Thread extends Part
      * Bulk deletes an array of messages.
      *
      * @param array|Traversable $messages
+     * @param string|null       $reason   Reason for Audit Log.
      *
      * @return ExtendedPromiseInterface
      */
-    public function deleteMessages($messages): ExtendedPromiseInterface
+    public function deleteMessages($messages, ?string $reason = null): ExtendedPromiseInterface
     {
         if (! is_array($messages) && ! ($messages instanceof Traversable)) {
             return \React\Promise\reject(new \Exception('$messages must be an array or implement Traversable.'));
@@ -343,13 +344,20 @@ class Thread extends Part
 
         if ($count == 0) {
             return \React\Promise\resolve();
-        } elseif ($count == 1) {
+        }
+
+        $headers = [];
+        if (isset($reason)) {
+            $headers['X-Audit-Log-Reason'] = $reason;
+        }
+        
+        if ($count == 1) {
             foreach ($messages as $message) {
                 if ($message instanceof Message) {
                     $message = $message->id;
                 }
 
-                return $this->http->delete(Endpoint::bind(Endpoint::CHANNEL_MESSAGE, $this->id, $message));
+                return $this->http->delete(Endpoint::bind(Endpoint::CHANNEL_MESSAGE, $this->id, $message), null, $headers);
             }
         }
 
@@ -365,7 +373,7 @@ class Thread extends Part
         foreach ($chunks as $messages) {
             $promises[] = $this->http->post(Endpoint::bind(Endpoint::CHANNEL_MESSAGES_BULK_DELETE, $this->id), [
                 'messages' => $messages,
-            ]);
+            ], $headers);
         }
 
         return \React\Promise\all($promises);
@@ -432,11 +440,12 @@ class Thread extends Part
     /**
      * Pins a message in the thread.
      *
-     * @param Message $message
+     * @param Message     $message
+     * @param string|null $reason  Reason for Audit Log.
      *
      * @return ExtendedPromiseInterface<Message>
      */
-    public function pinMessage(Message $message): ExtendedPromiseInterface
+    public function pinMessage(Message $message, ?string $reason = null): ExtendedPromiseInterface
     {
         if ($message->pinned) {
             return \React\Promise\reject(new \Exception('This message is already pinned.'));
@@ -446,7 +455,12 @@ class Thread extends Part
             return \React\Promise\reject(new \Exception('You cannot pin a message not sent in this thread.'));
         }
 
-        return $this->http->put(Endpoint::bind(Endpoint::CHANNEL_PIN, $this->id, $message->id))->then(function () use (&$message) {
+        $headers = [];
+        if (isset($reason)) {
+            $headers['X-Audit-Log-Reason'] = $reason;
+        }
+
+        return $this->http->put(Endpoint::bind(Endpoint::CHANNEL_PIN, $this->id, $message->id), null, $headers)->then(function () use (&$message) {
             $message->pinned = true;
 
             return $message;
@@ -456,11 +470,12 @@ class Thread extends Part
     /**
      * Unpins a message in the thread.
      *
-     * @param Message $message
+     * @param Message     $message
+     * @param string|null $reason  Reason for Audit Log.
      *
      * @return ExtendedPromiseInterface<Message>
      */
-    public function unpinMessage(Message $message): ExtendedPromiseInterface
+    public function unpinMessage(Message $message, ?string $reason = null): ExtendedPromiseInterface
     {
         if (! $message->pinned) {
             return \React\Promise\reject(new \Exception('This message is not pinned.'));
@@ -470,7 +485,12 @@ class Thread extends Part
             return \React\Promise\reject(new \Exception('You cannot un-pin a message not sent in this thread.'));
         }
 
-        return $this->http->delete(Endpoint::bind(Endpoint::CHANNEL_PIN, $this->id, $message->id))->then(function () use (&$message) {
+        $headers = [];
+        if (isset($reason)) {
+            $headers['X-Audit-Log-Reason'] = $reason;
+        }
+
+        return $this->http->delete(Endpoint::bind(Endpoint::CHANNEL_PIN, $this->id, $message->id), null, $headers)->then(function () use (&$message) {
             $message->pinned = false;
 
             return $message;

--- a/src/Discord/Parts/User/Member.php
+++ b/src/Discord/Parts/User/Member.php
@@ -132,7 +132,7 @@ class Member extends Part
      *
      * @return ExtendedPromiseInterface
      */
-    public function moveMember($channel): ExtendedPromiseInterface
+    public function moveMember($channel, ?string $reason = null): ExtendedPromiseInterface
     {
         if ($channel instanceof Channel) {
             $channel = $channel->id;

--- a/src/Discord/Parts/User/Member.php
+++ b/src/Discord/Parts/User/Member.php
@@ -100,28 +100,35 @@ class Member extends Part
     /**
      * Sets the nickname of the member.
      *
-     * @param string|null $nick The nickname of the member.
+     * @param string|null $nick   The nickname of the member.
+     * @param string|null $reason Reason for Audit Log.
      *
      * @return ExtendedPromiseInterface
      */
-    public function setNickname(?string $nick = null): ExtendedPromiseInterface
+    public function setNickname(?string $nick = null, ?string $reason = null): ExtendedPromiseInterface
     {
         $payload = [
             'nick' => $nick ?: '',
         ];
 
-        // jake plz
-        if ($this->discord->id == $this->id) {
-            return $this->http->patch(Endpoint::bind(Endpoint::GUILD_MEMBER_SELF_NICK, $this->guild_id), $payload);
+        $headers = [];
+        if (isset($reason)) {
+            $headers['X-Audit-Log-Reason'] = $reason;
         }
 
-        return $this->http->patch(Endpoint::bind(Endpoint::GUILD_MEMBER, $this->guild_id, $this->id), $payload);
+        // jake plz
+        if ($this->discord->id == $this->id) {
+            return $this->http->patch(Endpoint::bind(Endpoint::GUILD_MEMBER_SELF_NICK, $this->guild_id), $payload, $headers);
+        }
+
+        return $this->http->patch(Endpoint::bind(Endpoint::GUILD_MEMBER, $this->guild_id, $this->id), $payload, $headers);
     }
 
     /**
      * Moves the member to another voice channel.
      *
      * @param Channel|string $channel The channel to move the member to.
+     * @param string|null    $reason  Reason for Audit Log.
      *
      * @return ExtendedPromiseInterface
      */
@@ -131,17 +138,23 @@ class Member extends Part
             $channel = $channel->id;
         }
 
-        return $this->http->patch(Endpoint::bind(Endpoint::GUILD_MEMBER, $this->guild_id, $this->id), ['channel_id' => $channel]);
+        $headers = [];
+        if (isset($reason)) {
+            $headers['X-Audit-Log-Reason'] = $reason;
+        }
+
+        return $this->http->patch(Endpoint::bind(Endpoint::GUILD_MEMBER, $this->guild_id, $this->id), ['channel_id' => $channel], $headers);
     }
 
     /**
      * Adds a role to the member.
      *
-     * @param Role|string $role The role to add to the member.
+     * @param Role|string $role   The role to add to the member.
+     * @param string|null $reason Reason for Audit Log.
      *
      * @return ExtendedPromiseInterface
      */
-    public function addRole($role): ExtendedPromiseInterface
+    public function addRole($role, ?string $reason = null): ExtendedPromiseInterface
     {
         if ($role instanceof Role) {
             $role = $role->id;
@@ -152,24 +165,35 @@ class Member extends Part
             return \React\Promise\reject(new \Exception('User already has role.'));
         }
 
-        return $this->http->put(Endpoint::bind(Endpoint::GUILD_MEMBER_ROLE, $this->guild_id, $this->id, $role));
+        $headers = [];
+        if (isset($reason)) {
+            $headers['X-Audit-Log-Reason'] = $reason;
+        }
+
+        return $this->http->put(Endpoint::bind(Endpoint::GUILD_MEMBER_ROLE, $this->guild_id, $this->id, $role), null, $headers);
     }
 
     /**
      * Removes a role from the user.
      *
-     * @param Role|string $role The role to remove from the member.
+     * @param Role|string $role   The role to remove from the member.
+     * @param string|null $reason Reason for Audit Log.
      *
      * @return ExtendedPromiseInterface
      */
-    public function removeRole($role): ExtendedPromiseInterface
+    public function removeRole($role, ?string $reason = null): ExtendedPromiseInterface
     {
         if ($role instanceof Role) {
             $role = $role->id;
         }
 
         if (in_array($role, $this->attributes['roles'])) {
-            return $this->http->delete(Endpoint::bind(Endpoint::GUILD_MEMBER_ROLE, $this->guild_id, $this->id, $role));
+            $headers = [];
+            if (isset($reason)) {
+                $headers['X-Audit-Log-Reason'] = $reason;
+            }
+
+            return $this->http->delete(Endpoint::bind(Endpoint::GUILD_MEMBER_ROLE, $this->guild_id, $this->id, $role), null, $headers);
         }
 
         return \React\Promise\reject(new \Exception('User does not have role.'));

--- a/src/Discord/Repository/Guild/BanRepository.php
+++ b/src/Discord/Repository/Guild/BanRepository.php
@@ -63,6 +63,7 @@ class BanRepository extends AbstractRepository
     {
         $deferred = new Deferred();
         $content = [];
+        $headers = [];
 
         if ($member instanceof Member) {
             $member = $member->id;
@@ -73,12 +74,13 @@ class BanRepository extends AbstractRepository
         }
 
         if (! is_null($reason)) {
-            $content['reason'] = $reason;
+            $headers['X-Audit-Log-Reason'] = $reason;
         }
 
         $this->http->put(
             Endpoint::bind(Endpoint::GUILD_BAN, $this->vars['guild_id'], $member),
-            empty($content) ? null : $content
+            empty($content) ? null : $content,
+            $headers
         )->done(function ($response) use ($deferred) {
             $ban = $this->factory->create(Ban::class, $response, true);
             $this->push($ban);


### PR DESCRIPTION
Add an optional `$reason` parameter as `X-Audit-Log-Reason` header in some methods that support it (i.e. http `->post()` `->patch()` `->put()` and `->delete()`).
This does not cover audit log endpoints from create/update repository.

#653 

~~Note: not really tested yet.~~

- [ ] Update documentation