### PR TITLE
Fix 32 bit php compatibility with permission bits (GMP)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Before you start using this Library, you **need** to know how PHP works, you nee
 
 - PHP 7.4
 	- We recommend PHP 8.0 as it will be the most stable and most performant.
+	- x86 (32 bit) PHP requires `ext-gmp` [extension](https://www.php.net/manual/en/book.gmp.php) enabled for handling Permissions.
 - Composer
 - `ext-json`
 - `ext-zlib`

--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
         "ext-libev": "For a faster, and more performant loop.",
         "ext-event": "For a faster, and more performant loop.",
         "ext-mbstring": "For accurate calculations of string length when handling non-english characters.",
-        "ext-gmp": "For 32 bit php to deal with permissions and other 64 bit values"
+        "ext-gmp": "For Permissions and 64 bit calculations on x86 (32 bit) PHP."
     },
     "scripts": {
         "cs": ["./vendor/bin/php-cs-fixer fix"],

--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,8 @@
         "ext-uv": "For a faster, and more performant loop. Preferred.",
         "ext-libev": "For a faster, and more performant loop.",
         "ext-event": "For a faster, and more performant loop.",
-        "ext-mbstring": "For accurate calculations of string length when handling non-english characters."
+        "ext-mbstring": "For accurate calculations of string length when handling non-english characters.",
+        "ext-gmp": "For 32 bit php to deal with permissions and other 64 bit values"
     },
     "scripts": {
         "cs": ["./vendor/bin/php-cs-fixer fix"],

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,8 @@
         "ext-zlib": "*",
         "discord-php/http": "^9.0.5",
         "react/child-process": "^0.6.2",
-        "discord/interactions": "^2"
+        "discord/interactions": "^2",
+        "brick/math": "^0.9.3"
     },
     "require-dev": {
         "symfony/var-dumper": "*",

--- a/composer.json
+++ b/composer.json
@@ -23,8 +23,7 @@
         "ext-zlib": "*",
         "discord-php/http": "^9.0.5",
         "react/child-process": "^0.6.2",
-        "discord/interactions": "^2",
-        "brick/math": "^0.9.3"
+        "discord/interactions": "^2"
     },
     "require-dev": {
         "symfony/var-dumper": "*",

--- a/docs/src/pages/api/07_permissions.md
+++ b/docs/src/pages/api/07_permissions.md
@@ -87,4 +87,4 @@ Represents permissions for roles.
 - `view_guild_insights`
 - `change_nicknames`
 - `manage_nicknames`
-- `manage_emojis`
+- `manage_emojis_and_stickers`

--- a/src/Discord/Discord.php
+++ b/src/Discord/Discord.php
@@ -13,6 +13,7 @@ namespace Discord;
 
 use Discord\Exceptions\IntentException;
 use Discord\Factory\Factory;
+use Discord\Helpers\Bitwise;
 use Discord\Http\Http;
 use Discord\Parts\Guild\Guild;
 use Discord\Parts\OAuth\Application;
@@ -311,9 +312,13 @@ class Discord
             trigger_error('DiscordPHP will not run on a webserver. Please use PHP CLI to run a DiscordPHP bot.', E_USER_ERROR);
         }
 
-        // x86 need gmp extension for bit integer operation
-        if (PHP_INT_SIZE == 4 && ! extension_loaded('gmp')) {
-            trigger_error('ext-gmp is not loaded. Permissions will NOT work correctly!', E_USER_WARNING);
+        // x86 need gmp extension for big integer operation
+        if (PHP_INT_SIZE === 4) {
+            if (! extension_loaded('gmp')) {
+                trigger_error('ext-gmp is not loaded. Permissions will NOT work correctly!', E_USER_WARNING);
+            } else {
+                Bitwise::$is_32_gmp = true;
+            }
         }
 
         $options = $this->resolveOptions($options);

--- a/src/Discord/Discord.php
+++ b/src/Discord/Discord.php
@@ -311,6 +311,11 @@ class Discord
             trigger_error('DiscordPHP will not run on a webserver. Please use PHP CLI to run a DiscordPHP bot.', E_USER_ERROR);
         }
 
+        // x86 need gmp extension for bit integer operation
+        if (PHP_INT_SIZE == 4 && ! extension_loaded('gmp')) {
+            trigger_error('ext-gmp is not loaded. Permissions will NOT work correctly!', E_USER_WARNING);
+        }
+
         $options = $this->resolveOptions($options);
 
         $this->options = $options;

--- a/src/Discord/Helpers/Bitwise.php
+++ b/src/Discord/Helpers/Bitwise.php
@@ -16,7 +16,7 @@ namespace Discord\Helpers;
  */
 class Bitwise
 {
-    public static $is_32_gmp = false;
+    public static bool $is_32_gmp = false;
 
     /**
      * @param \GMP|int|string $a

--- a/src/Discord/Helpers/Bitwise.php
+++ b/src/Discord/Helpers/Bitwise.php
@@ -1,0 +1,86 @@
+<?php
+
+/*
+ * This file is a part of the DiscordPHP project.
+ *
+ * Copyright (c) 2015-present David Cole <david.cole1340@gmail.com>
+ *
+ * This file is subject to the MIT license that is bundled
+ * with this source code in the LICENSE.md file.
+ */
+
+namespace Discord\Helpers;
+
+use Brick\Math\BigInteger;
+
+/**
+ * A compat helper to handle bitwise operation in 32 bit php wrapping BigInteger
+ */
+class Bitwise
+{
+    /**
+     * @param BigInteger|int|float|string $a
+     * @param BigInteger|int|float|string $b
+     *
+     * @return BigInteger|int $a & $b
+     */
+    public static function and($a, $b)
+    {
+        return (PHP_INT_SIZE == 4) ? BigInteger::of($a)->and($b) : $a & $b;
+    }
+
+    /**
+     * @param BigInteger|int|float|string $a
+     * @param BigInteger|int|float|string $b
+     *
+     * @return BigInteger|int $a | $b
+     */
+    public static function or($a, $b)
+    {
+        return (PHP_INT_SIZE == 4) ? BigInteger::of($a)->or($b) : $a | $b;
+
+    }
+
+    /**
+     * @param BigInteger|int|float|string $a
+     * @param BigInteger|int|float|string $b
+     *
+     * @return BigInteger|int $a ^ $b
+     */
+    public static function xor($a, $b)
+    {
+        return (PHP_INT_SIZE == 4) ? BigInteger::of($a)->xor($b) : $a ^ $b;
+    }
+
+    /**
+     * @param BigInteger|int|float|string $a
+     *
+     * @return BigInteger|int ~ $a
+     */
+    public static function not($a)
+    {
+        return (PHP_INT_SIZE == 4) ? BigInteger::of($a)->not() : ~$a;
+    }
+
+    /**
+     * @param BigInteger|int|float|string $a
+     * @param BigInteger|int|float|string $b
+     *
+     * @return BigInteger|int $a << $b
+     */
+    public static function shiftLeft($a, $b)
+    {
+        return (PHP_INT_SIZE == 4) ? BigInteger::of($a)->shiftedLeft($b) : $a << $b;
+    }
+
+    /**
+     * @param BigInteger|int|float|string $a
+     * @param BigInteger|int|float|string $b
+     *
+     * @return BigInteger|int $a >> $b
+     */
+    public static function shiftRight($a, $b)
+    {
+        return (PHP_INT_SIZE == 4) ? BigInteger::of($a)->shiftedRight($b) : $a >> $b;
+    }
+}

--- a/src/Discord/Helpers/Bitwise.php
+++ b/src/Discord/Helpers/Bitwise.php
@@ -16,6 +16,8 @@ namespace Discord\Helpers;
  */
 class Bitwise
 {
+    public static $is_32_gmp = false;
+
     /**
      * @param \GMP|int|string $a
      * @param \GMP|int|string $b
@@ -24,7 +26,7 @@ class Bitwise
      */
     public static function and($a, $b)
     {
-        if (PHP_INT_SIZE == 4) {
+        if (self::$is_32_gmp) {
             return \gmp_and(self::floatCast($a), self::floatCast($b));
         }
 
@@ -39,7 +41,7 @@ class Bitwise
      */
     public static function or($a, $b)
     {
-        if (PHP_INT_SIZE == 4) {
+        if (self::$is_32_gmp) {
             return \gmp_or(self::floatCast($a), self::floatCast($b));
         }
 
@@ -54,7 +56,7 @@ class Bitwise
      */
     public static function xor($a, $b)
     {
-        if (PHP_INT_SIZE == 4) {
+        if (self::$is_32_gmp) {
             return \gmp_xor(self::floatCast($a), self::floatCast($b));
         }
 
@@ -68,7 +70,7 @@ class Bitwise
      */
     public static function not($a)
     {
-        if (PHP_INT_SIZE == 4) {
+        if (self::$is_32_gmp) {
             return \gmp_neg(self::floatCast($a));
         }
 
@@ -83,7 +85,7 @@ class Bitwise
      */
     public static function shiftLeft($a, int $b)
     {
-        if (PHP_INT_SIZE == 4) {
+        if (self::$is_32_gmp) {
             return \gmp_mul(self::floatCast($a), \gmp_pow(2, $b));
         }
 
@@ -98,11 +100,41 @@ class Bitwise
      */
     public static function shiftRight($a, int $b)
     {
-        if (PHP_INT_SIZE == 4) {
+        if (self::$is_32_gmp) {
             return \gmp_div(self::floatCast($a), \gmp_pow(2, $b));
         }
 
         return $a >> $b;
+    }
+
+    /**
+     * @param \GMP|int|string $a
+     * @param int             $b
+     *
+     * @return bool $a & (1 << $b)
+     */
+    public static function test($a, int $b): bool
+    {
+        if (self::$is_32_gmp) {
+            return \gmp_testbit(self::floatCast($a), $b);
+        }
+
+        return $a & (1 << $b);
+    }
+
+    /**
+     * @param \GMP|int|string $a
+     * @param int             $b
+     *
+     * @return \GMP|int $a |= (1 << $b)
+     */
+    public static function set($a, int $b)
+    {
+        if (self::$is_32_gmp) {
+            return \gmp_setbit(\gmp_init(self::floatCast($a)), $b);
+        }
+
+        return $a |= (1 << $b);
     }
 
     /**

--- a/src/Discord/Parts/Permissions/ChannelPermission.php
+++ b/src/Discord/Parts/Permissions/ChannelPermission.php
@@ -34,10 +34,10 @@ namespace Discord\Parts\Permissions;
  * @property bool $read_message_history
  * @property bool $mention_everyone
  * @property bool $use_external_emojis
- * @property bool $use_slash_commands
+ * @property bool $use_application_commands
  * @property bool $manage_threads
- * @property bool $use_public_threads
- * @property bool $use_private_threads
+ * @property bool $create_public_threads
+ * @property bool $create_private_threads
  * @property bool $use_external_stickers
  * @property bool $send_messages_in_threads
  */

--- a/src/Discord/Parts/Permissions/Permission.php
+++ b/src/Discord/Parts/Permissions/Permission.php
@@ -61,10 +61,10 @@ abstract class Permission extends Part
         'read_message_history' => 16,
         'mention_everyone' => 17,
         'use_external_emojis' => 18,
-        'use_slash_commands' => 31,
+        'use_application_commands' => 31,
         'manage_threads' => 34,
-        'use_public_threads' => 35,
-        'use_private_threads' => 36,
+        'create_public_threads' => 35,
+        'create_private_threads' => 36,
         'use_external_stickers' => 37,
         'send_messages_in_threads' => 38,
     ];
@@ -83,7 +83,7 @@ abstract class Permission extends Part
         'view_guild_insights' => 19,
         'change_nickname' => 26,
         'manage_nicknames' => 27,
-        'manage_emojis' => 30,
+        'manage_emojis_and_stickers' => 30,
         'manage_events' => 33,
         'moderate_members' => 40,
     ];
@@ -179,5 +179,25 @@ abstract class Permission extends Part
                 $this->attributes[$permission] = false;
             }
         }
+    }
+
+    public function getUseSlashCommandsAttribute(): bool
+    {
+        return $this->attributes['use_application_commands'] ?? null;
+    }
+
+    public function getUsePublicThreadsAttribute(): bool
+    {
+        return $this->attributes['create_public_threads'] ?? null;
+    }
+
+    public function getUsePrivateThreadsAttribute(): bool
+    {
+        return $this->attributes['create_private_threads'] ?? null;
+    }
+
+    public function getManageEmojisAttribute(): bool
+    {
+        return $this->attributes['manage_emojis_and_stickers'] ?? null;
     }
 }

--- a/src/Discord/Parts/Permissions/Permission.php
+++ b/src/Discord/Parts/Permissions/Permission.php
@@ -181,23 +181,83 @@ abstract class Permission extends Part
         }
     }
 
+    /**
+     * @inheritdoc
+     *
+     * @deprecated 7.0.0 Use `use_application_commands`
+     */
     public function getUseSlashCommandsAttribute()
     {
         return $this->attributes['use_application_commands'] ?? null;
     }
 
+    /**
+     * @inheritdoc
+     *
+     * @deprecated 7.0.0 Use `create_public_threads`
+     */
     public function getUsePublicThreadsAttribute()
     {
         return $this->attributes['create_public_threads'] ?? null;
     }
 
+    /**
+     * @inheritdoc
+     *
+     * @deprecated 7.0.0 Use `create_private_threads`
+     */
     public function getUsePrivateThreadsAttribute()
     {
         return $this->attributes['create_private_threads'] ?? null;
     }
 
+    /**
+     * @inheritdoc
+     *
+     * @deprecated 7.0.0 Use `manage_emojis_and_stickers`
+     */
     public function getManageEmojisAttribute()
     {
         return $this->attributes['manage_emojis_and_stickers'] ?? null;
+    }
+
+    /**
+     * @inheritdoc
+     *
+     * @deprecated 7.0.0 Use `use_application_commands`
+     */
+    public function setUseSlashCommandsAttribute($value)
+    {
+        return $this->attributes['use_application_commands'] = $value;
+    }
+
+    /**
+     * @inheritdoc
+     *
+     * @deprecated 7.0.0 Use `create_public_threads`
+     */
+    public function setUsePublicThreadsAttribute($value)
+    {
+        return $this->attributes['create_public_threads'] = $value;
+    }
+
+    /**
+     * @inheritdoc
+     *
+     * @deprecated 7.0.0 Use `create_private_threads`
+     */
+    public function setUsePrivateThreadsAttribute($value)
+    {
+        return $this->attributes['create_private_threads'] = $value;
+    }
+
+    /**
+     * @inheritdoc
+     *
+     * @deprecated 7.0.0 Use `manage_emojis_and_stickers`
+     */
+    public function setManageEmojisAttribute($value)
+    {
+        return $this->attributes['manage_emojis_and_stickers'] = $value;
     }
 }

--- a/src/Discord/Parts/Permissions/Permission.php
+++ b/src/Discord/Parts/Permissions/Permission.php
@@ -11,38 +11,42 @@
 
 namespace Discord\Parts\Permissions;
 
+use Brick\Math\BigInteger;
 use Discord\Discord;
+use Discord\Helpers\Bitwise;
 use Discord\Parts\Part;
 
 /**
  * Permission represents a set of permissions for a given role or overwrite.
  *
- * @property int  $bitwise
- * @property bool $create_instant_invite
- * @property bool $manage_channels
- * @property bool $view_channel
- * @property bool $manage_roles
- * @property bool $manage_webhooks
+ * @property int|string $bitwise
+ * @property bool       $create_instant_invite
+ * @property bool       $manage_channels
+ * @property bool       $view_channel
+ * @property bool       $manage_roles
+ * @property bool       $manage_webhooks
  */
 abstract class Permission extends Part
 {
+    // Note: Bits above 44th must use numeric string for 32 bit compatibility
+
     /**
      * Array of permissions that only apply to voice channels.
      *
      * @var array
      */
     public const VOICE_PERMISSIONS = [
-        'priority_speaker' => (1 << 8),
-        'stream' => (1 << 9),
-        'connect' => (1 << 20),
-        'speak' => (1 << 21),
-        'mute_members' => (1 << 22),
-        'deafen_members' => (1 << 23),
-        'move_members' => (1 << 24),
-        'use_vad' => (1 << 25),
-        'request_to_speak' => (1 << 32),
-        'manage_events' => (1 << 33),
-        'start_embedded_activities' => (1 << 39),
+        'priority_speaker' => 0x100,
+        'stream' => 0x200,
+        'connect' => 0x100000,
+        'speak' => 0x200000,
+        'mute_members' => 0x400000,
+        'deafen_members' => 0x800000,
+        'move_members' => 0x1000000,
+        'use_vad' => 0x2000000,
+        'request_to_speak' => 0x100000000,
+        'manage_events' => 0x200000000,
+        'start_embedded_activities' => 0x8000000000,
     ];
 
     /**
@@ -51,21 +55,21 @@ abstract class Permission extends Part
      * @var array
      */
     public const TEXT_PERMISSIONS = [
-        'add_reactions' => (1 << 6),
-        'send_messages' => (1 << 11),
-        'send_tts_messages' => (1 << 12),
-        'manage_messages' => (1 << 13),
-        'embed_links' => (1 << 14),
-        'attach_files' => (1 << 15),
-        'read_message_history' => (1 << 16),
-        'mention_everyone' => (1 << 17),
-        'use_external_emojis' => (1 << 18),
-        'use_slash_commands' => (1 << 31),
-        'manage_threads' => (1 << 34),
-        'use_public_threads' => (1 << 35),
-        'use_private_threads' => (1 << 36),
-        'use_external_stickers' => (1 << 37),
-        'send_messages_in_threads' => (1 << 38),
+        'add_reactions' => 0x40,
+        'send_messages' => 0x800,
+        'send_tts_messages' => 0x1000,
+        'manage_messages' => 0x2000,
+        'embed_links' => 0x4000,
+        'attach_files' => 0x8000,
+        'read_message_history' => 0x10000,
+        'mention_everyone' => 0x20000,
+        'use_external_emojis' => 0x40000,
+        'use_slash_commands' => 0x80000000,
+        'manage_threads' => 0x400000000,
+        'use_public_threads' => 0x800000000,
+        'use_private_threads' => 0x1000000000,
+        'use_external_stickers' => 0x2000000000,
+        'send_messages_in_threads' => 0x4000000000,
     ];
 
     /**
@@ -74,15 +78,17 @@ abstract class Permission extends Part
      * @var array
      */
     public const ROLE_PERMISSIONS = [
-        'kick_members' => (1 << 1),
-        'ban_members' => (1 << 2),
-        'administrator' => (1 << 3),
-        'manage_guild' => (1 << 5),
-        'view_audit_log' => (1 << 7),
-        'view_guild_insights' => (1 << 19),
-        'change_nickname' => (1 << 26),
-        'manage_nicknames' => (1 << 27),
-        'manage_emojis' => (1 << 30),
+        'kick_members' => 0x2,
+        'ban_members' => 0x4,
+        'administrator' => 0x8,
+        'manage_guild' => 0x20,
+        'view_audit_log' => 0x80,
+        'view_guild_insights' => 0x80000,
+        'change_nickname' => 0x4000000,
+        'manage_nicknames' => 0x8000000,
+        'manage_emojis' => 0x40000000,
+        'manage_events' => 0x200000000,
+        'moderate_members' => 0x10000000000,
     ];
 
     /**
@@ -91,11 +97,11 @@ abstract class Permission extends Part
      * @var array
      */
     public const ALL_PERMISSIONS = [
-        'create_instant_invite' => (1 << 0),
-        'manage_channels' => (1 << 4),
-        'view_channel' => (1 << 10),
-        'manage_roles' => (1 << 28),
-        'manage_webhooks' => (1 << 29),
+        'create_instant_invite' => 0x1,
+        'manage_channels' => 0x10,
+        'view_channel' => 0x400,
+        'manage_roles' => 0x10000000,
+        'manage_webhooks' => 0x20000000,
     ];
 
     /**
@@ -133,16 +139,20 @@ abstract class Permission extends Part
     /**
      * Gets the bitwise attribute of the permission.
      *
-     * @return int
+     * @return int|string
      */
-    protected function getBitwiseAttribute(): int
+    protected function getBitwiseAttribute()
     {
         $bitwise = 0;
 
         foreach ($this->permissions as $permission => $value) {
             if ($this->attributes[$permission]) {
-                $bitwise |= $value;
+                $bitwise = Bitwise::or($bitwise, $value);
             }
+        }
+
+        if ($bitwise instanceof BigInteger) {
+            return (string) $bitwise;
         }
 
         return $bitwise;
@@ -155,12 +165,18 @@ abstract class Permission extends Part
      */
     protected function setBitwiseAttribute($bitwise)
     {
-        if (is_string($bitwise)) {
-            $bitwise = (int) $bitwise;
-        }
+        $bitcomparator = function ($bit1, $bit2) {
+            if (PHP_INT_SIZE == 4) {
+                $bit2 = BigInteger::of($bit2);
+            } elseif (is_string($bit1)) {
+                $bit1 = (int) $bit1;
+            }
+
+            return (Bitwise::and($bit1, $bit2)) == $bit2;
+        };
 
         foreach ($this->permissions as $permission => $value) {
-            if (($bitwise & $value) == $value) {
+            if ($bitcomparator($bitwise, $value)) {
                 $this->attributes[$permission] = true;
             } else {
                 $this->attributes[$permission] = false;

--- a/src/Discord/Parts/Permissions/Permission.php
+++ b/src/Discord/Parts/Permissions/Permission.php
@@ -11,7 +11,6 @@
 
 namespace Discord\Parts\Permissions;
 
-use Brick\Math\BigInteger;
 use Discord\Discord;
 use Discord\Helpers\Bitwise;
 use Discord\Parts\Part;
@@ -28,7 +27,7 @@ use Discord\Parts\Part;
  */
 abstract class Permission extends Part
 {
-    // Note: Bits above 44th must use numeric string for 32 bit compatibility
+    // Note: Bits above 43rd (i.e. 1 << 44) must use numeric string for 32 bit compatibility
 
     /**
      * Array of permissions that only apply to voice channels.
@@ -151,8 +150,8 @@ abstract class Permission extends Part
             }
         }
 
-        if ($bitwise instanceof BigInteger) {
-            return (string) $bitwise;
+        if (! is_int($bitwise)) { // x86
+            return \gmp_strval($bitwise);
         }
 
         return $bitwise;
@@ -166,8 +165,8 @@ abstract class Permission extends Part
     protected function setBitwiseAttribute($bitwise)
     {
         $bitcomparator = function ($bit1, $bit2) {
-            if (PHP_INT_SIZE == 4) {
-                $bit2 = BigInteger::of($bit2);
+            if (PHP_INT_SIZE == 4) { // x86
+                $bit2 = \gmp_init(Bitwise::floatCast($bit2));
             } elseif (is_string($bit1)) {
                 $bit1 = (int) $bit1;
             }

--- a/src/Discord/Parts/Permissions/Permission.php
+++ b/src/Discord/Parts/Permissions/Permission.php
@@ -181,22 +181,22 @@ abstract class Permission extends Part
         }
     }
 
-    public function getUseSlashCommandsAttribute(): bool
+    public function getUseSlashCommandsAttribute()
     {
         return $this->attributes['use_application_commands'] ?? null;
     }
 
-    public function getUsePublicThreadsAttribute(): bool
+    public function getUsePublicThreadsAttribute()
     {
         return $this->attributes['create_public_threads'] ?? null;
     }
 
-    public function getUsePrivateThreadsAttribute(): bool
+    public function getUsePrivateThreadsAttribute()
     {
         return $this->attributes['create_private_threads'] ?? null;
     }
 
-    public function getManageEmojisAttribute(): bool
+    public function getManageEmojisAttribute()
     {
         return $this->attributes['manage_emojis_and_stickers'] ?? null;
     }

--- a/src/Discord/Parts/Permissions/RolePermission.php
+++ b/src/Discord/Parts/Permissions/RolePermission.php
@@ -34,10 +34,10 @@ namespace Discord\Parts\Permissions;
  * @property bool $read_message_history
  * @property bool $mention_everyone
  * @property bool $use_external_emojis
- * @property bool $use_slash_commands
+ * @property bool $use_application_commands
  * @property bool $manage_threads
- * @property bool $use_public_threads
- * @property bool $use_private_threads
+ * @property bool $create_public_threads
+ * @property bool $create_private_threads
  * @property bool $use_external_stickers
  * @property bool $send_messages_in_threads
  *
@@ -49,7 +49,7 @@ namespace Discord\Parts\Permissions;
  * @property bool $view_guild_insights
  * @property bool $change_nickname
  * @property bool $manage_nicknames
- * @property bool $manage_emojis
+ * @property bool $manage_emojis_and_stickers
  * @property bool $manage_events
  * @property bool $moderate_members
  */

--- a/src/Discord/Parts/Permissions/RolePermission.php
+++ b/src/Discord/Parts/Permissions/RolePermission.php
@@ -50,6 +50,8 @@ namespace Discord\Parts\Permissions;
  * @property bool $change_nickname
  * @property bool $manage_nicknames
  * @property bool $manage_emojis
+ * @property bool $manage_events
+ * @property bool $moderate_members
  */
 class RolePermission extends Permission
 {

--- a/src/Discord/Parts/User/Member.php
+++ b/src/Discord/Parts/User/Member.php
@@ -13,6 +13,7 @@ namespace Discord\Parts\User;
 
 use Carbon\Carbon;
 use Discord\Builders\MessageBuilder;
+use Discord\Helpers\Bitwise;
 use Discord\Helpers\Collection;
 use Discord\Http\Endpoint;
 use Discord\Parts\Channel\Channel;
@@ -216,14 +217,14 @@ class Member extends Part
         $bitwise = $this->guild->roles->get('id', $this->guild_id)->permissions->bitwise;
 
         if ($this->guild->owner_id == $this->id) {
-            $bitwise |= 0x8; // Add administrator permission
+            $bitwise = Bitwise::or($bitwise, 0x8); // Add administrator permission
         } else {
             $roles = [];
 
             /* @var Role */
             foreach ($this->roles ?? [] as $role) {
                 $roles[] = $role->id;
-                $bitwise |= $role->permissions->bitwise;
+                $bitwise = Bitwise::or($bitwise, $role->permissions->bitwise);
             }
         }
 
@@ -241,8 +242,8 @@ class Member extends Part
         if ($channel) {
             /* @var Overwrite */
             if ($overwrite = $channel->overwrites->get('id', $this->guild->id)) {
-                $bitwise |= $overwrite->allow->bitwise;
-                $bitwise &= ~($overwrite->deny->bitwise);
+                $bitwise = Bitwise::or($bitwise, $overwrite->allow->bitwise);
+                $bitwise = Bitwise::and($bitwise, Bitwise::not($overwrite->deny->bitwise));
             }
 
             /* @var Overwrite */
@@ -251,14 +252,14 @@ class Member extends Part
                     continue;
                 }
 
-                $bitwise |= $overwrite->allow->bitwise;
-                $bitwise &= ~($overwrite->deny->bitwise);
+                $bitwise = Bitwise::or($bitwise, $overwrite->allow->bitwise);
+                $bitwise = Bitwise::and($bitwise, Bitwise::not($overwrite->deny->bitwise));
             }
 
             /* @var Overwrite */
             if ($overwrite = $channel->overwrites->get('id', $this->id)) {
-                $bitwise |= $overwrite->allow->bitwise;
-                $bitwise &= ~($overwrite->deny->bitwise);
+                $bitwise = Bitwise::or($bitwise, $overwrite->allow->bitwise);
+                $bitwise = Bitwise::and($bitwise, Bitwise::not($overwrite->deny->bitwise));
             }
         }
 

--- a/src/Discord/Parts/User/Member.php
+++ b/src/Discord/Parts/User/Member.php
@@ -22,6 +22,7 @@ use Discord\Parts\Channel\Overwrite;
 use Discord\Parts\Guild\Guild;
 use Discord\Parts\Guild\Role;
 use Discord\Parts\Part;
+use Discord\Parts\Permissions\Permission;
 use Discord\Parts\Permissions\RolePermission;
 use Discord\Parts\WebSockets\PresenceUpdate;
 use React\Promise\ExtendedPromiseInterface;
@@ -217,7 +218,7 @@ class Member extends Part
         $bitwise = $this->guild->roles->get('id', $this->guild_id)->permissions->bitwise;
 
         if ($this->guild->owner_id == $this->id) {
-            $bitwise = Bitwise::or($bitwise, 0x8); // Add administrator permission
+            $bitwise = Bitwise::set($bitwise, Permission::ROLE_PERMISSIONS['administrator']); // Add administrator permission
         } else {
             $roles = [];
 


### PR DESCRIPTION
**ext-gmp** approach of #660 

- composer suggests `ext-gmp`
- a `E_USER_WARNING` will trigger on Discord initialization if bot running on 32 bit php without [GMP](https://www.php.net/manual/en/book.gmp.php) extension enabled

TODO:

- [x] Change permission constants using bit position instead of value (for sake of readability)
- [x] Add updated permission names using get<permission>Attributes overload
- [x] Change `PHP_INT_SIZE` comparison using strict `===`