### PR TITLE
Make role createable

### DIFF
--- a/src/Discord/Parts/Guild/Guild.php
+++ b/src/Discord/Parts/Guild/Guild.php
@@ -286,7 +286,7 @@ class Guild extends Part
      */
     public function getIconAttribute(string $format = 'webp', int $size = 1024)
     {
-        if (is_null($this->attributes['icon'])) {
+        if (! isset($this->attributes['icon'])) {
             return null;
         }
 
@@ -319,7 +319,7 @@ class Guild extends Part
      */
     public function getSplashAttribute(string $format = 'webp', int $size = 2048)
     {
-        if (is_null($this->attributes['splash'])) {
+        if (! isset($this->attributes['splash'])) {
             return null;
         }
 

--- a/src/Discord/Parts/Guild/Guild.php
+++ b/src/Discord/Parts/Guild/Guild.php
@@ -14,6 +14,7 @@ namespace Discord\Parts\Guild;
 use Carbon\Carbon;
 use Discord\Helpers\Collection;
 use Discord\Http\Endpoint;
+use Discord\Http\Exceptions\NoPermissionsException;
 use Discord\Parts\Part;
 use Discord\Parts\User\Member;
 use Discord\Parts\User\User;
@@ -477,6 +478,12 @@ class Guild extends Part
      */
     public function createRole(array $data = []): ExtendedPromiseInterface
     {
+        $botperms = $this->members->offsetGet($this->discord->id)->getPermissions();
+
+        if (! $botperms->manage_roles) {
+            return \React\Promise\reject(new NoPermissionsException('You do not have permission to manage roles in the specified guild.'));
+        }
+
         return $this->roles->save($this->factory->create(Role::class, $data));
     }
 

--- a/src/Discord/Parts/Guild/Guild.php
+++ b/src/Discord/Parts/Guild/Guild.php
@@ -477,13 +477,7 @@ class Guild extends Part
      */
     public function createRole(array $data = []): ExtendedPromiseInterface
     {
-        $rolePart = $this->factory->create(Role::class);
-
-        return $this->roles->save($rolePart)->then(function ($role) use ($data) {
-            $role->fill((array) $data);
-
-            return $this->roles->save($role);
-        });
+        return $this->roles->save($this->factory->create(Role::class, $data));
     }
 
     /**

--- a/src/Discord/Parts/Guild/Role.php
+++ b/src/Discord/Parts/Guild/Role.php
@@ -24,9 +24,9 @@ use Discord\Parts\Permissions\RolePermission;
  * @property bool           $hoist         Whether the role is hoisted on the sidebar.
  * @property int            $position      The position of the role on the sidebar.
  * @property RolePermission $permissions   The permissions of the role.
- * @property string         $icon          The URL to the role icon.
- * @property string         $icon_hash     The icon hash for the role.
- * @property string         $unicode_emoji The unicode emoji for the role.
+ * @property string|null    $icon          The URL to the role icon.
+ * @property string|null    $icon_hash     The icon hash for the role.
+ * @property string|null    $unicode_emoji The unicode emoji for the role.
  * @property bool           $mentionable   Whether the role is mentionable.
  * @property Guild          $guild         The guild that the role belongs to.
  * @property string         $guild_id      The unique identifier of the guild that the role belongs to.
@@ -90,7 +90,15 @@ class Role extends Part
      */
     public function getCreatableAttributes(): array
     {
-        return [];
+        return [
+            'name' => $this->name,
+            'permissions' => $this->permissions->bitwise,
+            'color' => $this->color,
+            'hoist' => $this->hoist,
+            'icon' => $this->attributes['icon'] ?? null,
+            'unicode_emoji' => $this->unicode_emoji ?? null,
+            'mentionable' => $this->mentionable,
+        ];
     }
 
     /**

--- a/src/Discord/Parts/Guild/Role.php
+++ b/src/Discord/Parts/Guild/Role.php
@@ -111,7 +111,7 @@ class Role extends Part
      */
     public function getIconAttribute(string $format = 'png', int $size = 64)
     {
-        if (is_null($this->attributes['icon'])) {
+        if (! isset($this->attributes['icon'])) {
             return null;
         }
 


### PR DESCRIPTION
Make Role Part createable, update the Guild::createRole to check bot permission and use only create role attributes instead of creating default empty role and sending a patch to fill the new role data:
```
[2021-12-28T10:44:18.991508+00:00] DiscordPHP.DEBUG: BUCKET postguilds/111111111111111111/roles queued REQ POST guilds/111111111111111111/roles [] []
[2021-12-28T10:44:19.362529+00:00] DiscordPHP.DEBUG: REQ POST guilds/111111111111111111/roles successful [] []
[2021-12-28T10:44:19.363529+00:00] DiscordPHP.DEBUG: http not checking {"waiting":0,"empty":true} []
[2021-12-28T10:44:19.364529+00:00] DiscordPHP.DEBUG: BUCKET patchguilds/111111111111111111/roles/:role_id queued REQ PATCH guilds/111111111111111111/roles/925338365262446642 [] []
[2021-12-28T10:44:19.807554+00:00] DiscordPHP.DEBUG: REQ PATCH guilds/111111111111111111/roles/925338365262446642 successful [] []
[2021-12-28T10:44:19.816555+00:00] DiscordPHP.DEBUG: http not checking {"waiting":0,"empty":true} []

CREATED NEW ROLE
object(Discord\Parts\Guild\Role)#1650 (11) {
```
Createable attributes:
https://discord.com/developers/docs/resources/guild#create-guild-role


Also added missing nullable properties from phpdoc

Also changed `is_null(attributes)` with `! isset(attributes)`