### PR TITLE
Correct Sticker location and namespace

### DIFF
--- a/src/Discord/Builders/MessageBuilder.php
+++ b/src/Discord/Builders/MessageBuilder.php
@@ -18,8 +18,8 @@ use Discord\Exceptions\FileNotFoundException;
 use Discord\Helpers\Multipart;
 use Discord\Http\Exceptions\RequestFailedException;
 use Discord\Parts\Channel\Message;
-use Discord\Parts\Channel\Sticker;
 use Discord\Parts\Embed\Embed;
+use Discord\Parts\Guild\Sticker;
 use InvalidArgumentException;
 use JsonSerializable;
 

--- a/src/Discord/Parts/Channel/Message.php
+++ b/src/Discord/Parts/Channel/Message.php
@@ -25,6 +25,7 @@ use Discord\WebSockets\Event;
 use Discord\Helpers\Deferred;
 use Discord\Http\Endpoint;
 use Discord\Parts\Guild\Guild;
+use Discord\Parts\Guild\Sticker;
 use Discord\Parts\Thread\Thread;
 use Discord\Repository\Channel\ReactionRepository;
 use InvalidArgumentException;

--- a/src/Discord/Parts/Guild/Sticker.php
+++ b/src/Discord/Parts/Guild/Sticker.php
@@ -9,9 +9,8 @@
  * with this source code in the LICENSE.md file.
  */
 
-namespace Discord\Parts\Channel;
+namespace Discord\Parts\Guild;
 
-use Discord\Parts\Guild\Guild;
 use Discord\Parts\Part;
 
 /**

--- a/src/Discord/Repository/Guild/StickerRepository.php
+++ b/src/Discord/Repository/Guild/StickerRepository.php
@@ -12,7 +12,7 @@
 namespace Discord\Repository\Guild;
 
 use Discord\Http\Endpoint;
-use Discord\Parts\Channel\Sticker;
+use Discord\Parts\Guild\Sticker;
 use Discord\Repository\AbstractRepository;
 
 /**

--- a/src/Discord/WebSockets/Events/GuildStickersUpdate.php
+++ b/src/Discord/WebSockets/Events/GuildStickersUpdate.php
@@ -14,7 +14,7 @@ namespace Discord\WebSockets\Events;
 use Discord\Helpers\Collection;
 use Discord\WebSockets\Event;
 use Discord\Helpers\Deferred;
-use Discord\Parts\Channel\Sticker;
+use Discord\Parts\Guild\Sticker;
 
 class GuildStickersUpdate extends Event
 {


### PR DESCRIPTION
This is a breaking change in v7 RC stage that corrected the file location of Sticker part class from Channel to Guild, as well updating the referenced namespaces.

Bot developer has to rename the `use` from `\Discord\Parts\Channel\Sticker` to `\Discord\Parts\Guild\Sticker` in their code