### PR TITLE
Add listenCommand auto complete callback

### DIFF
--- a/src/Discord/Discord.php
+++ b/src/Discord/Discord.php
@@ -1523,12 +1523,13 @@ class Discord
     /**
      * Registeres a command with the client.
      *
-     * @param string|array $name
-     * @param callable     $callback
+     * @param string|array  $name
+     * @param callable      $callback
+     * @param callable|null $autocomplete_callback
      *
      * @return RegisteredCommand
      */
-    public function listenCommand($name, callable $callback = null): RegisteredCommand
+    public function listenCommand($name, callable $callback = null, ?callable $autocomplete_callback = null): RegisteredCommand
     {
         if (is_array($name) && count($name) == 1) {
             $name = array_shift($name);
@@ -1540,7 +1541,7 @@ class Discord
                 throw new InvalidArgumentException("The command `{$name}` already exists.");
             }
 
-            return $this->application_commands[$name] = new RegisteredCommand($this, $name, $callback);
+            return $this->application_commands[$name] = new RegisteredCommand($this, $name, $callback, $autocomplete_callback);
         }
 
         $baseCommand = array_shift($name);

--- a/src/Discord/Helpers/RegisteredCommand.php
+++ b/src/Discord/Helpers/RegisteredCommand.php
@@ -115,15 +115,7 @@ class RegisteredCommand
     public function suggest(Interaction $interaction): bool
     {
         if (is_callable($this->autocomplete_callback)) {
-            $focusedOption = null;
-            foreach ($interaction->data->options as $option) {
-                if ($option->focused) {
-                    $focusedOption = $option;
-                    break;
-                }
-            }
-
-            $choice = ($this->autocomplete_callback)($interaction, $focusedOption);
+            $choice = ($this->autocomplete_callback)($interaction);
             if (is_array($choice)) {
                 $interaction->autoCompleteResult($choice);
             }

--- a/src/Discord/WebSockets/Events/InteractionCreate.php
+++ b/src/Discord/WebSockets/Events/InteractionCreate.php
@@ -51,6 +51,12 @@ class InteractionCreate extends Event
             };
 
             $checkCommand($interaction->data);
+        } elseif ($interaction->type == InteractionType::APPLICATION_COMMAND_AUTOCOMPLETE) {
+            if (isset($this->discord->application_commands[$interaction->data['name']])) {
+                if ($this->discord->application_commands[$interaction->data['name']]->suggest($interaction)) {
+                    return;
+                }
+            }
         }
 
         $deferred->resolve($interaction);


### PR DESCRIPTION
This PR is a followup to #597 especially for autocomplete options, which adds extra callable in `listenCommand()`

Example;
```php
$discord->listenCommand('my_cool_command', function (Interaction $interaction) use ($discord) {
    // do something...
}, function (Interaction $interaction) use ($discord) {
    // check the specific option value here...
    if ($interaction->data->options['optionname']->value) {
        // return suggestions, equivalent to calling $interaction->autoCompleteResult()
        return [
            new Choice($discord, ['name' => 'Choice 1', 'value' => 'one']),
            new Choice($discord, ['name' => 'Choice 2', 'value' => 'two']),
        ];
    }

    // return no result
    return [];
});
```