### PR TITLE
Rename application command method to listenCommand

### DIFF
--- a/src/Discord/Discord.php
+++ b/src/Discord/Discord.php
@@ -307,7 +307,7 @@ class Discord
      *
      * @var RegisteredCommand[]
      */
-    protected $commands;
+    private $application_commands;
 
     /**
      * Creates a Discord client instance.
@@ -1546,7 +1546,7 @@ class Discord
         $baseCommand = array_shift($name);
 
         if (! isset($this->application_commands[$baseCommand])) {
-            $this->registerCommand($baseCommand);
+            $this->listenCommand($baseCommand);
         }
         return $this->application_commands[$baseCommand]->addSubCommand($name, $callback);
     }

--- a/src/Discord/Discord.php
+++ b/src/Discord/Discord.php
@@ -1470,7 +1470,7 @@ class Discord
      */
     public function __get(string $name)
     {
-        $allowed = ['loop', 'options', 'logger', 'http', 'commands'];
+        $allowed = ['loop', 'options', 'logger', 'http', 'application_commands'];
 
         if (in_array($name, $allowed)) {
             return $this->{$name};
@@ -1528,7 +1528,7 @@ class Discord
      *
      * @return RegisteredCommand
      */
-    public function registerCommand($name, callable $callback = null): RegisteredCommand
+    public function listenCommand($name, callable $callback = null): RegisteredCommand
     {
         if (is_array($name) && count($name) == 1) {
             $name = array_shift($name);
@@ -1536,19 +1536,19 @@ class Discord
 
         // registering base command
         if (! is_array($name) || count($name) == 1) {
-            if (isset($this->commands[$name])) {
+            if (isset($this->application_commands[$name])) {
                 throw new InvalidArgumentException("The command `{$name}` already exists.");
             }
 
-            return $this->commands[$name] = new RegisteredCommand($this, $name, $callback);
+            return $this->application_commands[$name] = new RegisteredCommand($this, $name, $callback);
         }
 
         $baseCommand = array_shift($name);
 
-        if (! isset($this->commands[$baseCommand])) {
+        if (! isset($this->application_commands[$baseCommand])) {
             $this->registerCommand($baseCommand);
         }
-        return $this->commands[$baseCommand]->addSubCommand($name, $callback);
+        return $this->application_commands[$baseCommand]->addSubCommand($name, $callback);
     }
 
     /**

--- a/src/Discord/Parts/Interactions/Request/Resolved.php
+++ b/src/Discord/Parts/Interactions/Request/Resolved.php
@@ -40,21 +40,6 @@ class Resolved extends Part
     protected $fillable = ['users', 'members', 'roles', 'channels', 'messages', 'guild_id'];
 
     /**
-     * @inheritdoc
-     */
-    protected function afterConstruct(): void
-    {
-        foreach ($this->attributes['users'] ?? [] as $snowflake => $user) {
-            if ($userPart = $this->discord->users->get('id', $snowflake)) {
-                $userPart->fill((array) $user);
-            } else {
-                $userPart = $this->factory->create(User::class, $user, true);
-                $this->discord->users->pushItem($userPart);
-            }
-        }
-    }
-
-    /**
      * Returns a collection of resolved users.
      *
      * @return Collection|User[]|null Map of Snowflakes to user objects

--- a/src/Discord/WebSockets/Events/InteractionCreate.php
+++ b/src/Discord/WebSockets/Events/InteractionCreate.php
@@ -27,8 +27,8 @@ class InteractionCreate extends Event
 
         if ($interaction->type == InteractionType::APPLICATION_COMMAND) {
             $checkCommand = function ($command) use ($interaction, &$checkCommand) {
-                if (isset($this->discord->commands[$command['name']])) {
-                    if ($this->discord->commands[$command['name']]->execute($command['options'] ?? [], $interaction)) {
+                if (isset($this->discord->application_commands[$command['name']])) {
+                    if ($this->discord->application_commands[$command['name']]->execute($command['options'] ?? [], $interaction)) {
                         return true;
                     }
                 }


### PR DESCRIPTION
Breaking change in RC stage following up to #597 

- Renamed `registerCommand()` to `listenCommand()` due to confusing name and conflict with DiscordCommandClient
- Moved Resolved `User` caching code from the Part to the Interaction Create event