### PR TITLE
Add missing Part attributes & Fix Welcome Screen bug

### DIFF
--- a/src/Discord/Parts/Channel/Channel.php
+++ b/src/Discord/Parts/Channel/Channel.php
@@ -47,34 +47,35 @@ use function React\Promise\resolve;
  * A Channel can be either a text or voice channel on a Discord guild.
  *
  * @property string              $id                            The unique identifier of the Channel.
- * @property string              $name                          The name of the channel.
  * @property int                 $type                          The type of the channel.
- * @property string              $topic                         The topic of the channel.
- * @property Guild               $guild                         The guild that the channel belongs to. Only for text or voice channels.
  * @property string|null         $guild_id                      The unique identifier of the guild that the channel belongs to. Only for text or voice channels.
+ * @property Guild               $guild                         The guild that the channel belongs to. Only for text or voice channels.
  * @property int                 $position                      The position of the channel on the sidebar.
- * @property bool                $is_private                    Whether the channel is a private channel.
+ * @property string              $name                          The name of the channel.
+ * @property string              $topic                         The topic of the channel.
+ * @property bool                $nsfw                          Whether the channel is NSFW.
  * @property string              $last_message_id               The unique identifier of the last message sent in the channel.
  * @property int                 $bitrate                       The bitrate of the channel. Only for voice channels.
- * @property User                $recipient                     The first recipient of the channel. Only for DM or group channels.
- * @property string              $recipient_id                  The ID of the recipient of the channel, if it is a DM channel.
- * @property Collection|User[]   $recipients                    A collection of all the recipients in the channel. Only for DM or group channels.
- * @property bool                $nsfw                          Whether the channel is NSFW.
  * @property int                 $user_limit                    The user limit of the channel.
  * @property int                 $rate_limit_per_user           Amount of seconds a user has to wait before sending a new message.
+ * @property Collection|User[]   $recipients                    A collection of all the recipients in the channel. Only for DM or group channels.
+ * @property User                $recipient                     The first recipient of the channel. Only for DM or group channels.
+ * @property string              $recipient_id                  The ID of the recipient of the channel, if it is a DM channel.
  * @property string              $icon                          Icon hash.
  * @property string              $owner_id                      The ID of the DM creator. Only for DM or group channels.
  * @property string              $application_id                ID of the group DM creator if it is a bot.
  * @property string              $parent_id                     ID of the parent channel.
  * @property Carbon              $last_pin_timestamp            When the last message was pinned.
- * @property string|null         $rtc_region                    voice region id for the voice channel, automatic when set to null
- * @property int|null            $video_quality_mode            the camera video quality mode of the voice channel, 1 when not present
- * @property int|null            $default_auto_archive_duration default duration for newly created threads, in minutes, to automatically archive the thread after recent activity, can be set to: 60, 1440, 4320, 10080
- * @property MemberRepository    $members                       voice channel only - members in the channel
- * @property MessageRepository   $messages                      text channel only - messages sent in the channel
- * @property OverwriteRepository $overwrites                    permission overwrites
- * @property WebhookRepository   $webhooks                      webhooks in the channel
- * @property ThreadRepository    $threads                       threads that belong to the channel
+ * @property string|null         $rtc_region                    Voice region id for the voice channel, automatic when set to null
+ * @property int|null            $video_quality_mode            The camera video quality mode of the voice channel, 1 when not present
+ * @property int|null            $default_auto_archive_duration Default duration for newly created threads, in minutes, to automatically archive the thread after recent activity, can be set to: 60, 1440, 4320, 10080
+ * @property string|null         $permissions                   Computed permissions for the invoking user in the channel, including overwrites, only included when part of the resolved data received on a slash command interaction.
+ * @property bool                $is_private                    Whether the channel is a private channel.
+ * @property OverwriteRepository $overwrites                    Permission overwrites
+ * @property MemberRepository    $members                       Voice channel only - members in the channel
+ * @property MessageRepository   $messages                      Text channel only - messages sent in the channel
+ * @property WebhookRepository   $webhooks                      Webhooks in the channel
+ * @property ThreadRepository    $threads                       Threads that belong to the channel
  *
  * @method ExtendedPromiseInterface sendMessage(MessageBuilder $builder)
  * @method ExtendedPromiseInterface sendMessage(string $text, bool $tts = false, Embed|array $embed = null, array $allowed_mentions = null, ?Message $replyTo = null)
@@ -93,24 +94,26 @@ class Channel extends Part
     public const TYPE_PRIVATE_THREAD = 12;
     public const TYPE_STAGE_CHANNEL = 13;
 
+    public const VIDEO_QUALITY_AUTO = 1;
+    public const VIDEO_QUALITY_FULL = 2;
+
     /**
      * @inheritdoc
      */
     protected $fillable = [
         'id',
-        'name',
         'type',
-        'topic',
         'guild_id',
         'position',
-        'is_private',
-        'last_message_id',
         'permission_overwrites',
-        'bitrate',
-        'recipients',
+        'name',
+        'topic',
         'nsfw',
+        'last_message_id',
+        'bitrate',
         'user_limit',
         'rate_limit_per_user',
+        'recipients',
         'icon',
         'owner_id',
         'application_id',
@@ -119,15 +122,17 @@ class Channel extends Part
         'rtc_region',
         'video_quality_mode',
         'default_auto_archive_duration',
+        'permissions',
+        'is_private',
     ];
 
     /**
      * @inheritdoc
      */
     protected $repositories = [
+        'overwrites' => OverwriteRepository::class,
         'members' => MemberRepository::class,
         'messages' => MessageRepository::class,
-        'overwrites' => OverwriteRepository::class,
         'webhooks' => WebhookRepository::class,
         'threads' => ThreadRepository::class,
     ];

--- a/src/Discord/Parts/Channel/Message.php
+++ b/src/Discord/Parts/Channel/Message.php
@@ -63,6 +63,7 @@ use function React\Promise\reject;
  * @property string               $webhook_id             ID of the webhook that made the message, if any.
  * @property object               $activity               Current message activity. Requires rich presence.
  * @property object               $application            Application of message. Requires rich presence.
+ * @property string               $application_id         If the message is a response to an Interaction, this is the id of the interaction's application.
  * @property object               $message_reference      Message that is referenced by this message.
  * @property Message|null         $referenced_message     The message that is referenced in a reply.
  * @property int                  $flags                  Message flags.
@@ -73,6 +74,7 @@ use function React\Promise\reject;
  * @property bool                 $urgent                 Message is urgent.
  * @property Collection|Sticker[] $sticker_items          Stickers attached to the message.
  * @property object|null          $interaction            The interaction which triggered the message (slash commands).
+ * @property array                $components             Sent if the message contains components like buttons, action rows, or other interactive components.
  * @property string|null          $link                   Returns a link to the message.
  */
 class Message extends Part
@@ -92,13 +94,19 @@ class Message extends Part
     public const CHANNEL_FOLLOW_ADD = 12;
     public const GUILD_DISCOVERY_DISQUALIFIED = 14;
     public const GUILD_DISCOVERY_REQUALIFIED = 15;
+    public const GUILD_DISCOVERY_GRACE_PERIOD_INITIAL_WARNING = 16;
+    public const GUILD_DISCOVERY_GRACE_PERIOD_FINAL_WARNING = 17;
+    public const TYPE_THREAD_CREATED = 18;
     public const TYPE_REPLY = 19;
     public const TYPE_APPLICATION_COMMAND = 20;
+    public const TYPE_THREAD_STARTER_MESSAGE = 21;
+    public const TYPE_GUILD_INVITE_REMINDER = 22;
+    public const TYPE_CONTEXT_MENU_COMMAND = 23;
 
     public const ACTIVITY_JOIN = 1;
     public const ACTIVITY_SPECTATE = 2;
     public const ACTIVITY_LISTEN = 3;
-    public const ACTIVITY_JOIN_REQUEST = 4;
+    public const ACTIVITY_JOIN_REQUEST = 5;
 
     public const REACT_DELETE_ALL = 0;
     public const REACT_DELETE_ME = 1;
@@ -131,12 +139,14 @@ class Message extends Part
         'webhook_id',
         'activity',
         'application',
+        'application_id',
         'message_reference',
         'referenced_message',
         'flags',
         'sticker_items',
         'stickers',
         'interaction',
+        'components',
     ];
 
     /**

--- a/src/Discord/Parts/Embed/Author.php
+++ b/src/Discord/Parts/Embed/Author.php
@@ -16,10 +16,10 @@ use Discord\Parts\Part;
 /**
  * The author of an embed object.
  *
- * @property string $name           The name of the author.
- * @property string $url            The URL to the author.
- * @property string $icon_url       The source of the author icon. Must be https.
- * @property string $proxy_icon_url A proxied version of the icon url.
+ * @property string      $name           The name of the author.
+ * @property string|null $url            The URL to the author.
+ * @property string|null $icon_url       The source of the author icon. Must be https.
+ * @property string|null $proxy_icon_url A proxied version of the icon url.
  */
 class Author extends Part
 {

--- a/src/Discord/Parts/Embed/Footer.php
+++ b/src/Discord/Parts/Embed/Footer.php
@@ -16,9 +16,9 @@ use Discord\Parts\Part;
 /**
  * The footer section of an embed.
  *
- * @property string $text           Footer text.
- * @property string $icon_url       URL of an icon for the footer. Must be https.
- * @property string $proxy_icon_url Proxied version of the icon URL.
+ * @property string      $text           Footer text.
+ * @property string|null $icon_url       URL of an icon for the footer. Must be https.
+ * @property string|null $proxy_icon_url Proxied version of the icon URL.
  */
 class Footer extends Part
 {

--- a/src/Discord/Parts/Embed/Image.php
+++ b/src/Discord/Parts/Embed/Image.php
@@ -16,10 +16,10 @@ use Discord\Parts\Part;
 /**
  * An image for an embed.
  *
- * @property string $url       The source of the image. Must be https.
- * @property string $proxy_url A proxied version of the image.
- * @property int    $height    The height of the image.
- * @property int    $width     The width of the image.
+ * @property string      $url       The source of the image. Must be https.
+ * @property string|null $proxy_url A proxied version of the image.
+ * @property int|null    $height    The height of the image.
+ * @property int|null    $width     The width of the image.
  */
 class Image extends Part
 {

--- a/src/Discord/Parts/Embed/Video.php
+++ b/src/Discord/Parts/Embed/Video.php
@@ -16,14 +16,15 @@ use Discord\Parts\Part;
 /**
  * A video for an embed.
  *
- * @property string $url    The source of the video.
- * @property int    $height The height of the video.
- * @property int    $width  The width of the video.
+ * @property string|null $url       The source of the video.
+ * @property string|null $proxy_url A proxied url of the video.
+ * @property int|null    $height    The height of the video.
+ * @property int|null    $width     The width of the video.
  */
 class Video extends Part
 {
     /**
      * @inheritdoc
      */
-    protected $fillable = ['url', 'height', 'width'];
+    protected $fillable = ['url', 'proxy_url', 'height', 'width'];
 }

--- a/src/Discord/Parts/Guild/Guild.php
+++ b/src/Discord/Parts/Guild/Guild.php
@@ -760,7 +760,7 @@ class Guild extends Part
     public function getWelcomeScreen(bool $fresh = false): ExtendedPromiseInterface
     {
         if (! $fresh && isset($this->attributes['welcome_screen'])) {
-            return \React\Promise\resolve($this->attributes['welcome_screen']);
+            return \React\Promise\resolve($this->discord->factory(WelcomeScreen::class, $this->attributes['welcome_screen'], true));
         }
 
         return $this->http->get(Endpoint::bind(Endpoint::GUILD_WELCOME_SCREEN, $this->id))->then(function ($response) {
@@ -801,16 +801,6 @@ class Guild extends Part
 
             return $welcome_screen;
         });
-    }
-
-    /**
-     * Returns the Welcome Screen object for the guild.
-     *
-     * @return WelcomeScreen|null
-     */
-    public function getWelcomeScreenAttribute(): ?WelcomeScreen
-    {
-        return $this->attributes['welcome_screen'] ?? null;
     }
 
     /**

--- a/src/Discord/Parts/Guild/Guild.php
+++ b/src/Discord/Parts/Guild/Guild.php
@@ -142,6 +142,7 @@ class Guild extends Part
         'id',
         'name',
         'icon',
+        'icon_hash',
         'region',
         'owner_id',
         'roles',
@@ -330,7 +331,7 @@ class Guild extends Part
      */
     protected function getIconHashAttribute()
     {
-        return $this->attributes['icon'];
+        return $this->attributes['icon_hash'] ?? $this->attributes['icon'];
     }
 
     /**

--- a/src/Discord/Parts/OAuth/Application.php
+++ b/src/Discord/Parts/OAuth/Application.php
@@ -19,22 +19,42 @@ use Discord\Repository\Interaction\GlobalCommandRepository;
 /**
  * The OAuth2 application of the bot.
  *
- * @property string   $id          The client ID of the OAuth application.
- * @property string   $name        The name of the OAuth application.
- * @property string   $description The description of the OAuth application.
- * @property string   $icon        The icon hash of the OAuth application.
- * @property string   $invite_url  The invite URL to invite the bot to a guild.
- * @property string[] $rpc_origins An array of RPC origin URLs.
- * @property int      $flags       ?
- * @property User     $owner       The owner of the OAuth application.
- * @property GlobalCommandRepository  $commands
+ * @property string                  $id                     The client ID of the OAuth application.
+ * @property string                  $name                   The name of the OAuth application.
+ * @property string                  $icon                   The icon hash of the OAuth application.
+ * @property string                  $description            The description of the OAuth application.
+ * @property string[]                $rpc_origins            An array of RPC origin URLs.
+ * @property bool                    $bot_public             When false only app owner can join the app's bot to guilds.
+ * @property bool                    $bot_require_code_grant When true the app's bot will only join upon completion of the full oauth2 code grant flow.
+ * @property string|null             $terms_of_service_url   The url of the app's terms of service.
+ * @property string|null             $privacy_policy_url     The url of the app's privacy policy
+ * @property User                    $owner                  The owner of the OAuth application.
+ * @property string                  $verify_key             The hex encoded key for verification in interactions and the GameSDK's GetTicket.
+ * @property object|null             $team                   If the application belongs to a team, this will be a list of the members of that team.
+ * @property int                     $flags                  The application's public flags.
+ * @property string                  $invite_url             The invite URL to invite the bot to a guild.
+ * @property GlobalCommandRepository $commands               The application global commands.
  */
 class Application extends Part
 {
     /**
      * @inheritdoc
      */
-    protected $fillable = ['id', 'name', 'description', 'icon', 'rpc_origins', 'flags', 'owner'];
+    protected $fillable = [
+        'id',
+        'name',
+        'icon',
+        'description',
+        'rpc_origins',
+        'bot_public',
+        'bot_require_code_grant',
+        'terms_of_service_url',
+        'privacy_policy_url',
+        'owner',
+        'verify_key',
+        'team',
+        'flags',
+    ];
 
     /**
      * @inheritdoc

--- a/src/Discord/Parts/User/User.php
+++ b/src/Discord/Parts/User/User.php
@@ -21,23 +21,23 @@ use React\Promise\ExtendedPromiseInterface;
 /**
  * A user is a general user that is not attached to a guild.
  *
- * @property string $id            The unique identifier of the user.
- * @property string $username      The username of the user.
- * @property string $avatar        The avatar URL of the user.
- * @property string $avatar_hash   The avatar hash of the user.
- * @property string $discriminator The discriminator of the user.
- * @property bool   $bot           Whether the user is a bot.
- * @property bool   $system        Whether the user is a Discord system user.
- * @property bool   $mfa_enabled   Whether MFA is enabled.
- * @property string $banner        The banner URL of the user.
- * @property string $banner_hash   The banner hash of the user.
- * @property int    $accent_color  The user's banner color encoded as an integer representation of hexadecimal color code.
- * @property string $locale        User locale.
- * @property bool   $verified      Whether the user is verified.
- * @property string $email         User email.
- * @property int    $flags         User flags.
- * @property int    $premium_type  Type of nitro subscription.
- * @property int    $public_flags  Public flags on the user.
+ * @property string      $id            The unique identifier of the user.
+ * @property string      $username      The username of the user.
+ * @property string      $discriminator The discriminator of the user.
+ * @property string      $avatar        The avatar URL of the user.
+ * @property string      $avatar_hash   The avatar hash of the user.
+ * @property bool|null   $bot           Whether the user is a bot.
+ * @property bool|null   $system        Whether the user is a Discord system user.
+ * @property bool|null   $mfa_enabled   Whether MFA is enabled.
+ * @property string|null $banner        The banner URL of the user.
+ * @property string|null $banner_hash   The banner hash of the user.
+ * @property int|null    $accent_color  The user's banner color encoded as an integer representation of hexadecimal color code.
+ * @property string|null $locale        User locale.
+ * @property bool|null   $verified      Whether the user is verified.
+ * @property string|null $email         User email.
+ * @property int|null    $flags         User flags.
+ * @property int|null    $premium_type  Type of nitro subscription.
+ * @property int|null    $public_flags  Public flags on the user.
  *
  * @method ExtendedPromiseInterface sendMessage(MessageBuilder $builder)
  * @method ExtendedPromiseInterface sendMessage(string $text, bool $tts = false, Embed|array $embed = null, array $allowed_mentions = null, ?Message $replyTo = null)
@@ -67,7 +67,7 @@ class User extends Part
     /**
      * @inheritdoc
      */
-    protected $fillable = ['id', 'username', 'avatar', 'discriminator', 'bot', 'system', 'mfa_enabled', 'banner', 'accent_color', 'locale', 'verified', 'email', 'flags', 'premium_type', 'public_flags'];
+    protected $fillable = ['id', 'username', 'discriminator', 'avatar', 'bot', 'system', 'mfa_enabled', 'banner', 'accent_color', 'locale', 'verified', 'email', 'flags', 'premium_type', 'public_flags'];
 
     /**
      * Gets the private channel for the user.
@@ -195,11 +195,11 @@ class User extends Part
     /**
      * Returns the banner hash for the client.
      *
-     * @return string The client banner's hash.
+     * @return string|null The client banner's hash.
      */
-    protected function getBannerHashAttribute(): string
+    protected function getBannerHashAttribute(): ?string
     {
-        return $this->attributes['banner'];
+        return $this->attributes['banner'] ?? null;
     }
 
     /**


### PR DESCRIPTION
Added the missing Application attributes from: https://discord.com/developers/docs/resources/application#application-object-application-structure

Excluding attributes that is just for game & rich presence invite `cover_image` that are irrelevant to bots.