### PR TITLE
Correction for Throwable, phpdoc, add missing attributes

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2021 David Cole <david.cole1340@gmail.com> and all contributors
+Copyright (c) 2022 David Cole <david.cole1340@gmail.com> and all contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/Discord/Builders/CommandBuilder.php
+++ b/src/Discord/Builders/CommandBuilder.php
@@ -73,6 +73,8 @@ class CommandBuilder implements JsonSerializable
      *
      * @param int $type Type of the command
      *
+     * @throws \InvalidArgumentException
+     *
      * @return $this
      */
     public function setType(int $type): self
@@ -90,12 +92,14 @@ class CommandBuilder implements JsonSerializable
      *
      * @param string $description Name of the command
      *
+     * @throws \LengthException
+     *
      * @return $this
      */
     public function setName(string $name): self
     {
         if (poly_strlen($name) > 100) {
-            throw new \InvalidArgumentException('Command name must be less than or equal to 32 characters.');
+            throw new \LengthException('Command name must be less than or equal to 32 characters.');
         }
 
         $this->name = $name;
@@ -107,12 +111,14 @@ class CommandBuilder implements JsonSerializable
      *
      * @param string $description Description of the command
      *
+     * @throws \LengthException
+     *
      * @return $this
      */
     public function setDescription(string $description): self
     {
         if ($this->type == Command::CHAT_INPUT && poly_strlen($description) > 100) {
-            throw new \InvalidArgumentException('Command description must be less than or equal to 100 characters.');
+            throw new \LengthException('Command description must be less than or equal to 100 characters.');
         }
 
         $this->description = $description;
@@ -136,6 +142,8 @@ class CommandBuilder implements JsonSerializable
      * Adds an option to the command.
      *
      * @param Option $option The option
+     *
+     * @throws \InvalidArgumentException
      *
      * @return $this
      */
@@ -178,18 +186,20 @@ class CommandBuilder implements JsonSerializable
     /**
      * Returns an array with all the options.
      *
+     * @throws \Exception
+     *
      * @return array
      */
     public function toArray(): array
     {
         if (poly_strlen($this->name) < 1) {
-            throw new \InvalidArgumentException('Command name must be greater than or equal to 1 character.');
+            throw new \LengthException('Command name must be greater than or equal to 1 character.');
         }
 
         $desclen = poly_strlen($this->description);
         if ($this->type == Command::CHAT_INPUT) {
             if ($desclen < 1) {
-                throw new \InvalidArgumentException('Description must be greater than or equal to 1 character.');
+                throw new \LengthException('Description must be greater than or equal to 1 character.');
             }
         } elseif ($this->type == Command::USER || $this->type == Command::MESSAGE) {
             if ($desclen) {

--- a/src/Discord/Builders/CommandBuilder.php
+++ b/src/Discord/Builders/CommandBuilder.php
@@ -147,7 +147,7 @@ class CommandBuilder implements JsonSerializable
      *
      * @return $this
      */
-    public function addOption(Option $option)
+    public function addOption(Option $option): self
     {
         if (count($this->options) >= 25) {
             throw new \OverflowException('Command can only have a maximum of 25 options.');
@@ -164,7 +164,7 @@ class CommandBuilder implements JsonSerializable
      *
      * @return $this
      */
-    public function removeOption(Option $option)
+    public function removeOption(Option $option): self
     {
         if (($idx = array_search($option, $this->option)) !== null) {
             array_splice($this->options, $idx, 1);

--- a/src/Discord/Builders/CommandBuilder.php
+++ b/src/Discord/Builders/CommandBuilder.php
@@ -186,7 +186,8 @@ class CommandBuilder implements JsonSerializable
     /**
      * Returns an array with all the options.
      *
-     * @throws \LogicException
+     * @throws \LengthException
+     * @throws \DomainException
      *
      * @return array
      */

--- a/src/Discord/Builders/CommandBuilder.php
+++ b/src/Discord/Builders/CommandBuilder.php
@@ -143,14 +143,14 @@ class CommandBuilder implements JsonSerializable
      *
      * @param Option $option The option
      *
-     * @throws \InvalidArgumentException
+     * @throws \OverflowException
      *
      * @return $this
      */
     public function addOption(Option $option)
     {
         if (count($this->options) >= 25) {
-            throw new \InvalidArgumentException('Command can only have a maximum of 25 options.');
+            throw new \OverflowException('Command can only have a maximum of 25 options.');
         }
 
         $this->options[] = $option;
@@ -186,7 +186,7 @@ class CommandBuilder implements JsonSerializable
     /**
      * Returns an array with all the options.
      *
-     * @throws \Exception
+     * @throws \LogicException
      *
      * @return array
      */
@@ -203,7 +203,7 @@ class CommandBuilder implements JsonSerializable
             }
         } elseif ($this->type == Command::USER || $this->type == Command::MESSAGE) {
             if ($desclen) {
-                throw new \InvalidArgumentException('Only a command with type CHAT_INPUT accepts a description.');
+                throw new \DomainException('Only a command with type CHAT_INPUT accepts a description.');
             }
         }
 

--- a/src/Discord/Builders/Components/ActionRow.php
+++ b/src/Discord/Builders/Components/ActionRow.php
@@ -66,7 +66,7 @@ class ActionRow extends Component
      *
      * @return $this
      */
-    public function removeComponent(Component $component)
+    public function removeComponent(Component $component): self
     {
         if (($idx = array_search($component, $this->components)) !== null) {
             array_splice($this->components, $idx, 1);

--- a/src/Discord/Builders/Components/ActionRow.php
+++ b/src/Discord/Builders/Components/ActionRow.php
@@ -36,6 +36,7 @@ class ActionRow extends Component
      * @param Component $component Component to add.
      *
      * @throws \InvalidArgumentException
+     * @throws \OverflowException
      *
      * @return $this
      */
@@ -50,7 +51,7 @@ class ActionRow extends Component
         }
 
         if (count($this->components) >= 5) {
-            throw new \InvalidArgumentException('You can only have 5 components per action row.');
+            throw new \OverflowException('You can only have 5 components per action row.');
         }
 
         $this->components[] = $component;

--- a/src/Discord/Builders/Components/ActionRow.php
+++ b/src/Discord/Builders/Components/ActionRow.php
@@ -11,8 +11,6 @@
 
 namespace Discord\Builders\Components;
 
-use InvalidArgumentException;
-
 class ActionRow extends Component
 {
     /**
@@ -37,20 +35,22 @@ class ActionRow extends Component
      *
      * @param Component $component Component to add.
      *
+     * @throws \InvalidArgumentException
+     *
      * @return $this
      */
     public function addComponent(Component $component): self
     {
         if ($component instanceof ActionRow) {
-            throw new InvalidArgumentException('You cannot add another `ActionRow` to this action row.');
+            throw new \InvalidArgumentException('You cannot add another `ActionRow` to this action row.');
         }
 
         if ($component instanceof SelectMenu) {
-            throw new InvalidArgumentException('Cannot add a select menu to an action row.');
+            throw new \InvalidArgumentException('Cannot add a select menu to an action row.');
         }
 
         if (count($this->components) >= 5) {
-            throw new InvalidArgumentException('You can only have 5 components per action row.');
+            throw new \InvalidArgumentException('You can only have 5 components per action row.');
         }
 
         $this->components[] = $component;

--- a/src/Discord/Builders/Components/Button.php
+++ b/src/Discord/Builders/Components/Button.php
@@ -144,7 +144,7 @@ class Button extends Component
             self::STYLE_DANGER,
             self::STYLE_LINK,
         ])) {
-            throw new \InvalidArgumentException('Invalid style.');
+            throw new \InvalidArgumentException('Invalid button style.');
         }
 
         if ($this->style == self::STYLE_LINK && $style != self::STYLE_LINK) {

--- a/src/Discord/Builders/Components/Button.php
+++ b/src/Discord/Builders/Components/Button.php
@@ -16,7 +16,6 @@ use Discord\Parts\Guild\Emoji;
 use Discord\Parts\Interactions\Interaction;
 use Discord\WebSockets\Event;
 use Exception;
-use InvalidArgumentException;
 use React\Promise\PromiseInterface;
 
 use function Discord\poly_strlen;
@@ -90,6 +89,8 @@ class Button extends Component
      *
      * @param int $style Style of the button.
      * @param string|null $custom_id custom ID of the button. If not given, an UUID will be used
+     * 
+     * @throws \InvalidArgumentException
      */
     public function __construct(int $style, ?string $custom_id)
     {
@@ -100,7 +101,7 @@ class Button extends Component
             self::STYLE_DANGER,
             self::STYLE_LINK,
         ])) {
-            throw new InvalidArgumentException('Invalid style.');
+            throw new \InvalidArgumentException('Invalid button style.');
         }
 
         $this->style = $style;
@@ -130,6 +131,8 @@ class Button extends Component
      *
      * @param int $style
      *
+     * @throws \InvalidArgumentException
+     *
      * @return $this
      */
     public function setStyle(int $style): self
@@ -141,7 +144,7 @@ class Button extends Component
             self::STYLE_DANGER,
             self::STYLE_LINK,
         ])) {
-            throw new InvalidArgumentException('Invalid style.');
+            throw new \InvalidArgumentException('Invalid style.');
         }
 
         if ($this->style == self::STYLE_LINK && $style != self::STYLE_LINK) {
@@ -160,12 +163,14 @@ class Button extends Component
      *
      * @param string $label Label of the button. Maximum 80 characters.
      *
+     * @throws \LengthException
+     *
      * @return $this
      */
     public function setLabel(string $label): self
     {
         if (poly_strlen($label) > 80) {
-            throw new InvalidArgumentException('Label must be maximum 80 characters.');
+            throw new \LengthException('Label must be maximum 80 characters.');
         }
 
         $this->label = $label;
@@ -222,16 +227,18 @@ class Button extends Component
      *
      * @param string $custom_id
      *
+     * @throws \LogicException
+     *
      * @return $this
      */
     public function setCustomId(string $custom_id): self
     {
         if ($this->style == Button::STYLE_LINK) {
-            throw new InvalidArgumentException('You cannot set the custom ID of a link button.');
+            throw new \LogicException('You cannot set the custom ID of a link button.');
         }
 
         if (poly_strlen($custom_id) > 100) {
-            throw new InvalidArgumentException('Custom ID must be maximum 100 characters.');
+            throw new \LengthException('Custom ID must be maximum 100 characters.');
         }
 
         $this->custom_id = $custom_id;
@@ -244,12 +251,14 @@ class Button extends Component
      *
      * @param string $url
      *
+     * @throws \LogicException
+     *
      * @return $this
      */
     public function setUrl(string $url): self
     {
         if ($this->style != Button::STYLE_LINK) {
-            throw new InvalidArgumentException('You cannot set the URL of a non-link button.');
+            throw new \LogicException('You cannot set the URL of a non-link button.');
         }
 
         $this->url = $url;
@@ -289,12 +298,14 @@ class Button extends Component
      * @param Discord  $discord  Discord client.
      * @param bool     $oneOff   Whether the listener should be removed after the button is pressed for the first time.
      *
+     * @throws \LogicException
+     *
      * @return $this
      */
     public function setListener(?callable $callback, Discord $discord, bool $oneOff = false): self
     {
         if ($this->style == Button::STYLE_LINK) {
-            throw new InvalidArgumentException('You cannot add a listener to a link button.');
+            throw new \LogicException('You cannot add a listener to a link button.');
         }
 
         if (! $this->custom_id) {
@@ -431,13 +442,13 @@ class Button extends Component
         if ($this->custom_id) {
             $content['custom_id'] = $this->custom_id;
         } elseif ($this->style != Button::STYLE_LINK) {
-            throw new InvalidArgumentException('Buttons must have a `custom_id` field set.');
+            throw new \DomainException('Buttons must have a `custom_id` field set.');
         }
 
         if ($this->url) {
             $content['url'] = $this->url;
         } elseif ($this->style == Button::STYLE_LINK) {
-            throw new InvalidArgumentException('Link buttons must have a `url` field set.');
+            throw new \DomainException('Link buttons must have a `url` field set.');
         }
 
         if ($this->disabled) {

--- a/src/Discord/Builders/Components/Button.php
+++ b/src/Discord/Builders/Components/Button.php
@@ -15,7 +15,6 @@ use Discord\Discord;
 use Discord\Parts\Guild\Emoji;
 use Discord\Parts\Interactions\Interaction;
 use Discord\WebSockets\Event;
-use Exception;
 use React\Promise\PromiseInterface;
 
 use function Discord\poly_strlen;
@@ -228,6 +227,7 @@ class Button extends Component
      * @param string $custom_id
      *
      * @throws \LogicException
+     * @throws \LengthException
      *
      * @return $this
      */
@@ -330,7 +330,7 @@ class Button extends Component
                     // attempt to acknowledge interaction if it has not already been responded to.
                     try {
                         $interaction->acknowledge();
-                    } catch (Exception $e) {
+                    } catch (\Exception $e) {
                     }
                 };
 

--- a/src/Discord/Builders/Components/Option.php
+++ b/src/Discord/Builders/Components/Option.php
@@ -12,7 +12,6 @@
 namespace Discord\Builders\Components;
 
 use Discord\Parts\Guild\Emoji;
-use InvalidArgumentException;
 
 use function Discord\poly_strlen;
 
@@ -58,15 +57,17 @@ class Option extends Component
      *
      * @param string      $label User-visible label for the option. Maximum 100 characters.
      * @param string|null $value Developer value for the option. Maximum 100 characters. Leave as null to automatically generate a UUID.
+     *
+     * @throws \LengthException
      */
     public function __construct(string $label, ?string $value)
     {
         if (poly_strlen($label) > 100) {
-            throw new InvalidArgumentException('Label must be less than or equal to 100 characters.');
+            throw new \LengthException('Label must be less than or equal to 100 characters.');
         }
 
         if ($value && poly_strlen($value) > 100) {
-            throw new InvalidArgumentException('Value must be less than or equal to 100 characters.');
+            throw new \LengthException('Value must be less than or equal to 100 characters.');
         }
 
         $this->label = $label;
@@ -91,12 +92,14 @@ class Option extends Component
      *
      * @param string|null $description Description of the option. Maximum 100 characters.
      *
+     * @throws \LengthException
+     *
      * @return $this
      */
     public function setDescription(?string $description): self
     {
         if ($description && poly_strlen($description) > 100) {
-            throw new InvalidArgumentException('Description must be less than or equal to 100 characters.');
+            throw new \LengthException('Description must be less than or equal to 100 characters.');
         }
 
         $this->description = $description;
@@ -225,7 +228,7 @@ class Option extends Component
         if ($this->description) {
             $content['description'] = $this->description;
         }
-        
+
         if ($this->emoji) {
             $content['emoji'] = $this->emoji;
         }

--- a/src/Discord/Builders/Components/SelectMenu.php
+++ b/src/Discord/Builders/Components/SelectMenu.php
@@ -16,7 +16,6 @@ use Discord\Helpers\Collection;
 use Discord\Parts\Interactions\Interaction;
 use Discord\WebSockets\Event;
 use Exception;
-use InvalidArgumentException;
 use React\Promise\PromiseInterface;
 
 use function Discord\poly_strlen;
@@ -107,13 +106,15 @@ class SelectMenu extends Component
      * Sets the custom ID for the select menu
      * 
      * @param string $custom_id
-     
+     *
+     * @throws \LengthException
+     *
      * @return $this
      */
     public function setCustomId($custom_id): self
     {
         if (poly_strlen($custom_id) > 100) {
-            throw new InvalidArgumentException('Custom ID must be maximum 100 characters.');
+            throw new \LengthException('Custom ID must be maximum 100 characters.');
         }
         
         $this->custom_id = $custom_id;
@@ -126,12 +127,14 @@ class SelectMenu extends Component
      *
      * @param Option $option Option to add.
      *
+     * @throws \InvalidArgumentException
+     *
      * @return $this
      */
     public function addOption(Option $option): self
     {
         if (count($this->options) > 25) {
-            throw new InvalidArgumentException('You can only have 25 options per select menu.');
+            throw new \InvalidArgumentException('You can only have 25 options per select menu.');
         }
 
         $value = $option->getValue();
@@ -139,7 +142,7 @@ class SelectMenu extends Component
         // didn't wanna use a hashtable here so that we can keep the order of options
         foreach ($this->options as $other) {
             if ($other->getValue() == $value) {
-                throw new InvalidArgumentException('Another value already has the same value. These must not be the same.');
+                throw new \InvalidArgumentException('Another value already has the same value. These must not be the same.');
             }
         }
 
@@ -170,12 +173,14 @@ class SelectMenu extends Component
      *
      * @param string|null $placeholder
      *
+     * @throws \LengthException
+     *
      * @return $this
      */
     public function setPlaceholder(?string $placeholder): self
     {
         if ($placeholder && strlen($placeholder) > 100) {
-            throw new InvalidArgumentException('Placeholder string must be less than or equal to 100 characters.');
+            throw new \LengthException('Placeholder string must be less than or equal to 100 characters.');
         }
 
         $this->placeholder = $placeholder;
@@ -189,12 +194,14 @@ class SelectMenu extends Component
      *
      * @param int|null $min_values
      *
+     * @throws \LengthException
+     *
      * @return $this
      */
     public function setMinValues(?int $min_values): self
     {
         if ($min_values && ($min_values < 0 || $min_values > 25)) {
-            throw new InvalidArgumentException('Number must be between 0 and 25 inclusive.');
+            throw new \LengthException('Number must be between 0 and 25 inclusive.');
         }
 
         $this->min_values = $min_values;
@@ -208,12 +215,14 @@ class SelectMenu extends Component
      *
      * @param int|null $max_values
      *
+     * @throws \LengthException
+     *
      * @return $this
      */
     public function setMaxValues(?int $max_values): self
     {
         if ($max_values && $max_values > 25) {
-            throw new InvalidArgumentException('Number must be less than or equal to 25.');
+            throw new \LengthException('Number must be less than or equal to 25.');
         }
 
         $this->max_values = $max_values;
@@ -394,7 +403,7 @@ class SelectMenu extends Component
 
         if ($this->min_values) {
             if ($this->min_values > count($this->options)) {
-                throw new InvalidArgumentException('There are less options than the minimum number of options to be selected.');
+                throw new \LengthException('There are less options than the minimum number of options to be selected.');
             }
 
             $content['min_values'] = $this->min_values;
@@ -402,7 +411,7 @@ class SelectMenu extends Component
 
         if ($this->max_values) {
             if ($this->max_values > count($this->options)) {
-                throw new InvalidArgumentException('There are less options than the maximum number of options to be selected.');
+                throw new \LengthException('There are less options than the maximum number of options to be selected.');
             }
 
             $content['max_values'] = $this->max_values;

--- a/src/Discord/Builders/Components/SelectMenu.php
+++ b/src/Discord/Builders/Components/SelectMenu.php
@@ -15,7 +15,6 @@ use Discord\Discord;
 use Discord\Helpers\Collection;
 use Discord\Parts\Interactions\Interaction;
 use Discord\WebSockets\Event;
-use Exception;
 use React\Promise\PromiseInterface;
 
 use function Discord\poly_strlen;
@@ -127,14 +126,15 @@ class SelectMenu extends Component
      *
      * @param Option $option Option to add.
      *
-     * @throws \InvalidArgumentException
+     * @throws \OverflowException
+     * @throws \LogicException
      *
      * @return $this
      */
     public function addOption(Option $option): self
     {
         if (count($this->options) > 25) {
-            throw new \InvalidArgumentException('You can only have 25 options per select menu.');
+            throw new \OverflowException('You can only have 25 options per select menu.');
         }
 
         $value = $option->getValue();
@@ -142,7 +142,7 @@ class SelectMenu extends Component
         // didn't wanna use a hashtable here so that we can keep the order of options
         foreach ($this->options as $other) {
             if ($other->getValue() == $value) {
-                throw new \InvalidArgumentException('Another value already has the same value. These must not be the same.');
+                throw new \LogicException('Another value already has the same value. These must not be the same.');
             }
         }
 
@@ -295,7 +295,7 @@ class SelectMenu extends Component
                     // attempt to acknowledge interaction if it has not already been responded to.
                     try {
                         $interaction->acknowledge();
-                    } catch (Exception $e) {
+                    } catch (\Exception $e) {
                     }
                 };
 
@@ -403,7 +403,7 @@ class SelectMenu extends Component
 
         if ($this->min_values) {
             if ($this->min_values > count($this->options)) {
-                throw new \LengthException('There are less options than the minimum number of options to be selected.');
+                throw new \OutOfBoundsException('There are less options than the minimum number of options to be selected.');
             }
 
             $content['min_values'] = $this->min_values;
@@ -411,7 +411,7 @@ class SelectMenu extends Component
 
         if ($this->max_values) {
             if ($this->max_values > count($this->options)) {
-                throw new \LengthException('There are less options than the maximum number of options to be selected.');
+                throw new \OutOfBoundsException('There are less options than the maximum number of options to be selected.');
             }
 
             $content['max_values'] = $this->max_values;

--- a/src/Discord/Builders/Components/SelectMenu.php
+++ b/src/Discord/Builders/Components/SelectMenu.php
@@ -127,7 +127,7 @@ class SelectMenu extends Component
      * @param Option $option Option to add.
      *
      * @throws \OverflowException
-     * @throws \LogicException
+     * @throws \UnexpectedValueException
      *
      * @return $this
      */
@@ -142,7 +142,7 @@ class SelectMenu extends Component
         // didn't wanna use a hashtable here so that we can keep the order of options
         foreach ($this->options as $other) {
             if ($other->getValue() == $value) {
-                throw new \LogicException('Another value already has the same value. These must not be the same.');
+                throw new \UnexpectedValueException('Another value already has the same value. These must not be the same.');
             }
         }
 

--- a/src/Discord/Builders/MessageBuilder.php
+++ b/src/Discord/Builders/MessageBuilder.php
@@ -20,7 +20,6 @@ use Discord\Http\Exceptions\RequestFailedException;
 use Discord\Parts\Channel\Message;
 use Discord\Parts\Embed\Embed;
 use Discord\Parts\Guild\Sticker;
-use InvalidArgumentException;
 use JsonSerializable;
 
 use function Discord\poly_strlen;
@@ -110,12 +109,14 @@ class MessageBuilder implements JsonSerializable
      *
      * @param string $content Content of the message. Maximum 2000 characters.
      *
+     * @throws \LengthException
+     *
      * @return $this
      */
     public function setContent(string $content): self
     {
         if (poly_strlen($content) > 2000) {
-            throw new InvalidArgumentException('Message content must be less than or equal to 2000 characters.');
+            throw new \LengthException('Message content must be less than or equal to 2000 characters.');
         }
 
         $this->content = $content;
@@ -152,6 +153,8 @@ class MessageBuilder implements JsonSerializable
      *
      * @param Embed|array $embeds,...
      *
+     * @throws \InvalidArgumentException
+     *
      * @return $this
      */
     public function addEmbed(...$embeds): self
@@ -162,7 +165,7 @@ class MessageBuilder implements JsonSerializable
             }
 
             if (count($this->embeds) >= 10) {
-                throw new InvalidArgumentException('You can only have 10 embeds per message.');
+                throw new \InvalidArgumentException('You can only have 10 embeds per message.');
             }
 
             $this->embeds[] = $embed;
@@ -266,16 +269,18 @@ class MessageBuilder implements JsonSerializable
      *
      * @param Component $component Component to add.
      *
+     * @throws \InvalidArgumentException
+     *
      * @return $this
      */
     public function addComponent(Component $component): self
     {
         if (! ($component instanceof ActionRow || $component instanceof SelectMenu)) {
-            throw new InvalidArgumentException('You can only add action rows and select menus as components to messages. Put your other components inside an action row.');
+            throw new \InvalidArgumentException('You can only add action rows and select menus as components to messages. Put your other components inside an action row.');
         }
 
         if (count($this->components) >= 5) {
-            throw new InvalidArgumentException('You can only add 5 components to a message');
+            throw new \InvalidArgumentException('You can only add 5 components to a message');
         }
 
         $this->components[] = $component;
@@ -346,6 +351,8 @@ class MessageBuilder implements JsonSerializable
      *
      * @param string|Sticker $sticker Sticker to add.
      *
+     * @throws \InvalidArgumentException
+     *
      * @return $this
      */
     public function addSticker($sticker): self
@@ -355,7 +362,7 @@ class MessageBuilder implements JsonSerializable
         }
 
         if (count($this->sticker_ids) >= 3) {
-            throw new InvalidArgumentException('You can only add 3 stickers to a message');
+            throw new \InvalidArgumentException('You can only add 3 stickers to a message');
         }
 
         $this->sticker_ids[] = $sticker;

--- a/src/Discord/Builders/MessageBuilder.php
+++ b/src/Discord/Builders/MessageBuilder.php
@@ -340,7 +340,7 @@ class MessageBuilder implements JsonSerializable
      *
      * @return $this
      */
-    public function setAllowedMentions(array $allowed_mentions)
+    public function setAllowedMentions(array $allowed_mentions): self
     {
         $this->allowed_mentions = $allowed_mentions;
 

--- a/src/Discord/Builders/MessageBuilder.php
+++ b/src/Discord/Builders/MessageBuilder.php
@@ -153,7 +153,7 @@ class MessageBuilder implements JsonSerializable
      *
      * @param Embed|array $embeds,...
      *
-     * @throws \InvalidArgumentException
+     * @throws \OverflowException
      *
      * @return $this
      */
@@ -165,7 +165,7 @@ class MessageBuilder implements JsonSerializable
             }
 
             if (count($this->embeds) >= 10) {
-                throw new \InvalidArgumentException('You can only have 10 embeds per message.');
+                throw new \OverflowException('You can only have 10 embeds per message.');
             }
 
             $this->embeds[] = $embed;
@@ -270,6 +270,7 @@ class MessageBuilder implements JsonSerializable
      * @param Component $component Component to add.
      *
      * @throws \InvalidArgumentException
+     * @throws \OverflowException
      *
      * @return $this
      */
@@ -280,7 +281,7 @@ class MessageBuilder implements JsonSerializable
         }
 
         if (count($this->components) >= 5) {
-            throw new \InvalidArgumentException('You can only add 5 components to a message');
+            throw new \OverflowException('You can only add 5 components to a message');
         }
 
         $this->components[] = $component;
@@ -351,7 +352,7 @@ class MessageBuilder implements JsonSerializable
      *
      * @param string|Sticker $sticker Sticker to add.
      *
-     * @throws \InvalidArgumentException
+     * @throws \OverflowException
      *
      * @return $this
      */
@@ -362,7 +363,7 @@ class MessageBuilder implements JsonSerializable
         }
 
         if (count($this->sticker_ids) >= 3) {
-            throw new \InvalidArgumentException('You can only add 3 stickers to a message');
+            throw new \OverflowException('You can only add 3 stickers to a message');
         }
 
         $this->sticker_ids[] = $sticker;

--- a/src/Discord/Discord.php
+++ b/src/Discord/Discord.php
@@ -1071,7 +1071,8 @@ class Discord
      *                                 Must be one of the following:
      *                                 online, dnd, idle, invisible, offline
      * @param  bool          $afk      Whether the client is AFK.
-     * @throws \Exception
+     *
+     * @throws \UnexpectedValueException
      */
     public function updatePresence(Activity $activity = null, bool $idle = false, string $status = 'online', bool $afk = false): void
     {
@@ -1081,7 +1082,7 @@ class Discord
             $activity = $activity->getRawAttributes();
 
             if (! in_array($activity['type'], [Activity::TYPE_PLAYING, Activity::TYPE_STREAMING, Activity::TYPE_LISTENING, Activity::TYPE_WATCHING, Activity::TYPE_COMPETING])) {
-                throw new \Exception("The given activity type ({$activity['type']}) is invalid.");
+                throw new \UnexpectedValueException("The given activity type ({$activity['type']}) is invalid.");
 
                 return;
             }
@@ -1127,6 +1128,8 @@ class Discord
      * @param LoggerInterface|null $logger  Voice client logger. If null, uses same logger as Discord client.
      * @param bool                 $check   Whether to check for system requirements.
      *
+     * @throws \RuntimeException
+     *
      * @return PromiseInterface
      */
     public function joinVoiceChannel(Channel $channel, $mute = false, $deaf = true, ?LoggerInterface $logger = null, bool $check = true): ExtendedPromiseInterface
@@ -1134,13 +1137,13 @@ class Discord
         $deferred = new Deferred();
 
         if (! $channel->allowVoice()) {
-            $deferred->reject(new \Exception('Channel must allow voice.'));
+            $deferred->reject(new \RuntimeException('Channel must allow voice.'));
 
             return $deferred->promise();
         }
 
         if (isset($this->voiceClients[$channel->guild_id])) {
-            $deferred->reject(new \Exception('You cannot join more than one voice channel per guild.'));
+            $deferred->reject(new \RuntimeException('You cannot join more than one voice channel per guild.'));
 
             return $deferred->promise();
         }
@@ -1526,7 +1529,7 @@ class Discord
      * @param callable      $callback
      * @param callable|null $autocomplete_callback
      *
-     * @throws \InvalidArgumentException
+     * @throws \LogicException
      *
      * @return RegisteredCommand
      */
@@ -1539,7 +1542,7 @@ class Discord
         // registering base command
         if (! is_array($name) || count($name) == 1) {
             if (isset($this->application_commands[$name])) {
-                throw new \InvalidArgumentException("The command `{$name}` already exists.");
+                throw new \LogicException("The command `{$name}` already exists.");
             }
 
             return $this->application_commands[$name] = new RegisteredCommand($this, $name, $callback, $autocomplete_callback);

--- a/src/Discord/Discord.php
+++ b/src/Discord/Discord.php
@@ -46,7 +46,6 @@ use Discord\Helpers\RegisteredCommand;
 use Discord\Http\Drivers\React;
 use Discord\Http\Endpoint;
 use Evenement\EventEmitterTrait;
-use InvalidArgumentException;
 use Psr\Log\LoggerInterface;
 use React\Promise\ExtendedPromiseInterface;
 use React\Promise\PromiseInterface;
@@ -1527,6 +1526,8 @@ class Discord
      * @param callable      $callback
      * @param callable|null $autocomplete_callback
      *
+     * @throws \InvalidArgumentException
+     *
      * @return RegisteredCommand
      */
     public function listenCommand($name, callable $callback = null, ?callable $autocomplete_callback = null): RegisteredCommand
@@ -1538,7 +1539,7 @@ class Discord
         // registering base command
         if (! is_array($name) || count($name) == 1) {
             if (isset($this->application_commands[$name])) {
-                throw new InvalidArgumentException("The command `{$name}` already exists.");
+                throw new \InvalidArgumentException("The command `{$name}` already exists.");
             }
 
             return $this->application_commands[$name] = new RegisteredCommand($this, $name, $callback, $autocomplete_callback);
@@ -1549,7 +1550,7 @@ class Discord
         if (! isset($this->application_commands[$baseCommand])) {
             $this->listenCommand($baseCommand);
         }
-        return $this->application_commands[$baseCommand]->addSubCommand($name, $callback);
+        return $this->application_commands[$baseCommand]->addSubCommand($name, $callback, $autocomplete_callback);
     }
 
     /**

--- a/src/Discord/Helpers/RegisteredCommand.php
+++ b/src/Discord/Helpers/RegisteredCommand.php
@@ -1,12 +1,12 @@
 <?php
 
 /*
- * This file was a part of the DiscordPHP-Slash project.
+ * This file is a part of the DiscordPHP project.
  *
- * Copyright (c) 2021 David Cole <david.cole1340@gmail.com>
+ * Copyright (c) 2015-present David Cole <david.cole1340@gmail.com>
  *
- * This source file is subject to the MIT license which is
- * bundled with this source code in the LICENSE.md file.
+ * This file is subject to the MIT license that is bundled
+ * with this source code in the LICENSE.md file.
  */
 
 namespace Discord\Helpers;

--- a/src/Discord/Helpers/RegisteredCommand.php
+++ b/src/Discord/Helpers/RegisteredCommand.php
@@ -164,7 +164,7 @@ class RegisteredCommand
      * @param callable      $callback
      * @param callable|null $autocomplete_callback
      *
-     * @throws \InvalidArgumentException
+     * @throws \LogicException
      *
      * @return RegisteredCommand
      */
@@ -176,7 +176,7 @@ class RegisteredCommand
 
         if (! is_array($name) || count($name) == 1) {
             if (isset($this->subCommands[$name])) {
-                throw new \InvalidArgumentException("The command `{$name}` already exists.");
+                throw new \LogicException("The command `{$name}` already exists.");
             }
 
             return $this->subCommands[$name] = new static($this->discord, $name, $callback, $autocomplete_callback);

--- a/src/Discord/Helpers/RegisteredCommand.php
+++ b/src/Discord/Helpers/RegisteredCommand.php
@@ -13,7 +13,6 @@ namespace Discord\Helpers;
 
 use Discord\Discord;
 use Discord\Parts\Interactions\Interaction;
-use InvalidArgumentException;
 
 /**
  * RegisteredCommand represents a command that has been registered
@@ -161,12 +160,15 @@ class RegisteredCommand
     /**
      * Adds a sub-command to the command.
      *
-     * @param string|array $name
-     * @param callable     $callback
+     * @param string|array  $name
+     * @param callable      $callback
+     * @param callable|null $autocomplete_callback
+     *
+     * @throws \InvalidArgumentException
      *
      * @return RegisteredCommand
      */
-    public function addSubCommand($name, callable $callback = null): RegisteredCommand
+    public function addSubCommand($name, callable $callback = null, ?callable $autocomplete_callback = null): RegisteredCommand
     {
         if (is_array($name) && count($name) == 1) {
             $name = array_shift($name);
@@ -174,10 +176,10 @@ class RegisteredCommand
 
         if (! is_array($name) || count($name) == 1) {
             if (isset($this->subCommands[$name])) {
-                throw new InvalidArgumentException("The command `{$name}` already exists.");
+                throw new \InvalidArgumentException("The command `{$name}` already exists.");
             }
 
-            return $this->subCommands[$name] = new static($this->discord, $name, $callback);
+            return $this->subCommands[$name] = new static($this->discord, $name, $callback, $autocomplete_callback);
         }
 
         $baseCommand = array_shift($name);
@@ -186,7 +188,7 @@ class RegisteredCommand
             $this->addSubCommand($baseCommand);
         }
 
-        return $this->subCommands[$baseCommand]->addSubCommand($name, $callback);
+        return $this->subCommands[$baseCommand]->addSubCommand($name, $callback, $autocomplete_callback);
     }
 
     /**

--- a/src/Discord/Parts/Channel/Message.php
+++ b/src/Discord/Parts/Channel/Message.php
@@ -28,53 +28,56 @@ use Discord\Parts\Guild\Guild;
 use Discord\Parts\Guild\Sticker;
 use Discord\Parts\Thread\Thread;
 use Discord\Repository\Channel\ReactionRepository;
-use InvalidArgumentException;
 use React\Promise\ExtendedPromiseInterface;
-use RuntimeException;
 
 use function React\Promise\reject;
 
 /**
  * A message which is posted to a Discord text channel.
  *
+ * @see https://discord.com/developers/docs/resources/channel#message-object
+ *
  * @property string               $id                     The unique identifier of the message.
- * @property Channel|Thread|null  $channel                The channel that the message was sent in.
- * @property Thread|null          $thread                 The thread that the message was sent in.
  * @property string               $channel_id             The unique identifier of the channel that the message was went in.
- * @property string               $guild_id               The unique identifier of the guild that the channel the message was sent in belongs to.
+ * @property Channel|Thread|null  $channel                The channel that the message was sent in.
+ * @property string|null          $guild_id               The unique identifier of the guild that the channel the message was sent in belongs to.
  * @property Guild|null           $guild                  The guild that the message was sent in.
- * @property string               $content                The content of the message if it is a normal message.
- * @property int                  $type                   The type of message.
- * @property Collection|User[]    $mentions               A collection of the users mentioned in the message.
  * @property User|null            $author                 The author of the message. Will be a webhook if sent from one.
- * @property Member|null          $member                 The member that sent this message, or null if it was in a private message.
  * @property string               $user_id                The user id of the author.
- * @property bool                 $mention_everyone       Whether the message contained an @everyone mention.
+ * @property Member|null          $member                 The member that sent this message, or null if it was in a private message.
+ * @property string               $content                The content of the message if it is a normal message.
  * @property Carbon               $timestamp              A timestamp of when the message was sent.
  * @property Carbon|null          $edited_timestamp       A timestamp of when the message was edited, or null.
  * @property bool                 $tts                    Whether the message was sent as a text-to-speech message.
- * @property array                $attachments            An array of attachment objects.
- * @property Collection|Embed[]   $embeds                 A collection of embed objects.
- * @property string|null          $nonce                  A randomly generated string that provides verification for the client. Not required.
+ * @property bool                 $mention_everyone       Whether the message contained an @everyone mention.
+ * @property Collection|User[]    $mentions               A collection of the users mentioned in the message.
  * @property Collection|Role[]    $mention_roles          A collection of roles that were mentioned in the message.
- * @property bool                 $pinned                 Whether the message is pinned to the channel.
  * @property Collection|Channel[] $mention_channels       Collection of mentioned channels.
+ * @property array|null           $attachments            An array of attachment objects.
+ * @property Collection|Embed[]   $embeds                 A collection of embed objects.
  * @property ReactionRepository   $reactions              Collection of reactions on the message.
- * @property string               $webhook_id             ID of the webhook that made the message, if any.
- * @property object               $activity               Current message activity. Requires rich presence.
- * @property object               $application            Application of message. Requires rich presence.
- * @property string               $application_id         If the message is a response to an Interaction, this is the id of the interaction's application.
- * @property object               $message_reference      Message that is referenced by this message.
+ * @property string|null          $nonce                  A randomly generated string that provides verification for the client. Not required.
+ * @property bool                 $pinned                 Whether the message is pinned to the channel.
+ * @property string|null          $webhook_id             ID of the webhook that made the message, if any.
+ * @property int                  $type                   The type of message.
+ * @property object|null          $activity               Current message activity. Requires rich presence.
+ * @property object|null          $application            Application of message. Requires rich presence.
+ * @property string|null          $application_id         If the message is a response to an Interaction, this is the id of the interaction's application.
+ * @property object|null          $message_reference      Message that is referenced by this message.
+ * @property int|null             $flags                  Message flags.
  * @property Message|null         $referenced_message     The message that is referenced in a reply.
- * @property int                  $flags                  Message flags.
+ * @property object|null          $interaction            The interaction which triggered the message (application commands).
+ * @property Thread|null          $thread                 The thread that the message was sent in.
+ * @property array|null           $components             Sent if the message contains components like buttons, action rows, or other interactive components.
+ * @property Collection|Sticker[] $sticker_items          Stickers attached to the message.
  * @property bool                 $crossposted            Message has been crossposted.
  * @property bool                 $is_crosspost           Message is a crosspost from another channel.
  * @property bool                 $suppress_embeds        Do not include embeds when serializing message.
  * @property bool                 $source_message_deleted Source message for this message has been deleted.
  * @property bool                 $urgent                 Message is urgent.
- * @property Collection|Sticker[] $sticker_items          Stickers attached to the message.
- * @property object|null          $interaction            The interaction which triggered the message (slash commands).
- * @property array                $components             Sent if the message contains components like buttons, action rows, or other interactive components.
+ * @property bool                 $has_thread             Whether this message has an associated thread, with the same id as the message.
+ * @property bool                 $ephemeral              Whether this message is only visible to the user who invoked the Interaction.
+ * @property bool                 $loading                Whether this message is an Interaction Response and the bot is "thinking".
  * @property string|null          $link                   Returns a link to the message.
  */
 class Message extends Part
@@ -117,36 +120,36 @@ class Message extends Part
      * @inheritdoc
      */
     protected $fillable = [
-        'id',
-        'channel_id',
-        'guild_id',
-        'content',
-        'type',
-        'mentions',
-        'author',
-        'member',
-        'mention_everyone',
-        'timestamp',
-        'edited_timestamp',
-        'tts',
-        'attachments',
-        'embeds',
-        'nonce',
-        'mention_roles',
-        'pinned',
-        'mention_channels',
         'reactions',
+        'attachments',
+        'tts',
+        'embeds',
+        'timestamp',
+        'mention_everyone',
+        'id',
+        'pinned',
+        'edited_timestamp',
+        'author',
+        'mention_roles',
+        'mention_channels',
+        'content',
+        'channel_id',
+        'mentions',
+        'type',
+        'flags',
+        'message_reference',
+        'nonce',
+        'member',
+        'guild_id',
         'webhook_id',
         'activity',
         'application',
         'application_id',
-        'message_reference',
         'referenced_message',
-        'flags',
-        'sticker_items',
-        'stickers',
         'interaction',
         'components',
+        'sticker_items',
+        'stickers',
     ];
 
     /**
@@ -207,6 +210,36 @@ class Message extends Part
     }
 
     /**
+     * Gets the has thread attribute.
+     *
+     * @return bool
+     */
+    protected function getHasThreadAttribute(): bool
+    {
+        return (bool) ($this->flags & (1 << 5));
+    }
+
+    /**
+     * Gets the ephemeral attribute.
+     *
+     * @return bool
+     */
+    protected function getEphemeralAttribute(): bool
+    {
+        return (bool) ($this->flags & (1 << 6));
+    }
+
+    /**
+     * Gets the loading attribute.
+     *
+     * @return bool
+     */
+    protected function getLoadingAttribute(): bool
+    {
+        return (bool) ($this->flags & (1 << 7));
+    }
+
+    /**
      * Gets the mention_channels attribute.
      *
      * @return Collection|Channel[]
@@ -255,6 +288,10 @@ class Message extends Part
      */
     protected function getChannelAttribute(): Part
     {
+        if ($this->guild && $channel = $this->guild->channels->offsetGet($this->channel_id)) {
+            return $channel;
+        }
+
         if ($channel = $this->discord->getChannel($this->channel_id)) {
             return $channel;
         }
@@ -339,7 +376,7 @@ class Message extends Part
     /**
      * Returns the `user_id` attribute.
      *
-     * @return string
+     * @return string|null
      */
     protected function getUserIdAttribute(): ?string
     {
@@ -363,7 +400,7 @@ class Message extends Part
 
         return null;
     }
-    
+
     /**
      * Returns the member attribute.
      *
@@ -435,7 +472,7 @@ class Message extends Part
      */
     protected function getTimestampAttribute(): ?Carbon
     {
-        if ($this->attributes['timestamp'] ?? null) {
+        if (isset($this->attributes['timestamp'])) {
             return new Carbon($this->attributes['timestamp']);
         }
 
@@ -449,7 +486,7 @@ class Message extends Part
      */
     protected function getEditedTimestampAttribute(): ?Carbon
     {
-        if ($this->attributes['edited_timestamp'] ?? null) {
+        if (isset($this->attributes['edited_timestamp'])) {
             return new Carbon($this->attributes['edited_timestamp']);
         }
 
@@ -471,17 +508,19 @@ class Message extends Part
 
         return $sticker_items;
     }
-    
+
     /**
      * Returns the message link attribute.
      *
-     * @return String|null
+     * @return string|null
      */
     public function getLinkAttribute(): ?string
     {
         if ($this->id && $this->channel_id) {
             return 'https://discord.com/channels/'.($this->guild_id ?? '@me').'/'.$this->channel_id.'/'.$this->id;
         }
+
+        return null;
     }
 
     /**
@@ -491,27 +530,30 @@ class Message extends Part
      * @param int         $auto_archive_duration Number of minutes of inactivity until the thread is auto-archived. One of 60, 1440, 4320, 10080.
      * @param string|null $reason                Reason for Audit Log.
      *
+     * @throws \RuntimeException
+     * @throws \UnexpectedValueException
+     *
      * @return ExtendedPromiseInterface<Thread>
      */
     public function startThread(string $name, int $auto_archive_duration = 1440, ?string $reason = null): ExtendedPromiseInterface
     {
         if (! $this->guild) {
-            return reject(new RuntimeException('You can only start threads on guild text channels.'));
+            return reject(new \RuntimeException('You can only start threads on guild text channels.'));
         }
 
         if (! in_array($auto_archive_duration, [60, 1440, 4320, 10080])) {
-            return reject(new InvalidArgumentException('`auto_archive_duration` must be one of 60, 1440, 4320, 10080.'));
+            return reject(new \UnexpectedValueException('`auto_archive_duration` must be one of 60, 1440, 4320, 10080.'));
         }
 
         switch ($auto_archive_duration) {
             case 4320:
                 if (! $this->guild->feature_three_day_thread_archive) {
-                    return reject(new RuntimeException('Guild does not have access to three day thread archive.'));
+                    return reject(new \RuntimeException('Guild does not have access to three day thread archive.'));
                 }
                 break;
             case 10080:
                 if (! $this->guild->feature_seven_day_thread_archive) {
-                    return reject(new RuntimeException('Guild does not have access to seven day thread archive.'));
+                    return reject(new \RuntimeException('Guild does not have access to seven day thread archive.'));
                 }
                 break;
         }
@@ -619,34 +661,30 @@ class Message extends Part
      */
     public function deleteReaction(int $type, $emoticon = null, ?string $id = null): ExtendedPromiseInterface
     {
-        $types = [self::REACT_DELETE_ALL, self::REACT_DELETE_ME, self::REACT_DELETE_ID, self::REACT_DELETE_EMOJI];
-
         if ($emoticon instanceof Emoji) {
             $emoticon = $emoticon->toReactionString();
         } else {
             $emoticon = urlencode($emoticon);
         }
 
-        if (in_array($type, $types)) {
-            switch ($type) {
-                case self::REACT_DELETE_ALL:
-                    $url = Endpoint::bind(Endpoint::MESSAGE_REACTION_ALL, $this->channel_id, $this->id);
-                    break;
-                case self::REACT_DELETE_ME:
-                    $url = Endpoint::bind(Endpoint::OWN_MESSAGE_REACTION, $this->channel_id, $this->id, $emoticon);
-                    break;
-                case self::REACT_DELETE_ID:
-                    $url = Endpoint::bind(Endpoint::USER_MESSAGE_REACTION, $this->channel_id, $this->id, $emoticon, $id);
-                    break;
-                case self::REACT_DELETE_EMOJI:
-                    $url = Endpoint::bind(Endpoint::MESSAGE_REACTION_EMOJI, $this->channel_id, $this->id, $emoticon);
-                    break;
-            }
-
-            return $this->http->delete($url);
+        switch ($type) {
+            case self::REACT_DELETE_ALL:
+                $url = Endpoint::bind(Endpoint::MESSAGE_REACTION_ALL, $this->channel_id, $this->id);
+                break;
+            case self::REACT_DELETE_ME:
+                $url = Endpoint::bind(Endpoint::OWN_MESSAGE_REACTION, $this->channel_id, $this->id, $emoticon);
+                break;
+            case self::REACT_DELETE_ID:
+                $url = Endpoint::bind(Endpoint::USER_MESSAGE_REACTION, $this->channel_id, $this->id, $emoticon, $id);
+                break;
+            case self::REACT_DELETE_EMOJI:
+                $url = Endpoint::bind(Endpoint::MESSAGE_REACTION_EMOJI, $this->channel_id, $this->id, $emoticon);
+                break;
+            default:
+                return reject(new \UnexpectedValueException('Invalid reaction type'));
         }
 
-        return \React\Promise\reject();
+        return $this->http->delete($url);
     }
 
     /**

--- a/src/Discord/Parts/Channel/Reaction.php
+++ b/src/Discord/Parts/Channel/Reaction.php
@@ -26,10 +26,12 @@ use function React\Promise\resolve;
 /**
  * Represents a reaction to a message by members(s).
  *
- * @property string         $id         The identifier of the reaction.
+ * @see https://discord.com/developers/docs/resources/channel#reaction-object
+ *
  * @property int            $count      Number of reactions.
  * @property bool           $me         Whether the current bot has reacted.
  * @property Emoji          $emoji      The emoji that was reacted with.
+ * @property string         $id         The identifier of the reaction.
  * @property string         $message_id The message ID the reaction is for.
  * @property Message|null   $message    The message the reaction is for.
  * @property string         $channel_id The channel ID that the message belongs in.
@@ -158,10 +160,9 @@ class Reaction extends Part
     /**
      * Gets the partial emoji attribute.
      *
-     * @return Emoji
-     * @throws \Exception
+     * @return Emoji|null
      */
-    protected function getEmojiAttribute(): ?Part
+    protected function getEmojiAttribute(): ?Emoji
     {
         if (isset($this->attributes['emoji'])) {
             return $this->factory->create(Emoji::class, $this->attributes['emoji'], true);

--- a/src/Discord/Parts/Channel/StageInstance.php
+++ b/src/Discord/Parts/Channel/StageInstance.php
@@ -17,14 +17,16 @@ use Discord\Parts\Part;
 /**
  * A Stage Instance holds information about a live stage. on a Discord guild.
  *
- * @property string  $id                    The unique identifier of the Stage Instance.
- * @property string  $guild_id              The unique identifier of the guild that the stage instance associated to.
- * @property Guild   $guild                 The guild that the stage instance associated to.
- * @property string  $channel_id            The id of the associated Stage channel.
- * @property Channel $channel               The channel that the stage instance associated to.
- * @property string  $topic                 The topic of the Stage instance (1-120 characters).
- * @property int     $privacy_level         The privacy level of the Stage instance.
- * @property bool    $discoverable_disabled Whether or not Stage Discovery is disabled.
+ * @see https://discord.com/developers/docs/resources/stage-instance#stage-instance-resource
+ *
+ * @property string     $id                    The unique identifier of the Stage Instance.
+ * @property string     $guild_id              The unique identifier of the guild that the stage instance associated to.
+ * @property Guild|null $guild                 The guild that the stage instance associated to.
+ * @property string     $channel_id            The id of the associated Stage channel.
+ * @property Channel    $channel               The channel that the stage instance associated to.
+ * @property string     $topic                 The topic of the Stage instance (1-120 characters).
+ * @property int        $privacy_level         The privacy level of the Stage instance.
+ * @property bool       $discoverable_disabled Whether or not Stage Discovery is disabled.
  */
 class StageInstance extends Part
 {
@@ -46,28 +48,29 @@ class StageInstance extends Part
     /**
      * Returns the guild attribute.
      *
-     * @return Guild The guild attribute.
+     * @return Guild|null The guild attribute.
      */
-    protected function getGuildAttribute(): Guild
+    protected function getGuildAttribute(): ?Guild
     {
-        return $this->discord->guilds->get('id', $this->guild_id);
+        return $this->discord->guilds->offsetGet($this->guild_id);
     }
 
     /**
      * Returns the channel attribute.
      *
-     * @return Channel The Stage channel.
+     * @return Channel|null The Stage channel.
      */
-    protected function getChannelAttribute(): Part
+    protected function getChannelAttribute(): ?Channel
     {
+        if ($this->guild && $channel = $this->guild->channels->offsetGet($this->channel_id)) {
+            return $channel;
+        }
+
         if ($channel = $this->discord->getChannel($this->channel_id)) {
             return $channel;
         }
 
-        return $this->factory->create(Channel::class, [
-            'id' => $this->channel_id,
-            'type' => Channel::TYPE_STAGE_CHANNEL,
-        ], true);
+        return null;
     }
 
     /**

--- a/src/Discord/Parts/Channel/Webhook.php
+++ b/src/Discord/Parts/Channel/Webhook.php
@@ -12,6 +12,7 @@
 namespace Discord\Parts\Channel;
 
 use Discord\Http\Endpoint;
+use Discord\Http\Http;
 use Discord\Parts\Guild\Guild;
 use Discord\Parts\Part;
 use Discord\Parts\User\User;
@@ -118,6 +119,24 @@ class Webhook extends Part
         }
 
         return $this->factory->part(User::class, (array) $this->attributes['user'], true);
+    }
+
+    /**
+     * Gets the webhook url attribute.
+     *
+     * @return string|null
+     */
+    protected function getUrlAttribute(): ?string
+    {
+        if (isset($this->attributes['url'])) {
+            return $this->attributes['url'];
+        }
+
+        if (isset($this->attributes['token'])) {
+            return Http::BASE_URL.'/'.Endpoint::bind(Endpoint::WEBHOOK_TOKEN, $this->id, $this->token);
+        }
+
+        return null;
     }
 
     /**

--- a/src/Discord/Parts/Channel/Webhook.php
+++ b/src/Discord/Parts/Channel/Webhook.php
@@ -107,7 +107,7 @@ class Webhook extends Part
      *
      * @return User|null
      */
-    protected function getUserAttribute(): ?Part
+    protected function getUserAttribute(): ?User
     {
         if (! isset($this->attributes['user'])) {
             return null;
@@ -117,7 +117,7 @@ class Webhook extends Part
             return $user;
         }
 
-        return $this->factory->part(User::class, $this->attributes['user'], true);
+        return $this->factory->part(User::class, (array) $this->attributes['user'], true);
     }
 
     /**

--- a/src/Discord/Parts/Embed/Author.php
+++ b/src/Discord/Parts/Embed/Author.php
@@ -16,6 +16,8 @@ use Discord\Parts\Part;
 /**
  * The author of an embed object.
  *
+ * @see https://discord.com/developers/docs/resources/channel#embed-object-embed-author-structure
+ *
  * @property string      $name           The name of the author.
  * @property string|null $url            The URL to the author.
  * @property string|null $icon_url       The source of the author icon. Must be https.

--- a/src/Discord/Parts/Embed/Embed.php
+++ b/src/Discord/Parts/Embed/Embed.php
@@ -207,7 +207,7 @@ class Embed extends Part
      *
      * @return $this
      */
-    protected function setTitleAttribute(string $title)
+    protected function setTitleAttribute(string $title): self
     {
         if (poly_strlen($title) == 0) {
             $this->attributes['title'] = null;
@@ -229,7 +229,7 @@ class Embed extends Part
      *
      * @return $this
      */
-    public function setTitle(string $title)
+    public function setTitle(string $title): self
     {
         $this->title = $title;
 
@@ -243,7 +243,7 @@ class Embed extends Part
      *
      * @return $this
      */
-    public function setType(string $type)
+    public function setType(string $type): self
     {
         $this->type = $type;
 
@@ -257,7 +257,7 @@ class Embed extends Part
      *
      * @return $this
      */
-    public function setDescription(string $description)
+    public function setDescription(string $description): self
     {
         $this->description = $description;
 
@@ -271,7 +271,7 @@ class Embed extends Part
      *
      * @return $this
      */
-    public function setColor($color)
+    public function setColor($color): self
     {
         $this->color = $color;
 
@@ -335,7 +335,7 @@ class Embed extends Part
      *
      * @return $this
      */
-    public function setAuthor(string $name, string $iconurl = '', string $url = '')
+    public function setAuthor(string $name, string $iconurl = '', string $url = ''): self
     {
         if (poly_strlen($name) === 0) {
             $this->author = null;
@@ -364,7 +364,7 @@ class Embed extends Part
      *
      * @return $this
      */
-    public function setFooter(string $text, string $iconurl = '')
+    public function setFooter(string $text, string $iconurl = ''): self
     {
         if (poly_strlen($text) === 0) {
             $this->footer = null;
@@ -389,7 +389,7 @@ class Embed extends Part
      *
      * @return $this
      */
-    public function setImage($url)
+    public function setImage($url): self
     {
         $this->image = ['url' => (string) $url];
 
@@ -403,7 +403,7 @@ class Embed extends Part
      *
      * @return $this
      */
-    public function setThumbnail($url)
+    public function setThumbnail($url): self
     {
         $this->thumbnail = ['url' => (string) $url];
 
@@ -419,7 +419,7 @@ class Embed extends Part
      *
      * @return $this
      */
-    public function setTimestamp(?int $timestamp = null)
+    public function setTimestamp(?int $timestamp = null): self
     {
         $this->timestamp = (new Carbon(($timestamp !== null ? '@'.$timestamp : 'now')))->format('c');
 
@@ -433,7 +433,7 @@ class Embed extends Part
      *
      * @return $this
      */
-    public function setURL(string $url)
+    public function setURL(string $url): self
     {
         $this->url = $url;
 

--- a/src/Discord/Parts/Embed/Embed.php
+++ b/src/Discord/Parts/Embed/Embed.php
@@ -19,18 +19,18 @@ use function Discord\poly_strlen;
 /**
  * An embed object to be sent with a message.
  *
- * @property string             $title       The title of the embed.
- * @property string             $type        The type of the embed.
- * @property string             $description A description of the embed.
- * @property string             $url         The URL of the embed.
- * @property Carbon|string      $timestamp   A timestamp of the embed.
- * @property int                $color       The color of the embed.
- * @property Footer             $footer      The footer of the embed.
- * @property Image              $image       The image of the embed.
- * @property Image              $thumbnail   The thumbnail of the embed.
- * @property Video              $video       The video of the embed.
- * @property array              $provider    The provider of the embed.
- * @property Author             $author      The author of the embed.
+ * @property string|null        $title       The title of the embed.
+ * @property string|null        $type        The type of the embed.
+ * @property string|null        $description A description of the embed.
+ * @property string|null        $url         The URL of the embed.
+ * @property Carbon|string|null $timestamp   A timestamp of the embed.
+ * @property int|null           $color       The color of the embed.
+ * @property Footer|null        $footer      The footer of the embed.
+ * @property Image|null         $image       The image of the embed.
+ * @property Image|null         $thumbnail   The thumbnail of the embed.
+ * @property Video|null         $video       The video of the embed.
+ * @property object|null        $provider    The provider of the embed.
+ * @property Author|null        $author      The author of the embed.
  * @property Collection|Field[] $fields      A collection of embed fields.
  */
 class Embed extends Part
@@ -165,17 +165,17 @@ class Embed extends Part
      *
      * @param string $description Maximum length is 2048 characters.
      *
-     * @throws \InvalidArgumentException
+     * @throws \LengthException
      */
     protected function setDescriptionAttribute($description)
     {
         if (poly_strlen($description) === 0) {
             $this->attributes['description'] = null;
         } elseif (poly_strlen($description) > 2048) {
-            throw new \InvalidArgumentException('Embed description can not be longer than 2048 characters');
+            throw new \LengthException('Embed description can not be longer than 2048 characters');
         } else {
             if ($this->exceedsOverallLimit(poly_strlen($description))) {
-                throw new \InvalidArgumentException('Embed text values collectively can not exceed than 6000 characters');
+                throw new \LengthException('Embed text values collectively can not exceed than 6000 characters');
             }
 
             $this->attributes['description'] = $description;
@@ -205,16 +205,16 @@ class Embed extends Part
      *
      * @return $this
      *
-     * @throws \InvalidArgumentException
+     * @throws \LengthException
      */
     protected function setTitleAttribute(string $title)
     {
         if (poly_strlen($title) == 0) {
             $this->attributes['title'] = null;
         } elseif (poly_strlen($title) > 256) {
-            throw new \InvalidArgumentException('Embed title can not be longer than 256 characters');
+            throw new \LengthException('Embed title can not be longer than 256 characters');
         } elseif ($this->exceedsOverallLimit(poly_strlen($title))) {
-            throw new \InvalidArgumentException('Embed text values collectively can not exceed than 6000 characters');
+            throw new \LengthException('Embed text values collectively can not exceed than 6000 characters');
         } else {
             $this->attributes['title'] = $title;
         }
@@ -285,13 +285,13 @@ class Embed extends Part
      *
      * @return $this
      *
-     * @throws \RangeException
+     * @throws \InvalidArgumentException
      */
     public function addField(...$fields): self
     {
         foreach ($fields as $field) {
             if (count($this->fields) > 25) {
-                throw new \RangeException('Embeds can not have more than 25 fields.');
+                throw new \InvalidArgumentException('Embeds can not have more than 25 fields.');
             }
 
             if ($field instanceof Field) {
@@ -313,7 +313,7 @@ class Embed extends Part
      *
      * @return $this
      *
-     * @throws \RangeException
+     * @throws \InvalidArgumentException
      */
     public function addFieldValues(string $name, string $value, bool $inline = false)
     {
@@ -333,16 +333,16 @@ class Embed extends Part
      *
      * @return $this
      *
-     * @throws \InvalidArgumentException
+     * @throws \LengthException
      */
     public function setAuthor(string $name, string $iconurl = '', string $url = '')
     {
         if (poly_strlen($name) === 0) {
             $this->author = null;
         } elseif (poly_strlen($name) > 256) {
-            throw new \InvalidArgumentException('Author name can not be longer than 256 characters.');
+            throw new \LengthException('Author name can not be longer than 256 characters.');
         } elseif ($this->exceedsOverallLimit(poly_strlen($name))) {
-            throw new \InvalidArgumentException('Embed text values collectively can not exceed than 6000 characters');
+            throw new \LengthException('Embed text values collectively can not exceed than 6000 characters');
         } else {
             $this->author = [
                 'name' => $name,
@@ -362,16 +362,16 @@ class Embed extends Part
      *
      * @return $this
      *
-     * @throws \InvalidArgumentException
+     * @throws \LengthException
      */
     public function setFooter(string $text, string $iconurl = '')
     {
         if (poly_strlen($text) === 0) {
             $this->footer = null;
         } elseif (poly_strlen($text) > 2048) {
-            throw new \InvalidArgumentException('Footer text can not be longer than 2048 characters.');
+            throw new \LengthException('Footer text can not be longer than 2048 characters.');
         } elseif ($this->exceedsOverallLimit(poly_strlen($text))) {
-            throw new \InvalidArgumentException('Embed text values collectively can not exceed than 6000 characters');
+            throw new \LengthException('Embed text values collectively can not exceed than 6000 characters');
         } else {
             $this->footer = [
                 'text' => $text,

--- a/src/Discord/Parts/Embed/Embed.php
+++ b/src/Discord/Parts/Embed/Embed.php
@@ -203,9 +203,9 @@ class Embed extends Part
      *
      * @param string $title Maximum length is 256 characters.
      *
-     * @return $this
-     *
      * @throws \LengthException
+     *
+     * @return $this
      */
     protected function setTitleAttribute(string $title)
     {
@@ -283,15 +283,15 @@ class Embed extends Part
      *
      * @param Field|array $field
      *
-     * @return $this
+     * @throws \OverflowException
      *
-     * @throws \InvalidArgumentException
+     * @return $this
      */
     public function addField(...$fields): self
     {
         foreach ($fields as $field) {
             if (count($this->fields) > 25) {
-                throw new \InvalidArgumentException('Embeds can not have more than 25 fields.');
+                throw new \OverflowException('Embeds can not have more than 25 fields.');
             }
 
             if ($field instanceof Field) {
@@ -311,9 +311,9 @@ class Embed extends Part
      * @param string $value  Maximum length is 1024 characters.
      * @param bool   $inline Whether this field gets shown with other inline fields on one line.
      *
-     * @return $this
+     * @throws \OverflowException
      *
-     * @throws \InvalidArgumentException
+     * @return $this
      */
     public function addFieldValues(string $name, string $value, bool $inline = false)
     {
@@ -331,9 +331,9 @@ class Embed extends Part
      * @param string $iconurl The URL to the icon.
      * @param string $url     The URL to the author.
      *
-     * @return $this
-     *
      * @throws \LengthException
+     *
+     * @return $this
      */
     public function setAuthor(string $name, string $iconurl = '', string $url = '')
     {
@@ -360,9 +360,9 @@ class Embed extends Part
      * @param string $text    Maximum length is 2048 characters.
      * @param string $iconurl The URL to the icon.
      *
-     * @return $this
-     *
      * @throws \LengthException
+     *
+     * @return $this
      */
     public function setFooter(string $text, string $iconurl = '')
     {
@@ -415,9 +415,9 @@ class Embed extends Part
      *
      * @param int|null $timestamp
      *
-     * @return $this
-     *
      * @throws \Exception
+     *
+     * @return $this
      */
     public function setTimestamp(?int $timestamp = null)
     {
@@ -470,9 +470,9 @@ class Embed extends Part
      *
      * @param array|int|string $color
      *
-     * @return int
-     *
      * @throws \InvalidArgumentException
+     *
+     * @return int
      */
     protected static function resolveColor($color)
     {
@@ -497,8 +497,9 @@ class Embed extends Part
      * @param string $key   The attribute key.
      * @param string $class The attribute class.
      *
-     * @return mixed
      * @throws \Exception
+     *
+     * @return mixed
      */
     private function attributeHelper($key, $class)
     {

--- a/src/Discord/Parts/Embed/Field.php
+++ b/src/Discord/Parts/Embed/Field.php
@@ -16,6 +16,8 @@ use Discord\Parts\Part;
 /**
  * A field of an embed object.
  *
+ * @see https://discord.com/developers/docs/resources/channel#embed-object-embed-field-structure
+ *
  * @property string $name   The name of the field.
  * @property string $value  The value of the field.
  * @property bool   $inline Whether the field should be displayed in-line.

--- a/src/Discord/Parts/Embed/Footer.php
+++ b/src/Discord/Parts/Embed/Footer.php
@@ -16,6 +16,8 @@ use Discord\Parts\Part;
 /**
  * The footer section of an embed.
  *
+ * @see https://discord.com/developers/docs/resources/channel#embed-object-embed-footer-structure
+ *
  * @property string      $text           Footer text.
  * @property string|null $icon_url       URL of an icon for the footer. Must be https.
  * @property string|null $proxy_icon_url Proxied version of the icon URL.

--- a/src/Discord/Parts/Embed/Image.php
+++ b/src/Discord/Parts/Embed/Image.php
@@ -16,6 +16,9 @@ use Discord\Parts\Part;
 /**
  * An image for an embed.
  *
+ * @see https://discord.com/developers/docs/resources/channel#embed-object-embed-image-structure
+ * @see https://discord.com/developers/docs/resources/channel#embed-object-embed-thumbnail-structure
+ *
  * @property string      $url       The source of the image. Must be https.
  * @property string|null $proxy_url A proxied version of the image.
  * @property int|null    $height    The height of the image.

--- a/src/Discord/Parts/Embed/Video.php
+++ b/src/Discord/Parts/Embed/Video.php
@@ -16,6 +16,8 @@ use Discord\Parts\Part;
 /**
  * A video for an embed.
  *
+ * @see https://discord.com/developers/docs/resources/channel#embed-object-embed-video-structure
+ *
  * @property string|null $url       The source of the video.
  * @property string|null $proxy_url A proxied url of the video.
  * @property int|null    $height    The height of the video.

--- a/src/Discord/Parts/Guild/AuditLog/AuditLog.php
+++ b/src/Discord/Parts/Guild/AuditLog/AuditLog.php
@@ -18,20 +18,21 @@ use Discord\Parts\Guild\ScheduledEvent;
 use Discord\Parts\Part;
 use Discord\Parts\Thread\Thread;
 use Discord\Parts\User\User;
-use InvalidArgumentException;
 use ReflectionClass;
 
 /**
  * Represents an audit log query from a guild.
  *
- * @property string               $guild_id
- * @property Guild                $guild
- * @property Collection|Webhook[] $webhooks
- * @property Collection|User[]    $users
- * @property Collection|Entry[]   $audit_log_entries
- * @property Collection           $integrations
- * @property Collection|GuildScheduledEvent[] $guild_scheduled_events
- * @property Collection|Threads[] $threads
+ * @see https://discord.com/developers/docs/resources/audit-log#audit-log-object
+ *
+ * @property Collection|Entry[]               $audit_log_entries      List of audit log entries.
+ * @property Collection|GuildScheduledEvent[] $guild_scheduled_events List of guild scheduled events found in the audit log.
+ * @property Collection                       $integrations           List of partial integration objects.
+ * @property Collection|Threads[]             $threads                List of threads found in the audit log.
+ * @property Collection|User[]                $users                  List of users found in the audit log.
+ * @property Collection|Webhook[]             $webhooks               List of webhooks found in the audit log.
+ * @property string                           $guild_id
+ * @property Guild                            $guild
  */
 class AuditLog extends Part
 {
@@ -39,13 +40,13 @@ class AuditLog extends Part
      * @inheritdoc
      */
     protected $fillable = [
-        'guild_id',
         'webhooks',
+        'guild_scheduled_events',
         'users',
         'audit_log_entries',
         'integrations',
-        'guild_scheduled_events',
         'threads',
+        'guild_id',
     ];
 
     /**
@@ -69,6 +70,22 @@ class AuditLog extends Part
 
         foreach ($this->attributes['webhooks'] ?? [] as $webhook) {
             $collection->push($this->factory->create(Webhook::class, $webhook, true));
+        }
+
+        return $collection;
+    }
+
+    /**
+     * Returns a collection of guild scheduled events found in the audit log.
+     *
+     * @return Collection|ScheduledEvent[]
+     */
+    protected function getGuildScheduledEventsAttribute(): Collection
+    {
+        $collection = Collection::for(ScheduledEvent::class);
+
+        foreach ($this->attributes['guild_scheduled_events'] ?? [] as $scheduled_event) {
+            $collection->push($this->factory->create(ScheduledEvent::class, $scheduled_event, true));
         }
 
         return $collection;
@@ -121,22 +138,6 @@ class AuditLog extends Part
     }
 
     /**
-     * Returns a collection of guild scheduled events found in the audit log.
-     *
-     * @return Collection|ScheduledEvent[]
-     */
-    protected function getGuildScheduledEventsAttribute(): Collection
-    {
-        $collection = Collection::for(ScheduledEvent::class);
-
-        foreach ($this->attributes['guild_scheduled_events'] ?? [] as $scheduled_event) {
-            $collection->push($this->factory->create(ScheduledEvent::class, $scheduled_event, true));
-        }
-
-        return $collection;
-    }
-
-    /**
      * Returns a collection of threads found in the audit log.
      *
      * @return Collection|Thread[]
@@ -164,7 +165,7 @@ class AuditLog extends Part
         $types = array_values((new ReflectionClass(Entry::class))->getConstants());
 
         if (! in_array($action_type, $types)) {
-            throw new InvalidArgumentException("The given action type `{$action_type}` is not valid.");
+            throw new \InvalidArgumentException("The given action type `{$action_type}` is not valid.");
         }
 
         return $this->audit_log_entries->filter(function (Entry $entry) use ($action_type) {

--- a/src/Discord/Parts/Guild/AuditLog/AuditLog.php
+++ b/src/Discord/Parts/Guild/AuditLog/AuditLog.php
@@ -158,6 +158,8 @@ class AuditLog extends Part
      *
      * @param int $action_type
      *
+     * @throws \InvalidArgumentException
+     *
      * @return Collection|Entry[]
      */
     public function searchByType(int $action_type): Collection

--- a/src/Discord/Parts/Guild/AuditLog/Entry.php
+++ b/src/Discord/Parts/Guild/AuditLog/Entry.php
@@ -18,14 +18,16 @@ use Discord\Parts\User\User;
 /**
  * Represents an entry in the audit log.
  *
- * @property string     $id
- * @property string     $user_id
- * @property User       $user
- * @property string     $target_id
- * @property int        $action_type
- * @property Collection $changes
- * @property Options    $options
- * @property string     $reason
+ * @see https://discord.com/developers/docs/resources/audit-log#audit-log-entry-object
+ *
+ * @property string       $target_id   Id of the affected entity (webhook, user, role, etc.).
+ * @property Collection   $changes     Changes made to the target_id.
+ * @property string|null  $user_id     The user who made the changes.
+ * @property User|null    $user
+ * @property string       $id          Id of the entry.
+ * @property int          $action_type Type of action that occurred.
+ * @property Options|null $options     Additional info for certain action types.
+ * @property string|null  $reason      The reason for the change (0-512 characters).
  */
 class Entry extends Part
 {
@@ -83,11 +85,11 @@ class Entry extends Part
      * @inheritdoc
      */
     protected $fillable = [
-        'id',
-        'user_id',
         'target_id',
-        'action_type',
         'changes',
+        'user_id',
+        'id',
+        'action_type',
         'options',
         'reason',
     ];

--- a/src/Discord/Parts/Guild/AuditLog/Options.php
+++ b/src/Discord/Parts/Guild/AuditLog/Options.php
@@ -20,14 +20,14 @@ use Discord\Parts\Part;
  *
  * @see https://discord.com/developers/docs/resources/audit-log#audit-log-entry-object-optional-audit-entry-info
  *
- * @property string $delete_member_days
- * @property string $members_removed
- * @property string $channel_id
- * @property string $message_id
- * @property string $count
- * @property string $id
- * @property string $type
- * @property string $role_name
+ * @property string $channel_id         Channel in which the entities were targeted.
+ * @property string $count              Number of entities that were targeted.
+ * @property string $delete_member_days Number of days after which inactive members were kicked.
+ * @property string $id                 Id of the overwritten entity.
+ * @property string $members_removed    Number of members removed by the prune.
+ * @property string $message_id         Id of the message that was targeted.
+ * @property string $role_name          Name of the role if type is "0" (not present if type is "1").
+ * @property string $type               Type of overwritten entity - "0" for "role" or "1" for "member".
  */
 class Options extends Part
 {

--- a/src/Discord/Parts/Guild/Ban.php
+++ b/src/Discord/Parts/Guild/Ban.php
@@ -17,18 +17,20 @@ use Discord\Parts\User\User;
 /**
  * A Ban is a ban on a user specific to a guild. It is also IP based.
  *
- * @property string $guild_id
- * @property Guild  $guild
- * @property string $user_id
- * @property User   $user
- * @property string $reason
+ * @see https://discord.com/developers/docs/resources/guild#ban-object
+ *
+ * @property string     $reason   The reason for the ban.
+ * @property User       $user     The banned user.
+ * @property string     $guild_id
+ * @property Guild|null $guild
+ * @property string     $user_id
  */
 class Ban extends Part
 {
     /**
      * @inheritdoc
      */
-    protected $fillable = ['user_id', 'user', 'guild_id', 'reason'];
+    protected $fillable = ['reason', 'user', 'user_id', 'guild_id'];
 
     /**
      * Returns the user id of the ban.
@@ -51,7 +53,7 @@ class Ban extends Part
     /**
      * Returns the guild attribute of the ban.
      *
-     * @return Guild
+     * @return Guild|null
      */
     protected function getGuildAttribute(): ?Guild
     {

--- a/src/Discord/Parts/Guild/Ban.php
+++ b/src/Discord/Parts/Guild/Ban.php
@@ -21,9 +21,9 @@ use Discord\Parts\User\User;
  *
  * @property string     $reason   The reason for the ban.
  * @property User       $user     The banned user.
+ * @property string     $user_id
  * @property string     $guild_id
  * @property Guild|null $guild
- * @property string     $user_id
  */
 class Ban extends Part
 {
@@ -65,27 +65,17 @@ class Ban extends Part
      *
      * @return User
      */
-    protected function getUserAttribute(): ?Part
+    protected function getUserAttribute(): User
     {
         if (isset($this->attributes['user_id'])) {
             return $this->discord->users->get('id', $this->attributes['user_id']);
-        } elseif (isset($this->attributes['user'])) {
-            if ($user = $this->discord->users->get('id', $this->attributes['user']->id)) {
-                return $user;
-            }
-
-            return $this->factory->part(User::class, (array) $this->attributes['user'], true);
+        }
+        
+        if ($user = $this->discord->users->get('id', $this->attributes['user']->id)) {
+            return $user;
         }
 
-        return null;
-    }
-
-    /**
-     * @inheritdoc
-     */
-    public function getCreatableAttributes(): array
-    {
-        return [];
+        return $this->factory->part(User::class, (array) $this->attributes['user'], true);
     }
 
     /**

--- a/src/Discord/Parts/Guild/Emoji.php
+++ b/src/Discord/Parts/Guild/Emoji.php
@@ -19,21 +19,21 @@ use Discord\Parts\Part;
  *
  * @property string            $id             The identifier for the emoji.
  * @property string            $name           The name of the emoji.
- * @property Guild             $guild          The guild that owns the emoji.
- * @property string            $guild_id       The identifier of the guild that owns the emoji.
- * @property bool              $managed        Whether this emoji is managed by a role.
- * @property bool              $require_colons Whether the emoji requires colons to be triggered.
  * @property Collection|Role[] $roles          The roles that are allowed to use the emoji.
  * @property User|null         $user           user that created this emoji.
+ * @property bool              $require_colons Whether the emoji requires colons to be triggered.
+ * @property bool              $managed        Whether this emoji is managed by a role.
  * @property bool              $animated       Whether the emoji is animated.
  * @property bool              $available      Whether this emoji can be used, may be false due to loss of Server Boosts.
+ * @property string|null       $guild_id       The identifier of the guild that owns the emoji.
+ * @property Guild|null        $guild          The guild that owns the emoji.
  */
 class Emoji extends Part
 {
     /**
      * @inheritdoc
      */
-    protected $fillable = ['id', 'name', 'guild_id', 'managed', 'require_colons', 'roles', 'user', 'animated', 'available'];
+    protected $fillable = ['id', 'name', 'roles', 'user', 'require_colons', 'managed', 'animated', 'available', 'guild_id'];
 
     /**
      * Returns the guild attribute.

--- a/src/Discord/Parts/Guild/Emoji.php
+++ b/src/Discord/Parts/Guild/Emoji.php
@@ -13,14 +13,17 @@ namespace Discord\Parts\Guild;
 
 use Discord\Helpers\Collection;
 use Discord\Parts\Part;
+use Discord\Parts\User\User;
 
 /**
  * An emoji object represents a custom emoji.
  *
+ * @see https://discord.com/developers/docs/resources/emoji
+ *
  * @property string            $id             The identifier for the emoji.
  * @property string            $name           The name of the emoji.
  * @property Collection|Role[] $roles          The roles that are allowed to use the emoji.
- * @property User|null         $user           user that created this emoji.
+ * @property User|null         $user           User that created this emoji.
  * @property bool              $require_colons Whether the emoji requires colons to be triggered.
  * @property bool              $managed        Whether this emoji is managed by a role.
  * @property bool              $animated       Whether the emoji is animated.
@@ -33,12 +36,22 @@ class Emoji extends Part
     /**
      * @inheritdoc
      */
-    protected $fillable = ['id', 'name', 'roles', 'user', 'require_colons', 'managed', 'animated', 'available', 'guild_id'];
+    protected $fillable = [
+        'id', 
+        'name', 
+        'roles', 
+        'user', 
+        'require_colons', 
+        'managed', 
+        'animated', 
+        'available', 
+        'guild_id'
+    ];
 
     /**
      * Returns the guild attribute.
      *
-     * @return Guild The guild the emoji belongs to.
+     * @return Guild|null The guild the emoji belongs to.
      */
     protected function getGuildAttribute(): ?Guild
     {
@@ -66,7 +79,7 @@ class Emoji extends Part
      *
      * @return User|null
      */
-    protected function getUserAttribute(): ?Part
+    protected function getUserAttribute(): ?User
     {
         if (! isset($this->attributes['user'])) {
             return null;
@@ -76,7 +89,7 @@ class Emoji extends Part
             return $user;
         }
 
-        return $this->factory->part(User::class, $this->attributes['user'], true);
+        return $this->factory->part(User::class, (array) $this->attributes['user'], true);
     }
 
     /**
@@ -105,14 +118,6 @@ class Emoji extends Part
         }
 
         return $this->name;
-    }
-
-    /**
-     * @inheritdoc
-     */
-    public function getCreatableAttributes(): array
-    {
-        return [];
     }
 
     /**

--- a/src/Discord/Parts/Guild/Emoji.php
+++ b/src/Discord/Parts/Guild/Emoji.php
@@ -111,7 +111,7 @@ class Emoji extends Part
      *
      * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         if ($this->id) {
             return '<'.($this->animated ? 'a' : '').$this->toReactionString().'>';

--- a/src/Discord/Parts/Guild/GuildTemplate.php
+++ b/src/Discord/Parts/Guild/GuildTemplate.php
@@ -69,15 +69,14 @@ class GuildTemplate extends Part
      * Returns the source guild attribute.
      *
      * @return Guild      The guild snapshot this template contains.
-     * @throws \Exception
      */
-    protected function getSourceGuildAttribute(): ?Guild
+    protected function getSourceGuildAttribute(): Guild
     {
-        if (isset($this->attributes['serialized_source_guild']) && $guild = $this->discord->guilds->get('id', $this->attributes['source_guild_id'])) {
+        if ($guild = $this->discord->guilds->offsetGet($this->source_guild_id)) {
             return $guild;
         }
 
-        return $this->factory->create(Guild::class, $this->attributes['serialized_source_guild'] ?? [], true);
+        return $this->factory->part(Guild::class, (array) $this->attributes['serialized_source_guild'], true);
     }
 
     /**
@@ -87,7 +86,7 @@ class GuildTemplate extends Part
      */
     protected function getCreatorAttribute(): Part
     {
-        if ($creator = $this->discord->users->get('id', $this->attributes['creator_id'])) {
+        if ($creator = $this->discord->users->offsetGet($this->creator_id)) {
             return $creator;
         }
 

--- a/src/Discord/Parts/Guild/GuildTemplate.php
+++ b/src/Discord/Parts/Guild/GuildTemplate.php
@@ -121,8 +121,8 @@ class GuildTemplate extends Part
      * Creates a guild from this template. Can be used only by bots in less than 10 guilds.
      *
      * @param array       $options An array of options.
-     * @param string      $options ['name'] The name of the guild (2-100 characters).
-     * @param string|null $options ['icon'] The base64 128x128 image for the guild icon.
+     * @param string      $options['name'] The name of the guild (2-100 characters).
+     * @param string|null $options['icon'] The base64 128x128 image for the guild icon.
      *
      * @return ExtendedPromiseInterface<Guild>
      */

--- a/src/Discord/Parts/Guild/GuildTemplate.php
+++ b/src/Discord/Parts/Guild/GuildTemplate.php
@@ -97,6 +97,7 @@ class GuildTemplate extends Part
      * Returns the created at attribute.
      *
      * @return Carbon     The time that the guild template was created.
+     *
      * @throws \Exception
      */
     protected function getCreatedAtAttribute(): Carbon
@@ -108,6 +109,7 @@ class GuildTemplate extends Part
      * Returns the updated at attribute.
      *
      * @return Carbon     The time that the guild template was updated.
+     *
      * @throws \Exception
      */
     protected function getUpdatedAtAttribute(): Carbon

--- a/src/Discord/Parts/Guild/Invite.php
+++ b/src/Discord/Parts/Guild/Invite.php
@@ -85,7 +85,7 @@ class Invite extends Part
     public function accept(): ExtendedPromiseInterface
     {
         if ($this->uses >= $this->max_uses) {
-            return \React\Promise\reject(new \Exception('This invite has been used the max times.'));
+            return \React\Promise\reject(new \RuntimeException('This invite has been used the max times.'));
         }
 
         return $this->http->post(Endpoint::bind(Endpoint::INVITE, $this->code));

--- a/src/Discord/Parts/Guild/Invite.php
+++ b/src/Discord/Parts/Guild/Invite.php
@@ -21,25 +21,27 @@ use React\Promise\ExtendedPromiseInterface;
 /**
  * An invite to a Channel and Guild.
  *
- * @property string      $code                       The invite code.
- * @property Guild|null  $guild                      The guild that the invite is for.
- * @property string|null $guild_id
- * @property Channel     $channel                    The channel that the invite is for.
- * @property string|null $channel_id
- * @property User|null   $inviter                    The user that created the invite.
- * @property int|null    $target_type                The type of target for this voice channel invite.
- * @property User|null   $target_user                The user whose stream to display for this voice channel stream invite.
- * @property object|null $target_application         The embedded application to open for this voice channel embedded application invite.
- * @property int|null    $approximate_presence_count Approximate count of online members, returned from the GET /invites/<code> endpoint when with_counts is true.
- * @property int|null    $approximate_member_count   Approximate count of total members, returned from the GET /invites/<code> endpoint when with_counts is true.
- * @property Carbon|null $expires_at                 The expiration date of this invite, returned from the GET /invites/<code> endpoint when with_expiration is true.
- * @property object|null $stage_instance             Stage instance data if there is a public Stage instance in the Stage channel this invite is for.
- * @property object|null $guild_scheduled_event      Guild scheduled event data, only included if guild_scheduled_event_id contains a valid guild scheduled event id.
- * @property int         $uses                       How many times the invite has been used.
- * @property int         $max_uses                   How many times the invite can be used.
- * @property int         $max_age                    How many seconds the invite will be alive.
- * @property bool        $temporary                  Whether the invite is for temporary membership.
- * @property Carbon      $created_at                 A timestamp of when the invite was created.
+ * @see https://discord.com/developers/docs/resources/invite
+ *
+ * @property string              $code                       The invite code.
+ * @property Guild|null          $guild                      The guild that the invite is for.
+ * @property string|null         $guild_id
+ * @property Channel             $channel                    The channel that the invite is for.
+ * @property string|null         $channel_id
+ * @property User|null           $inviter                    The user that created the invite.
+ * @property int|null            $target_type                The type of target for this voice channel invite.
+ * @property User|null           $target_user                The user whose stream to display for this voice channel stream invite.
+ * @property object|null         $target_application         The embedded application to open for this voice channel embedded application invite.
+ * @property int|null            $approximate_presence_count Approximate count of online members, returned from the GET /invites/<code> endpoint when with_counts is true.
+ * @property int|null            $approximate_member_count   Approximate count of total members, returned from the GET /invites/<code> endpoint when with_counts is true.
+ * @property Carbon|null         $expires_at                 The expiration date of this invite, returned from the GET /invites/<code> endpoint when with_expiration is true.
+ * @property object|null         $stage_instance             Stage instance data if there is a public Stage instance in the Stage channel this invite is for.
+ * @property ScheduledEvent|null $guild_scheduled_event      Guild scheduled event data, only included if guild_scheduled_event_id contains a valid guild scheduled event id.
+ * @property int                 $uses                       How many times the invite has been used.
+ * @property int                 $max_uses                   How many times the invite can be used.
+ * @property int                 $max_age                    How many seconds the invite will be alive.
+ * @property bool                $temporary                  Whether the invite is for temporary membership.
+ * @property Carbon              $created_at                 A timestamp of when the invite was created.
  */
 class Invite extends Part
 {
@@ -176,8 +178,6 @@ class Invite extends Part
     /**
      * Returns the inviter attribute.
      *
-     * @throws \Exception
-     *
      * @return User|null The User that invited you.
      */
     protected function getInviterAttribute(): ?User
@@ -186,11 +186,11 @@ class Invite extends Part
             return null;
         }
 
-        if ($user = $this->discord->users->get('id', $this->attributes['inviter']->id ?? null)) {
+        if ($user = $this->discord->users->get('id', $this->attributes['inviter']->id)) {
             return $user;
         }
 
-        return $this->factory->create(User::class, $this->attributes['inviter'], true);
+        return $this->factory->part(User::class, (array) $this->attributes['inviter'], true);
     }
 
     /**
@@ -218,11 +218,11 @@ class Invite extends Part
             return null;
         }
 
-        if ($user = $this->discord->users->get('id', $this->attributes['target_user']->id ?? null)) {
+        if ($user = $this->discord->users->get('id', $this->attributes['target_user']->id)) {
             return $user;
         }
 
-        return $this->factory->create(User::class, $this->attributes['target_user'], true);
+        return $this->factory->part(User::class, (array) $this->attributes['target_user'], true);
     }
 
     /**
@@ -239,6 +239,24 @@ class Invite extends Part
         }
 
         return new Carbon($this->attributes['expires_at']);
+    }
+
+    /**
+     * Returns the guild scheduled event on this invite.
+     *
+     * @return ScheduledEvent|null The guild scheduled event data.
+     */
+    protected function getGuildScheduledEventAttribute(): ?ScheduledEvent
+    {
+        if (! isset($this->attributes['guild_scheduled_event'])) {
+            return null;
+        }
+
+        if ($this->guild && $scheduled_event = $this->guild->guild_scheduled_events->get('id', $this->attributes['guild_scheduled_event']->id)) {
+            return $scheduled_event;
+        }
+
+        return $this->factory->part(ScheduledEvent::class, (array) $this->attributes['guild_scheduled_event'], true);
     }
 
     /**

--- a/src/Discord/Parts/Guild/Invite.php
+++ b/src/Discord/Parts/Guild/Invite.php
@@ -126,7 +126,7 @@ class Invite extends Part
             return null;
         }
 
-        return $this->factory->create(Guild::class, $this->attributes['guild'], true);
+        return $this->factory->part(Guild::class, (array) $this->attributes['guild'], true);
     }
 
     /**

--- a/src/Discord/Parts/Guild/Invite.php
+++ b/src/Discord/Parts/Guild/Invite.php
@@ -22,7 +22,7 @@ use React\Promise\ExtendedPromiseInterface;
  * An invite to a Channel and Guild.
  *
  * @property string      $code                       The invite code.
- * @property Guild       $guild                      The guild that the invite is for.
+ * @property Guild|null  $guild                      The guild that the invite is for.
  * @property string|null $guild_id
  * @property Channel     $channel                    The channel that the invite is for.
  * @property string|null $channel_id
@@ -112,8 +112,9 @@ class Invite extends Part
     /**
      * Returns the guild attribute.
      *
-     * @return Guild      The Guild that you have been invited to.
      * @throws \Exception
+     *
+     * @return Guild|null The Guild that you have been invited to.
      */
     protected function getGuildAttribute(): ?Guild
     {
@@ -121,7 +122,11 @@ class Invite extends Part
             return $guild;
         }
 
-        return $this->factory->create(Guild::class, $this->attributes['guild'] ?? [], true);
+        if (! isset($this->attributes['guild'])) {
+            return null;
+        }
+
+        return $this->factory->create(Guild::class, $this->attributes['guild'], true);
     }
 
     /**
@@ -141,8 +146,9 @@ class Invite extends Part
     /**
      * Returns the channel attribute.
      *
-     * @return Channel    The Channel that you have been invited to.
      * @throws \Exception
+     *
+     * @return Channel    The Channel that you have been invited to.
      */
     protected function getChannelAttribute(): ?Channel
     {
@@ -170,12 +176,17 @@ class Invite extends Part
     /**
      * Returns the inviter attribute.
      *
-     * @return User       The User that invited you.
      * @throws \Exception
+     *
+     * @return User|null The User that invited you.
      */
-    protected function getInviterAttribute(): User
+    protected function getInviterAttribute(): ?User
     {
-        if (isset($this->attributes['inviter']) && $user = $this->discord->users->get('id', $this->attributes['inviter']->id ?? null)) {
+        if (! isset($this->attributes['inviter'])) {
+            return null;
+        }
+
+        if ($user = $this->discord->users->get('id', $this->attributes['inviter']->id ?? null)) {
             return $user;
         }
 
@@ -185,8 +196,9 @@ class Invite extends Part
     /**
      * Returns the created at attribute.
      *
-     * @return Carbon     The time that the invite was created.
      * @throws \Exception
+     *
+     * @return Carbon     The time that the invite was created.
      */
     protected function getCreatedAtAttribute(): Carbon
     {
@@ -196,8 +208,9 @@ class Invite extends Part
     /**
      * Returns the target user attribute.
      *
-     * @return User|null  The user whose stream to display for this voice channel stream invite.
      * @throws \Exception
+     *
+     * @return User|null  The user whose stream to display for this voice channel stream invite.
      */
     protected function getTargetUserAttribute(): ?User
     {
@@ -215,8 +228,9 @@ class Invite extends Part
     /**
      * Returns the expires at attribute.
      *
-     * @return Carbon|null The time that the invite was created.
      * @throws \Exception
+     *
+     * @return Carbon|null The time that the invite was created.
      */
     protected function getExpiresAtAttribute(): ?Carbon
     {
@@ -225,14 +239,6 @@ class Invite extends Part
         }
 
         return new Carbon($this->attributes['expires_at']);
-    }
-
-    /**
-     * @inheritdoc
-     */
-    public function getCreatableAttributes(): array
-    {
-        return [];
     }
 
     /**

--- a/src/Discord/Parts/Guild/Invite.php
+++ b/src/Discord/Parts/Guild/Invite.php
@@ -128,7 +128,11 @@ class Invite extends Part
             return null;
         }
 
-        return $this->factory->part(Guild::class, (array) $this->attributes['guild'], true);
+        if ($guild = $this->discord->guilds->get('id', $this->attributes['guild']->id)) {
+            return $guild;
+        }
+
+        return $this->factory->create(Guild::class, $this->attributes['guild'], true);
     }
 
     /**
@@ -178,6 +182,8 @@ class Invite extends Part
     /**
      * Returns the inviter attribute.
      *
+     * @throws \Exception
+     *
      * @return User|null The User that invited you.
      */
     protected function getInviterAttribute(): ?User
@@ -190,7 +196,7 @@ class Invite extends Part
             return $user;
         }
 
-        return $this->factory->part(User::class, (array) $this->attributes['inviter'], true);
+        return $this->factory->create(User::class, $this->attributes['inviter'], true);
     }
 
     /**
@@ -222,7 +228,7 @@ class Invite extends Part
             return $user;
         }
 
-        return $this->factory->part(User::class, (array) $this->attributes['target_user'], true);
+        return $this->factory->create(User::class, $this->attributes['target_user'], true);
     }
 
     /**
@@ -256,7 +262,7 @@ class Invite extends Part
             return $scheduled_event;
         }
 
-        return $this->factory->part(ScheduledEvent::class, (array) $this->attributes['guild_scheduled_event'], true);
+        return $this->factory->create(ScheduledEvent::class, $this->attributes['guild_scheduled_event'], true);
     }
 
     /**

--- a/src/Discord/Parts/Guild/Role.php
+++ b/src/Discord/Parts/Guild/Role.php
@@ -20,23 +20,37 @@ use Discord\Parts\Permissions\RolePermission;
  * @property string         $id            The unique identifier of the role.
  * @property string         $name          The name of the role.
  * @property int            $color         The color of the guild.
- * @property bool           $managed       Whether the role is managed by a Twitch subscriber feature.
  * @property bool           $hoist         Whether the role is hoisted on the sidebar.
- * @property int            $position      The position of the role on the sidebar.
- * @property RolePermission $permissions   The permissions of the role.
  * @property string|null    $icon          The URL to the role icon.
  * @property string|null    $icon_hash     The icon hash for the role.
  * @property string|null    $unicode_emoji The unicode emoji for the role.
+ * @property int            $position      The position of the role on the sidebar.
+ * @property RolePermission $permissions   The permissions of the role.
+ * @property bool           $managed       Whether the role is managed by a Twitch subscriber feature.
  * @property bool           $mentionable   Whether the role is mentionable.
- * @property Guild          $guild         The guild that the role belongs to.
+ * @property object|null    $tags          The tags this role has.
  * @property string         $guild_id      The unique identifier of the guild that the role belongs to.
+ * @property Guild|null     $guild         The guild that the role belongs to.
  */
 class Role extends Part
 {
     /**
      * @inheritdoc
      */
-    protected $fillable = ['id', 'name', 'color', 'managed', 'hoist', 'position', 'permissions', 'icon', 'unicode_emoji', 'mentionable', 'guild_id'];
+    protected $fillable = [
+        'id',
+        'name',
+        'color',
+        'hoist',
+        'icon',
+        'unicode_emoji',
+        'position',
+        'permissions',
+        'managed',
+        'mentionable',
+        'tags',
+        'guild_id',
+    ];
 
     /**
      * @inheritdoc
@@ -51,9 +65,9 @@ class Role extends Part
     /**
      * Gets the guild attribute.
      *
-     * @return Guild The guild attribute.
+     * @return Guild|null The guild attribute.
      */
-    protected function getGuildAttribute(): Guild
+    protected function getGuildAttribute(): ?Guild
     {
         return $this->discord->guilds->get('id', $this->guild_id);
     }
@@ -62,6 +76,7 @@ class Role extends Part
      * Sets the permissions attribute.
      *
      * @param  RolePermission|int $permission The permissions to set.
+     *
      * @throws \Exception
      */
     protected function setPermissionsAttribute($permission): void
@@ -116,7 +131,7 @@ class Role extends Part
         }
 
         $allowed = ['png', 'jpg', 'webp'];
-	
+
         if (! in_array(strtolower($format), $allowed)) {
             $format = 'png';
         }
@@ -141,15 +156,15 @@ class Role extends Part
     {
         return [
             'name' => $this->name,
-            'hoist' => $this->hoist,
-            'color' => $this->color,
             'permissions' => $this->permissions->bitwise,
+            'color' => $this->color,
+            'hoist' => $this->hoist,
             'icon' => $this->attributes['icon'],
             'unicode_emoji' => $this->unicode_emoji,
             'mentionable' => $this->mentionable,
         ];
     }
-    
+
     /**
      * @inheritdoc
      */

--- a/src/Discord/Parts/Guild/Role.php
+++ b/src/Discord/Parts/Guild/Role.php
@@ -180,7 +180,7 @@ class Role extends Part
      *
      * @return string A formatted mention.
      */
-    public function __toString()
+    public function __toString(): string
     {
         return "<@&{$this->id}>";
     }

--- a/src/Discord/Parts/Guild/ScheduledEvent.php
+++ b/src/Discord/Parts/Guild/ScheduledEvent.php
@@ -79,6 +79,8 @@ class ScheduledEvent extends Part
     /**
      * Get a list of guild scheduled event users subscribed to a guild scheduled event. Returns a list of guild scheduled event user objects on success. Guild member data, if it exists, is included if the with_member query parameter is set.
      *
+     * @throws \InvalidArgumentException
+     *
      * @return ExtendedPromiseInterface
      */
     public function getUsers(array $options): ExtendedPromiseInterface
@@ -93,7 +95,7 @@ class ScheduledEvent extends Part
 
         $options = $resolver->resolve($options);
         if (isset($options['before'], $options['after'])) {
-            return \React\Promise\reject(new \Exception('Can only specify one of before after.'));
+            return \React\Promise\reject(new \RangeException('Can only specify one of before after.'));
         }
 
         $endpoint = Endpoint::bind(Endpoint::GUILD_SCHEDULED_EVENT_USERS, $this->guild_id, $this->id);

--- a/src/Discord/Parts/Guild/ScheduledEvent.php
+++ b/src/Discord/Parts/Guild/ScheduledEvent.php
@@ -79,7 +79,7 @@ class ScheduledEvent extends Part
     /**
      * Get a list of guild scheduled event users subscribed to a guild scheduled event. Returns a list of guild scheduled event user objects on success. Guild member data, if it exists, is included if the with_member query parameter is set.
      *
-     * @throws \InvalidArgumentException
+     * @throws \RangeException
      *
      * @return ExtendedPromiseInterface
      */
@@ -183,6 +183,8 @@ class ScheduledEvent extends Part
     /**
      * Gets the user that created the scheduled event.
      *
+     * @throws \Exception
+     *
      * @return User|null The user that created the scheduled event.
      */
     protected function getCreatorAttribute(): ?User
@@ -196,7 +198,7 @@ class ScheduledEvent extends Part
                 return $user;
             }
 
-            return $this->factory->part(User::class, (array) $this->attributes['user'], true);
+            return $this->factory->create(User::class, $this->attributes['user'], true);
         }
 
         return null;

--- a/src/Discord/Parts/Guild/ScheduledEvent.php
+++ b/src/Discord/Parts/Guild/ScheduledEvent.php
@@ -183,8 +183,6 @@ class ScheduledEvent extends Part
     /**
      * Gets the user that created the scheduled event.
      *
-     * @throws \Exception
-     *
      * @return User|null The user that created the scheduled event.
      */
     protected function getCreatorAttribute(): ?User
@@ -193,12 +191,12 @@ class ScheduledEvent extends Part
             return $user;
         }
 
-        if (isset($this->attributes['user'])) {
-            if ($user = $this->discord->users->get('id', $this->attributes['user']->id)) {
+        if (isset($this->attributes['creator'])) {
+            if ($user = $this->discord->users->get('id', $this->attributes['creator']->id)) {
                 return $user;
             }
 
-            return $this->factory->create(User::class, $this->attributes['user'], true);
+            return $this->factory->part(User::class, (array) $this->attributes['creator'], true);
         }
 
         return null;

--- a/src/Discord/Parts/Guild/ScheduledEvent.php
+++ b/src/Discord/Parts/Guild/ScheduledEvent.php
@@ -133,11 +133,7 @@ class ScheduledEvent extends Part
      */
     protected function getGuildAttribute(): ?Guild
     {
-        if (! isset($this->attributes['guild_id'])) {
-            return null;
-        }
-
-        return $this->discord->guilds->offsetGet($this->attributes['guild_id']);
+        return $this->discord->guilds->get('id', $this->attributes['guild_id']);
     }
 
     /**

--- a/src/Discord/Parts/Guild/Sticker.php
+++ b/src/Discord/Parts/Guild/Sticker.php
@@ -45,17 +45,17 @@ class Sticker extends Part
      */
     protected $fillable = [
         'id',
-        'pack_id',
         'name',
-        'description',
         'tags',
         'asset',
         'type',
         'format_type',
+        'description',
+        'pack_id',
+        'sort_value',
         'available',
         'guild_id',
         'user',
-        'sort_value',
     ];
 
     /**

--- a/src/Discord/Parts/Guild/WelcomeScreen.php
+++ b/src/Discord/Parts/Guild/WelcomeScreen.php
@@ -39,7 +39,7 @@ class WelcomeScreen extends Part
         $collection = Collection::for(WelcomeChannel::class, 'channel_id');
 
         foreach ($this->attributes['welcome_channels'] ?? [] as $welcome_channel) {
-            $collection->push($this->factory->create(WelcomeChannel::class, $welcome_channel, true));
+            $collection->push($this->factory->part(WelcomeChannel::class, (array) $welcome_channel, true));
         }
 
         return $collection;

--- a/src/Discord/Parts/Interactions/Command/Choice.php
+++ b/src/Discord/Parts/Interactions/Command/Choice.php
@@ -64,6 +64,7 @@ class Choice extends Part
         }
 
         $this->name = $name;
+
         return $this;
     }
 
@@ -83,6 +84,7 @@ class Choice extends Part
         }
 
         $this->value = $value;
+
         return $this;
     }
 }

--- a/src/Discord/Parts/Interactions/Command/Choice.php
+++ b/src/Discord/Parts/Interactions/Command/Choice.php
@@ -54,7 +54,7 @@ class Choice extends Part
      *
      * @return $this
      */
-    public function setName(string $name)
+    public function setName(string $name): self
     {
         $namelen = poly_strlen($name);
         if ($namelen < 1) {
@@ -77,7 +77,7 @@ class Choice extends Part
      *
      * @return $this
      */
-    public function setValue($value)
+    public function setValue($value): self
     {
         if (is_string($value) && poly_strlen($value) > 100) {
             throw new \LengthException('Choice value must be less than or equal to 100 characters.');

--- a/src/Discord/Parts/Interactions/Command/Choice.php
+++ b/src/Discord/Parts/Interactions/Command/Choice.php
@@ -34,8 +34,8 @@ class Choice extends Part
     /**
      * Creates a new Choice builder.
      *
-     * @param Discord $discord
-     * @param string $name name of the choice
+     * @param Discord          $discord
+     * @param string           $name name of the choice
      * @param string|int|float $value value of the choice
      *
      * @return $this

--- a/src/Discord/Parts/Interactions/Command/Choice.php
+++ b/src/Discord/Parts/Interactions/Command/Choice.php
@@ -1,12 +1,12 @@
 <?php
 
 /*
- * This file was a part of the DiscordPHP-Slash project.
+ * This file is a part of the DiscordPHP project.
  *
- * Copyright (c) 2021 David Cole <david.cole1340@gmail.com>
+ * Copyright (c) 2015-present David Cole <david.cole1340@gmail.com>
  *
- * This source file is subject to the MIT license which is
- * bundled with this source code in the LICENSE.md file.
+ * This file is subject to the MIT license that is bundled
+ * with this source code in the LICENSE.md file.
  */
 
 namespace Discord\Parts\Interactions\Command;

--- a/src/Discord/Parts/Interactions/Command/Choice.php
+++ b/src/Discord/Parts/Interactions/Command/Choice.php
@@ -11,6 +11,7 @@
 
 namespace Discord\Parts\Interactions\Command;
 
+use Discord\Discord;
 use Discord\Parts\Part;
 
 use function Discord\poly_strlen;
@@ -31,9 +32,25 @@ class Choice extends Part
     protected $fillable = ['name', 'value'];
 
     /**
+     * Creates a new Choice builder.
+     *
+     * @param Discord $discord
+     * @param string $name name of the choice
+     * @param string|int|float $value value of the choice
+     *
+     * @return $this
+     */
+    public static function new(Discord $discord, string $name, $value): self
+    {
+        return new static($discord, ['name' => $name, 'value' => $value]);
+    }
+
+    /**
      * Sets the name of the choice.
      *
      * @param string $name name of the choice
+     *
+     * @throws \LengthException
      *
      * @return $this
      */
@@ -41,9 +58,9 @@ class Choice extends Part
     {
         $namelen = poly_strlen($name);
         if ($namelen < 1) {
-            throw new \InvalidArgumentException('Choice name can not be empty.');
+            throw new \LengthException('Choice name can not be empty.');
         } elseif ($namelen > 100) {
-            throw new \InvalidArgumentException('Choice name must be less than or equal to 100 characters.');
+            throw new \LengthException('Choice name must be less than or equal to 100 characters.');
         }
 
         $this->name = $name;
@@ -55,12 +72,14 @@ class Choice extends Part
      *
      * @param string|int|float $value value of the choice
      *
+     * @throws \LengthException
+     *
      * @return $this
      */
     public function setValue($value)
     {
         if (is_string($value) && poly_strlen($value) > 100) {
-            throw new \InvalidArgumentException('Choice value must be less than or equal to 100 characters.');
+            throw new \LengthException('Choice value must be less than or equal to 100 characters.');
         }
 
         $this->value = $value;

--- a/src/Discord/Parts/Interactions/Command/Command.php
+++ b/src/Discord/Parts/Interactions/Command/Command.php
@@ -123,6 +123,8 @@ class Command extends Part
      *
      * @param Overwrite $overwrite An overwrite object.
      *
+     * @deprecated 7.0.0
+     *
      * @return ExtendedPromiseInterface
      */
     public function setOverwrite(Overwrite $overwrite): ExtendedPromiseInterface

--- a/src/Discord/Parts/Interactions/Command/Command.php
+++ b/src/Discord/Parts/Interactions/Command/Command.php
@@ -24,16 +24,16 @@ use React\Promise\ExtendedPromiseInterface;
  * @see https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-structure
  *
  * @property string                   $id                 The unique identifier of the command.
- * @property int                      $type               The type of the command, defaults 1 if not set
+ * @property int                      $type               The type of the command, defaults 1 if not set.
  * @property string                   $application_id     The unique identifier of the parent Application that made the command, if made by one.
  * @property string|null              $guild_id           The unique identifier of the guild that the command belongs to. Null if global.
  * @property Guild|null               $guild              The guild that the command belongs to. Null if global.
  * @property string                   $name               1-32 character name of the command.
- * @property string                   $description        1-100 character description for CHAT_INPUT commands, empty string for USER and MESSAGE commands
+ * @property string                   $description        1-100 character description for CHAT_INPUT commands, empty string for USER and MESSAGE commands.
  * @property Collection|Option[]|null $options            The parameters for the command, max 25. Only for Slash command (CHAT_INPUT).
  * @property boolean                  $default_permission Whether the command is enabled by default when the app is added to a guild.
- * @property string                   $version            Autoincrementing version identifier updated during substantial record changes
- * @property OverwriteRepository      $overwrites         Permission overwrites
+ * @property string                   $version            Autoincrementing version identifier updated during substantial record changes.
+ * @property OverwriteRepository      $overwrites         Permission overwrites.
  */
 class Command extends Part
 {
@@ -69,13 +69,17 @@ class Command extends Part
     ];
 
     /**
-     * @inheritdoc
+     * Gets the application id attribute.
+     *
+     * @return string Application ID of this Bot if not set.
      */
-    protected function afterConstruct(): void
+    protected function getApplicationIdAttribute(): string
     {
         if (! isset($this->attributes['application_id'])) {
-            $this->offsetSet('application_id', $this->discord->application->id);
+            return $this->discord->application->id;
         }
+
+        return $this->attributes['application_id'];
     }
 
     /**
@@ -114,6 +118,8 @@ class Command extends Part
 
     /**
      * Sets an overwrite to the guild application command.
+     *
+     * @see https://discord.com/developers/docs/interactions/application-commands#edit-application-command-permissions
      *
      * @param Overwrite $overwrite An overwrite object.
      *

--- a/src/Discord/Parts/Interactions/Command/Command.php
+++ b/src/Discord/Parts/Interactions/Command/Command.php
@@ -1,12 +1,12 @@
 <?php
 
 /*
- * This file was a part of the DiscordPHP-Slash project.
+ * This file is a part of the DiscordPHP project.
  *
- * Copyright (c) 2021 David Cole <david.cole1340@gmail.com>
+ * Copyright (c) 2015-present David Cole <david.cole1340@gmail.com>
  *
- * This source file is subject to the MIT license which is
- * bundled with this source code in the LICENSE.md file.
+ * This file is subject to the MIT license that is bundled
+ * with this source code in the LICENSE.md file.
  */
 
 namespace Discord\Parts\Interactions\Command;

--- a/src/Discord/Parts/Interactions/Command/Option.php
+++ b/src/Discord/Parts/Interactions/Command/Option.php
@@ -190,14 +190,14 @@ class Option extends Part
      *
      * @param Option $option The option
      *
-     * @throws \InvalidArgumentException
+     * @throws \OverflowException
      *
      * @return $this
      */
     public function addOption(Option $option)
     {
         if (count($this->options) >= 25) {
-            throw new \InvalidArgumentException('Option can not have more than 25 parameters.');
+            throw new \OverflowException('Option can not have more than 25 parameters.');
         }
 
         $this->attributes['options'][] = $option->getRawAttributes();
@@ -210,14 +210,14 @@ class Option extends Part
      *
      * @param Choice $choice The choice
      *
-     * @throws \InvalidArgumentException
+     * @throws \OverflowException
      *
      * @return $this
      */
     public function addChoice(Choice $choice)
     {
         if (count($this->choices) >= 25) {
-            throw new \InvalidArgumentException('Option can only have a maximum of 25 Choices.');
+            throw new \OverflowException('Option can only have a maximum of 25 Choices.');
         }
 
         $this->attributes['choices'][] = $choice->getRawAttributes();

--- a/src/Discord/Parts/Interactions/Command/Option.php
+++ b/src/Discord/Parts/Interactions/Command/Option.php
@@ -91,6 +91,8 @@ class Option extends Part
      *
      * @param int $type type of the option
      *
+     * @throws \InvalidArgumentException
+     *
      * @return $this
      */
     public function setType(int $type)
@@ -108,12 +110,14 @@ class Option extends Part
      *
      * @param string $name name of the option
      *
+     * @throws \LengthException
+     *
      * @return $this
      */
     public function setName(string $name)
     {
         if ($name && poly_strlen($name) > 32) {
-            throw new \InvalidArgumentException('Name must be less than or equal to 32 characters.');
+            throw new \LengthException('Name must be less than or equal to 32 characters.');
         }
 
         $this->name = $name;
@@ -125,12 +129,14 @@ class Option extends Part
      *
      * @param string $description description of the option
      *
+     * @throws \LengthException
+     *
      * @return $this
      */
     public function setDescription(string $description)
     {
         if ($description && poly_strlen($description) > 100) {
-            throw new \InvalidArgumentException('Description must be less than or equal to 100 characters.');
+            throw new \LengthException('Description must be less than or equal to 100 characters.');
         }
 
         $this->description = $description;
@@ -168,12 +174,14 @@ class Option extends Part
      *
      * @param Option $option The option
      *
+     * @throws \InvalidArgumentException
+     *
      * @return $this
      */
     public function addOption(Option $option)
     {
         if (count($this->options) >= 25) {
-            throw new \RangeException('Option can not have more than 25 parameters.');
+            throw new \InvalidArgumentException('Option can not have more than 25 parameters.');
         }
 
         $this->attributes['options'][] = $option->getRawAttributes();
@@ -185,12 +193,14 @@ class Option extends Part
      *
      * @param Choice $choice The choice
      *
+     * @throws \InvalidArgumentException
+     *
      * @return $this
      */
     public function addChoice(Choice $choice)
     {
         if (count($this->choices) >= 25) {
-            throw new \RangeException('Option can only have a maximum of 25 Choices.');
+            throw new \InvalidArgumentException('Option can only have a maximum of 25 Choices.');
         }
 
         $this->attributes['choices'][] = $choice->getRawAttributes();
@@ -260,16 +270,19 @@ class Option extends Part
      *
      * @param bool $autocomplete enable autocomplete interactions for this option
      *
+     * @throws \LogicException
+     *
      * @return $this
      */
     public function setAutoComplete(bool $autocomplete)
     {
         if ($autocomplete) {
             if (!empty($this->attributes['choices'])) {
-                throw new \InvalidArgumentException('Autocomplete may not be set to true if choices are present.');
+                throw new \LogicException('Autocomplete may not be set to true if choices are present.');
             }
+
             if (! in_array($this->type, [self::STRING, self::INTEGER, self::NUMBER])) {
-                throw new \InvalidArgumentException('Autocomplete may be only set to true if option type is STRING, INTEGER, or NUMBER.');
+                throw new \LogicException('Autocomplete may be only set to true if option type is STRING, INTEGER, or NUMBER.');
             }
         }
 

--- a/src/Discord/Parts/Interactions/Command/Option.php
+++ b/src/Discord/Parts/Interactions/Command/Option.php
@@ -106,7 +106,7 @@ class Option extends Part
      *
      * @return $this
      */
-    public function setType(int $type)
+    public function setType(int $type): self
     {
         if ($type < 1 || $type > 10) {
             throw new \InvalidArgumentException('Invalid type provided.');
@@ -126,7 +126,7 @@ class Option extends Part
      *
      * @return $this
      */
-    public function setName(string $name)
+    public function setName(string $name): self
     {
         if ($name && poly_strlen($name) > 32) {
             throw new \LengthException('Name must be less than or equal to 32 characters.');
@@ -146,7 +146,7 @@ class Option extends Part
      *
      * @return $this
      */
-    public function setDescription(string $description)
+    public function setDescription(string $description): self
     {
         if ($description && poly_strlen($description) > 100) {
             throw new \LengthException('Description must be less than or equal to 100 characters.');
@@ -164,7 +164,7 @@ class Option extends Part
      *
      * @return $this
      */
-    public function setRequired(bool $required)
+    public function setRequired(bool $required): self
     {
         $this->required = $required;
 
@@ -178,7 +178,7 @@ class Option extends Part
      *
      * @return $this
      */
-    public function setChannelTypes(array $types)
+    public function setChannelTypes(array $types): self
     {
         $this->channel_types = $types;
 
@@ -194,7 +194,7 @@ class Option extends Part
      *
      * @return $this
      */
-    public function addOption(Option $option)
+    public function addOption(Option $option): self
     {
         if (count($this->options) >= 25) {
             throw new \OverflowException('Option can not have more than 25 parameters.');
@@ -214,7 +214,7 @@ class Option extends Part
      *
      * @return $this
      */
-    public function addChoice(Choice $choice)
+    public function addChoice(Choice $choice): self
     {
         if (count($this->choices) >= 25) {
             throw new \OverflowException('Option can only have a maximum of 25 Choices.');
@@ -228,15 +228,19 @@ class Option extends Part
     /**
      * Removes an option.
      *
-     * @param Option $option Option to remove.
+     * @param string|Option $option Option object or name to remove.
      *
      * @return $this
      */
-    public function removeOption(Option $option)
+    public function removeOption($option): self
     {
+        if ($option instanceof Option) {
+            $option = $option->name;
+        }
+
         if (! empty($this->attributes['options'])) {
             foreach ($this->attributes['options'] as $idx => $opt) {
-                if ($opt['name'] == $option->name) {
+                if ($opt['name'] == $option) {
                     unset($this->attributes['options'][$idx]);
                     break;
                 }
@@ -249,15 +253,19 @@ class Option extends Part
     /**
      * Removes a choice.
      *
-     * @param Choice $choice Choice to remove
+     * @param string|Choice $choice Choice object or name to remove.
      *
      * @return $this
      */
-    public function removeChoice(Choice $choice)
+    public function removeChoice($choice): self
     {
+        if ($choice instanceof Choice) {
+            $choice = $choice->name;
+        }
+
         if (! empty($this->attributes['choices'])) {
             foreach ($this->attributes['choices'] as $idx => $cho) {
-                if ($cho['name'] == $choice->name) {
+                if ($cho['name'] == $choice) {
                     unset($this->attributes['choices'][$idx]);
                     break;
                 }
@@ -274,7 +282,7 @@ class Option extends Part
      *
      * @return $this
      */
-    public function setMinValue($min_value)
+    public function setMinValue($min_value): self
     {
         $this->min_value = $min_value;
 
@@ -288,7 +296,7 @@ class Option extends Part
      *
      * @return $this
      */
-    public function setMaxValue($max_value)
+    public function setMaxValue($max_value): self
     {
         $this->max_value = $max_value;
 
@@ -304,7 +312,7 @@ class Option extends Part
      *
      * @return $this
      */
-    public function setAutoComplete(bool $autocomplete)
+    public function setAutoComplete(bool $autocomplete): self
     {
         if ($autocomplete) {
             if (!empty($this->attributes['choices'])) {

--- a/src/Discord/Parts/Interactions/Command/Option.php
+++ b/src/Discord/Parts/Interactions/Command/Option.php
@@ -270,7 +270,7 @@ class Option extends Part
      *
      * @param bool $autocomplete enable autocomplete interactions for this option
      *
-     * @throws \LogicException
+     * @throws \InvalidArgumentException
      *
      * @return $this
      */
@@ -278,11 +278,11 @@ class Option extends Part
     {
         if ($autocomplete) {
             if (!empty($this->attributes['choices'])) {
-                throw new \LogicException('Autocomplete may not be set to true if choices are present.');
+                throw new \InvalidArgumentException('Autocomplete may not be set to true if choices are present.');
             }
 
             if (! in_array($this->type, [self::STRING, self::INTEGER, self::NUMBER])) {
-                throw new \LogicException('Autocomplete may be only set to true if option type is STRING, INTEGER, or NUMBER.');
+                throw new \InvalidArgumentException('Autocomplete may be only set to true if option type is STRING, INTEGER, or NUMBER.');
             }
         }
 

--- a/src/Discord/Parts/Interactions/Command/Option.php
+++ b/src/Discord/Parts/Interactions/Command/Option.php
@@ -3,10 +3,10 @@
 /*
  * This file is a part of the DiscordPHP project.
  *
- * Copyright (c) 2021 David Cole <david.cole1340@gmail.com>
+ * Copyright (c) 2015-present David Cole <david.cole1340@gmail.com>
  *
- * This source file is subject to the MIT license which is
- * bundled with this source code in the LICENSE.md file.
+ * This file is subject to the MIT license that is bundled
+ * with this source code in the LICENSE.md file.
  */
 
 namespace Discord\Parts\Interactions\Command;

--- a/src/Discord/Parts/Interactions/Command/Option.php
+++ b/src/Discord/Parts/Interactions/Command/Option.php
@@ -48,12 +48,23 @@ class Option extends Part
     /**
      * @inheritdoc
      */
-    protected $fillable = ['type', 'name', 'description', 'required', 'choices', 'options', 'channel_types', 'min_value', 'max_value', 'autocomplete'];
+    protected $fillable = [
+        'type',
+        'name',
+        'description',
+        'required',
+        'choices',
+        'options',
+        'channel_types',
+        'min_value',
+        'max_value',
+        'autocomplete'
+    ];
 
     /**
      * Gets the choices attribute.
      *
-     * @return Collection|Choices[]|null A collection of choices.
+     * @return Collection|Choice[]|null A collection of choices.
      */
     protected function getChoicesAttribute(): ?Collection
     {
@@ -73,7 +84,7 @@ class Option extends Part
     /**
      * Gets the options attribute.
      *
-     * @return Collection|Options[] A collection of options.
+     * @return Collection|Option[] A collection of options.
      */
     protected function getOptionsAttribute(): Collection
     {
@@ -102,6 +113,7 @@ class Option extends Part
         }
 
         $this->type = $type;
+
         return $this;
     }
 
@@ -121,6 +133,7 @@ class Option extends Part
         }
 
         $this->name = $name;
+
         return $this;
     }
 
@@ -140,6 +153,7 @@ class Option extends Part
         }
 
         $this->description = $description;
+
         return $this;
     }
 
@@ -153,6 +167,7 @@ class Option extends Part
     public function setRequired(bool $required)
     {
         $this->required = $required;
+
         return $this;
     }
 
@@ -166,6 +181,7 @@ class Option extends Part
     public function setChannelTypes(array $types)
     {
         $this->channel_types = $types;
+
         return $this;
     }
 
@@ -185,6 +201,7 @@ class Option extends Part
         }
 
         $this->attributes['options'][] = $option->getRawAttributes();
+
         return $this;
     }
 
@@ -204,6 +221,7 @@ class Option extends Part
         }
 
         $this->attributes['choices'][] = $choice->getRawAttributes();
+
         return $this;
     }
 
@@ -216,8 +234,13 @@ class Option extends Part
      */
     public function removeOption(Option $option)
     {
-        if ($opt = $this->attributes['options']->offsetGet($option->name)) {
-            $this->attributes['options']->offsetUnset($opt);
+        if (! empty($this->attributes['options'])) {
+            foreach ($this->attributes['options'] as $idx => $opt) {
+                if ($opt['name'] == $option->name) {
+                    unset($this->attributes['options'][$idx]);
+                    break;
+                }
+            }
         }
 
         return $this;
@@ -232,8 +255,13 @@ class Option extends Part
      */
     public function removeChoice(Choice $choice)
     {
-        if ($cho = $this->attributes['choices']->offsetGet($choice->name)) {
-            $this->attributes['choices']->offsetUnset($cho);
+        if (! empty($this->attributes['choices'])) {
+            foreach ($this->attributes['choices'] as $idx => $cho) {
+                if ($cho['name'] == $choice->name) {
+                    unset($this->attributes['choices'][$idx]);
+                    break;
+                }
+            }
         }
 
         return $this;
@@ -249,6 +277,7 @@ class Option extends Part
     public function setMinValue($min_value)
     {
         $this->min_value = $min_value;
+
         return $this;
     }
 
@@ -262,6 +291,7 @@ class Option extends Part
     public function setMaxValue($max_value)
     {
         $this->max_value = $max_value;
+
         return $this;
     }
 
@@ -287,6 +317,7 @@ class Option extends Part
         }
 
         $this->autocomplete = $autocomplete;
+
         return $this;
     }
 }

--- a/src/Discord/Parts/Interactions/Interaction.php
+++ b/src/Discord/Parts/Interactions/Interaction.php
@@ -27,6 +27,8 @@ use Discord\Parts\User\User;
 use React\Promise\ExtendedPromiseInterface;
 use RuntimeException;
 
+use function React\Promise\reject;
+
 /**
  * Represents an interaction from Discord.
  *
@@ -241,7 +243,7 @@ class Interaction extends Part
     public function getOriginalResponse(): ExtendedPromiseInterface
     {
         if (! $this->responded) {
-            throw new RuntimeException('Interaction has not been responded to.');
+            return reject(new RuntimeException('Interaction has not been responded to.'));
         }
 
         return $this->http->get(Endpoint::bind(Endpoint::ORIGINAL_INTERACTION_RESPONSE, $this->application_id, $this->token))
@@ -288,7 +290,7 @@ class Interaction extends Part
     public function deleteOriginalResponse(): ExtendedPromiseInterface
     {
         if (! $this->responded) {
-            throw new RuntimeException('Interaction has not been responded to.');
+            return reject(new RuntimeException('Interaction has not been responded to.'));
         }
 
         return $this->http->delete(Endpoint::bind(Endpoint::ORIGINAL_INTERACTION_RESPONSE, $this->application_id, $this->token));
@@ -369,7 +371,7 @@ class Interaction extends Part
     protected function respond(array $payload, ?Multipart $multipart = null): ExtendedPromiseInterface
     {
         if ($this->responded) {
-            throw new RuntimeException('Interaction has already been responded to.');
+            return reject(new RuntimeException('Interaction has already been responded to.'));
         }
 
         $this->responded = true;

--- a/src/Discord/Parts/Interactions/Interaction.php
+++ b/src/Discord/Parts/Interactions/Interaction.php
@@ -48,6 +48,8 @@ use function React\Promise\reject;
  * @property string               $token          Continuation token for responding to the interaction.
  * @property int                  $version        Version of interaction.
  * @property Message|null         $message        Message that triggered the interactions, when triggered from message components.
+ * @property string|null          $locale         The selected language of the invoking user.
+ * @property string|null          $guild_locale   The guild's preferred locale, if invoked in a guild.
  */
 class Interaction extends Part
 {
@@ -66,6 +68,8 @@ class Interaction extends Part
         'token',
         'version',
         'message',
+        'locale',
+        'guild_locale',
     ];
 
     /**

--- a/src/Discord/Parts/Interactions/Interaction.php
+++ b/src/Discord/Parts/Interactions/Interaction.php
@@ -25,7 +25,6 @@ use Discord\Parts\Part;
 use Discord\Parts\User\Member;
 use Discord\Parts\User\User;
 use React\Promise\ExtendedPromiseInterface;
-use RuntimeException;
 
 use function React\Promise\reject;
 
@@ -240,14 +239,14 @@ class Interaction extends Part
     /**
      * Retrieves the original interaction response.
      *
-     * @throws RuntimeException
+     * @throws \RuntimeException
      *
      * @return ExtendedPromiseInterface<Message>
      */
     public function getOriginalResponse(): ExtendedPromiseInterface
     {
         if (! $this->responded) {
-            return reject(new RuntimeException('Interaction has not been responded to.'));
+            return reject(new \RuntimeException('Interaction has not been responded to.'));
         }
 
         return $this->http->get(Endpoint::bind(Endpoint::ORIGINAL_INTERACTION_RESPONSE, $this->application_id, $this->token))
@@ -261,14 +260,14 @@ class Interaction extends Part
      *
      * @param MessageBuilder $builder New message contents.
      *
-     * @throws RuntimeException
+     * @throws \RuntimeException
      *
      * @return ExtendedPromiseInterface<Message>
      */
     public function updateOriginalResponse(MessageBuilder $builder): ExtendedPromiseInterface
     {
         if (! $this->responded) {
-            throw new RuntimeException('Interaction has not been responded to.');
+            throw new \RuntimeException('Interaction has not been responded to.');
         }
 
         return (function () use ($builder): ExtendedPromiseInterface {
@@ -287,14 +286,14 @@ class Interaction extends Part
     /**
      * Deletes the original interaction response.
      *
-     * @throws RuntimeException
+     * @throws \RuntimeException
      *
      * @return ExtendedPromiseInterface
      */
     public function deleteOriginalResponse(): ExtendedPromiseInterface
     {
         if (! $this->responded) {
-            return reject(new RuntimeException('Interaction has not been responded to.'));
+            return reject(new \RuntimeException('Interaction has not been responded to.'));
         }
 
         return $this->http->delete(Endpoint::bind(Endpoint::ORIGINAL_INTERACTION_RESPONSE, $this->application_id, $this->token));
@@ -306,14 +305,14 @@ class Interaction extends Part
      * @param MessageBuilder $builder   Message to send.
      * @param bool           $ephemeral Whether the created follow-up should be ephemeral.
      *
-     * @throws RuntimeException
+     * @throws \RuntimeException
      *
      * @return ExtendedPromiseInterface<Message>
      */
     public function sendFollowUpMessage(MessageBuilder $builder, bool $ephemeral = false): ExtendedPromiseInterface
     {
         if (! $this->responded) {
-            throw new RuntimeException('Cannot create a follow-up message as the interaction has not been responded to.');
+            throw new \RuntimeException('Cannot create a follow-up message as the interaction has not been responded to.');
         }
 
         if ($ephemeral) {
@@ -368,14 +367,14 @@ class Interaction extends Part
      * @param array          $payload   Response payload.
      * @param Multipart|null $multipart Optional multipart payload.
      *
-     * @throws RuntimeException
+     * @throws \RuntimeException
      *
      * @return ExtendedPromiseInterface
      */
     protected function respond(array $payload, ?Multipart $multipart = null): ExtendedPromiseInterface
     {
         if ($this->responded) {
-            return reject(new RuntimeException('Interaction has already been responded to.'));
+            return reject(new \RuntimeException('Interaction has already been responded to.'));
         }
 
         $this->responded = true;
@@ -401,14 +400,14 @@ class Interaction extends Part
      * @param string         $message_id Message to update.
      * @param MessageBuilder $builder    New message contents.
      *
-     * @throws RuntimeException
+     * @throws \RuntimeException
      *
      * @return ExtendedPromiseInterface<Message>
      */
     public function updateFollowUpMessage(string $message_id, MessageBuilder $builder)
     {
         if (! $this->responded) {
-            throw new RuntimeException('Cannot create a follow-up message as the interaction has not been responded to.');
+            throw new \RuntimeException('Cannot create a follow-up message as the interaction has not been responded to.');
         }
 
         return (function () use ($message_id, $builder): ExtendedPromiseInterface {

--- a/src/Discord/Parts/Interactions/Request/InteractionData.php
+++ b/src/Discord/Parts/Interactions/Request/InteractionData.php
@@ -66,7 +66,7 @@ class InteractionData extends Part
      *
      * @return Resolved|null
      */
-    protected function getResolvedAttribute()
+    protected function getResolvedAttribute(): ?Resolved
     {
         if (! isset($this->attributes['resolved'])) {
             return null;

--- a/src/Discord/Parts/OAuth/Application.php
+++ b/src/Discord/Parts/OAuth/Application.php
@@ -28,7 +28,7 @@ use Discord\Repository\Interaction\GlobalCommandRepository;
  * @property bool                    $bot_require_code_grant When true the app's bot will only join upon completion of the full oauth2 code grant flow.
  * @property string|null             $terms_of_service_url   The url of the app's terms of service.
  * @property string|null             $privacy_policy_url     The url of the app's privacy policy
- * @property User                    $owner                  The owner of the OAuth application.
+ * @property User|null               $owner                  The owner of the OAuth application.
  * @property string                  $verify_key             The hex encoded key for verification in interactions and the GameSDK's GetTicket.
  * @property object|null             $team                   If the application belongs to a team, this will be a list of the members of that team.
  * @property int                     $flags                  The application's public flags.
@@ -62,20 +62,23 @@ class Application extends Part
     protected $repositories = [
         'commands' => GlobalCommandRepository::class,
     ];
-    
+
     /**
      * Returns the owner of the application.
      *
-     * @return User       Owner of the application.
-     * @throws \Exception
+     * @return User|null Owner of the application.
      */
     protected function getOwnerAttribute(): ?User
     {
-        if (isset($this->attributes['owner'])) {
-            return $this->factory->create(User::class, $this->attributes['owner'], true);
+        if (! isset($this->attributes['owner'])) {
+            return null;
         }
-        
-        return null;
+
+        if ($owner = $this->discord->users->get('id', $this->attributes['owner']->id)) {
+            return $owner;
+        }
+
+        return $this->factory->create(User::class, $this->attributes['owner'], true);
     }
 
     /**

--- a/src/Discord/Parts/OAuth/Application.php
+++ b/src/Discord/Parts/OAuth/Application.php
@@ -78,7 +78,7 @@ class Application extends Part
             return $owner;
         }
 
-        return $this->factory->create(User::class, $this->attributes['owner'], true);
+        return $this->factory->part(User::class, (array) $this->attributes['owner'], true);
     }
 
     /**

--- a/src/Discord/Parts/OAuth/Application.php
+++ b/src/Discord/Parts/OAuth/Application.php
@@ -19,9 +19,12 @@ use Discord\Repository\Interaction\GlobalCommandRepository;
 /**
  * The OAuth2 application of the bot.
  *
+ * @see https://discord.com/developers/docs/resources/application
+ *
  * @property string                  $id                     The client ID of the OAuth application.
  * @property string                  $name                   The name of the OAuth application.
- * @property string                  $icon                   The icon hash of the OAuth application.
+ * @property string|null             $icon                   The icon URL of the OAuth application.
+ * @property string                  $icon_hash              The icon hash of the OAuth application.
  * @property string                  $description            The description of the OAuth application.
  * @property string[]                $rpc_origins            An array of RPC origin URLs.
  * @property bool                    $bot_public             When false only app owner can join the app's bot to guilds.
@@ -29,8 +32,14 @@ use Discord\Repository\Interaction\GlobalCommandRepository;
  * @property string|null             $terms_of_service_url   The url of the app's terms of service.
  * @property string|null             $privacy_policy_url     The url of the app's privacy policy
  * @property User|null               $owner                  The owner of the OAuth application.
+ * @property string                  $summary                If this application is a game sold on Discord, this field will be the summary field for the store page of its primary sku.
  * @property string                  $verify_key             The hex encoded key for verification in interactions and the GameSDK's GetTicket.
  * @property object|null             $team                   If the application belongs to a team, this will be a list of the members of that team.
+ * @property string|null             $guild_id               If this application is a game sold on Discord, this field will be the guild to which it has been linked.
+ * @property string|null             $primary_sku_id         If this application is a game sold on Discord, this field will be the id of the "Game SKU" that is created, if exists.
+ * @property string|null             $slug                   If this application is a game sold on Discord, this field will be the URL slug that links to the store page.
+ * @property string|null             $cover_image            The application's default rich presence invite cover image URL.
+ * @property string|null             $cover_image_hash       The application's default rich presence invite cover image hash.
  * @property int                     $flags                  The application's public flags.
  * @property string                  $invite_url             The invite URL to invite the bot to a guild.
  * @property GlobalCommandRepository $commands               The application global commands.
@@ -41,20 +50,34 @@ class Application extends Part
      * @inheritdoc
      */
     protected $fillable = [
-        'id',
-        'name',
-        'icon',
-        'description',
-        'rpc_origins',
         'bot_public',
         'bot_require_code_grant',
+        'cover_image',
+        'description',
+        'guild_id',
+        'icon',
+        'id',
+        'name',
+        'owner',
+        'primary_sku_id',
+        'slug',
+        'summary',
+        'team',
+        'verify_key',
+        'rpc_origins',
         'terms_of_service_url',
         'privacy_policy_url',
-        'owner',
-        'verify_key',
-        'team',
         'flags',
     ];
+
+    public const GATEWAY_PRESENCE = (1 << 12);
+    public const GATEWAY_PRESENCE_LIMITED = (1 << 13);
+    public const GATEWAY_GUILD_MEMBERS = (1 << 14);
+    public const GATEWAY_GUILD_MEMBERS_LIMITED = (1 << 15);
+    public const VERIFICATION_PENDING_GUILD_LIMIT = (1 << 16);
+    public const EMBEDDED = (1 << 17);
+    public const GATEWAY_MESSAGE_CONTENT = (1 << 18);
+    public const GATEWAY_MESSAGE_CONTENT_LIMITED = (1 << 19);
 
     /**
      * @inheritdoc
@@ -62,6 +85,38 @@ class Application extends Part
     protected $repositories = [
         'commands' => GlobalCommandRepository::class,
     ];
+
+    /**
+     * Returns the application icon.
+     *
+     * @param string|null $format The image format.
+     * @param int         $size   The size of the image.
+     *
+     * @return string|null The URL to the application icon or null.
+     */
+    public function getIconAttribute(string $format = 'webp', int $size = 1024): ?string
+    {
+        if (! isset($this->attributes['icon'])) {
+            return null;
+        }
+
+        $allowed = ['png', 'jpg', 'webp'];
+        if (! in_array(strtolower($format), $allowed)) {
+            $format = 'webp';
+        }
+
+        return "https://cdn.discordapp.com/app-icons/{$this->id}/{$this->attributes['icon']}.{$format}?size={$size}";
+    }
+
+    /**
+     * Returns the application icon attribute.
+     *
+     * @return string|null The application icon hash or null.
+     */
+    protected function getIconHashAttribute(): ?string
+    {
+        return $this->attributes['icon'];
+    }
 
     /**
      * Returns the owner of the application.
@@ -79,6 +134,38 @@ class Application extends Part
         }
 
         return $this->factory->part(User::class, (array) $this->attributes['owner'], true);
+    }
+
+    /**
+     * Returns the application cover image.
+     *
+     * @param string|null $format The image format.
+     * @param int         $size   The size of the image.
+     *
+     * @return string|null The URL to the application cover image or null.
+     */
+    public function getCoverImageAttribute(string $format = 'webp', int $size = 1024): ?string
+    {
+        if (! isset($this->attributes['cover_image'])) {
+            return null;
+        }
+
+        $allowed = ['png', 'jpg', 'webp'];
+        if (! in_array(strtolower($format), $allowed)) {
+            $format = 'webp';
+        }
+
+        return "https://cdn.discordapp.com/app-icons/{$this->id}/{$this->attributes['cover_image']}.{$format}?size={$size}";
+    }
+
+    /**
+     * Returns the application cover image attribute.
+     *
+     * @return string|null The application cover image hash or null.
+     */
+    protected function getCoverImageHashAttribute(): ?string
+    {
+        return $this->attributes['cover_image'];
     }
 
     /**

--- a/src/Discord/Parts/Permissions/Permission.php
+++ b/src/Discord/Parts/Permissions/Permission.php
@@ -204,7 +204,7 @@ abstract class Permission extends Part
      *
      * @deprecated 7.0.0 Use `use_application_commands`
      */
-    public function getUseSlashCommandsAttribute()
+    protected function getUseSlashCommandsAttribute()
     {
         return $this->attributes['use_application_commands'] ?? null;
     }
@@ -214,7 +214,7 @@ abstract class Permission extends Part
      *
      * @deprecated 7.0.0 Use `create_public_threads`
      */
-    public function getUsePublicThreadsAttribute()
+    protected function getUsePublicThreadsAttribute()
     {
         return $this->attributes['create_public_threads'] ?? null;
     }
@@ -224,7 +224,7 @@ abstract class Permission extends Part
      *
      * @deprecated 7.0.0 Use `create_private_threads`
      */
-    public function getUsePrivateThreadsAttribute()
+    protected function getUsePrivateThreadsAttribute()
     {
         return $this->attributes['create_private_threads'] ?? null;
     }
@@ -234,7 +234,7 @@ abstract class Permission extends Part
      *
      * @deprecated 7.0.0 Use `manage_emojis_and_stickers`
      */
-    public function getManageEmojisAttribute()
+    protected function getManageEmojisAttribute()
     {
         return $this->attributes['manage_emojis_and_stickers'] ?? null;
     }
@@ -244,7 +244,7 @@ abstract class Permission extends Part
      *
      * @deprecated 7.0.0 Use `use_application_commands`
      */
-    public function setUseSlashCommandsAttribute($value)
+    protected function setUseSlashCommandsAttribute($value)
     {
         return $this->attributes['use_application_commands'] = $value;
     }
@@ -254,7 +254,7 @@ abstract class Permission extends Part
      *
      * @deprecated 7.0.0 Use `create_public_threads`
      */
-    public function setUsePublicThreadsAttribute($value)
+    protected function setUsePublicThreadsAttribute($value)
     {
         return $this->attributes['create_public_threads'] = $value;
     }
@@ -264,7 +264,7 @@ abstract class Permission extends Part
      *
      * @deprecated 7.0.0 Use `create_private_threads`
      */
-    public function setUsePrivateThreadsAttribute($value)
+    protected function setUsePrivateThreadsAttribute($value)
     {
         return $this->attributes['create_private_threads'] = $value;
     }
@@ -274,7 +274,7 @@ abstract class Permission extends Part
      *
      * @deprecated 7.0.0 Use `manage_emojis_and_stickers`
      */
-    public function setManageEmojisAttribute($value)
+    protected function setManageEmojisAttribute($value)
     {
         return $this->attributes['manage_emojis_and_stickers'] = $value;
     }

--- a/src/Discord/Parts/Thread/Member.php
+++ b/src/Discord/Parts/Thread/Member.php
@@ -20,28 +20,20 @@ use React\Promise\ExtendedPromiseInterface;
 /**
  * Represents a member that belongs to a thread. Not the same as a user nor a guild member.
  *
- * @property string $id             ID of the thread.
- * @property string $user_id        ID of the user that the member object represents.
- * @property User   $user           The user that the member object represents.
- * @property int    $flags          Flags relating to the member. Only used for client notifications.
- * @property Carbon $join_timestamp The time that the member joined the thread.
+ * @see https://discord.com/developers/docs/resources/channel#thread-member-object
+ *
+ * @property string|null $id             ID of the thread.
+ * @property string|null $user_id        ID of the user that the member object represents.
+ * @property User|null   $user           The user that the member object represents.
+ * @property Carbon      $join_timestamp The time that the member joined the thread.
+ * @property int         $flags          Flags relating to the member. Only used for client notifications.
  */
 class Member extends Part
 {
     /**
      * @inheritdoc
      */
-    protected $fillable = ['id', 'user_id', 'flags', 'join_timestamp'];
-
-    /**
-     * Returns the time that the member joined the thread.
-     *
-     * @return Carbon
-     */
-    protected function getJoinTimestampAttribute(): Carbon
-    {
-        return new Carbon($this->attributes['join_timestamp']);
-    }
+    protected $fillable = ['id', 'user_id', 'join_timestamp', 'flags'];
 
     /**
      * Returns the user that the member represents.
@@ -51,6 +43,16 @@ class Member extends Part
     protected function getUserAttribute(): ?User
     {
         return $this->discord->users->get('id', $this->user_id);
+    }
+
+    /**
+     * Returns the time that the member joined the thread.
+     *
+     * @return Carbon
+     */
+    protected function getJoinTimestampAttribute(): Carbon
+    {
+        return new Carbon($this->attributes['join_timestamp']);
     }
 
     /**

--- a/src/Discord/Parts/User/Activity.php
+++ b/src/Discord/Parts/User/Activity.php
@@ -18,21 +18,23 @@ use Discord\Parts\Part;
 /**
  * The Activity part describes activities the member is undertaking.
  *
- * @property string   $name
- * @property int      $type
- * @property string   $url
- * @property Carbon   $created_at
- * @property array    $timestamps
- * @property string   $application_id
- * @property string   $details
- * @property string   $state
- * @property Emoji    $emoji
- * @property object   $party
- * @property object   $assets
- * @property object   $secrets
- * @property bool     $instance
- * @property int      $flags
- * @property object[] $buttons
+ * @see https://discord.com/developers/docs/topics/gateway#activity-object
+ *
+ * @property string        $name
+ * @property int           $type
+ * @property string|null   $url
+ * @property Carbon|null   $created_at
+ * @property object|null   $timestamps
+ * @property string|null   $application_id
+ * @property string|null   $details
+ * @property string|null   $state
+ * @property Emoji|null    $emoji
+ * @property object|null   $party
+ * @property object|null   $assets
+ * @property object|null   $secrets
+ * @property bool|null     $instance
+ * @property int|null      $flags
+ * @property object[]|null $buttons
  */
 class Activity extends Part
 {
@@ -42,6 +44,16 @@ class Activity extends Part
     public const TYPE_WATCHING = 3; // Watching {$this->name}
     public const TYPE_CUSTOM = 4; // {$this->emoji} {$this->name}
     public const TYPE_COMPETING = 5; // Competing in {$this->name}
+
+    public const FLAG_INSTANCE = (1 << 0);
+    public const FLAG_JOIN = (1 << 1);
+    public const FLAG_SPECTATE = (1 << 2);
+    public const FLAG_JOIN_REQUEST = (1 << 3);
+    public const FLAG_SYNC = (1 << 4);
+    public const FLAG_PLAY = (1 << 5);
+    public const FLAG_PARTY_PRIVACY_FRIENDS = (1 << 6);
+    public const FLAG_PARTY_PRIVACY_VOICE_CHANNEL = (1 << 7);
+    public const FLAG_EMBEDDED = (1 << 8);
 
     public const STATUS_ONLINE = 'online';
     public const STATUS_IDLE = 'idle';
@@ -72,7 +84,7 @@ class Activity extends Part
     /**
      * Gets the created at timestamp.
      *
-     * @return Carbon
+     * @return Carbon|null
      */
     protected function getCreatedAtAttribute(): ?Carbon
     {
@@ -86,7 +98,7 @@ class Activity extends Part
     /**
      * Gets the emoji object of the activity.
      *
-     * @return Emoji
+     * @return Emoji|null
      */
     protected function getEmojiAttribute(): ?Emoji
     {

--- a/src/Discord/Parts/User/Client.php
+++ b/src/Discord/Parts/User/Client.php
@@ -25,12 +25,14 @@ use React\Promise\ExtendedPromiseInterface;
  *
  * @property string                   $id               The unique identifier of the client.
  * @property string                   $username         The username of the client.
- * @property string                   $email            The email of the client.
- * @property bool                     $verified         Whether the client has verified their email.
+ * @property string                   $discriminator    The unique discriminator of the client.
  * @property string                   $avatar           The avatar URL of the client.
  * @property string                   $avatar_hash      The avatar hash of the client.
- * @property string                   $discriminator    The unique discriminator of the client.
  * @property bool                     $bot              Whether the client is a bot.
+ * @property bool|null                $mfa_enabled      Whether the Bot owner has two factor enabled on their account.
+ * @property bool                     $verified         Whether the client has verified their email.
+ * @property string|null              $email            The email of the client.
+ * @property string|null              $flags            The flags on a user's account.
  * @property User                     $user             The user instance of the client.
  * @property Application              $application      The OAuth2 application of the bot.
  * @property GuildRepository          $guilds
@@ -42,7 +44,19 @@ class Client extends Part
     /**
      * @inheritdoc
      */
-    protected $fillable = ['id', 'username', 'email', 'verified', 'avatar', 'discriminator', 'bot', 'user', 'application'];
+    protected $fillable = [
+        'verified',
+        'username',
+        'mfa_enabled',
+        'id',
+        'flags',
+        'email',
+        'discriminator',
+        'bot',
+        'avatar',
+        'user',
+        'application',
+    ];
 
     /**
      * @inheritdoc
@@ -70,7 +84,7 @@ class Client extends Part
      *
      * @return User
      */
-    protected function getUserAttribute()
+    protected function getUserAttribute(): Part
     {
         return $this->factory->create(User::class, $this->attributes, true);
     }

--- a/src/Discord/Parts/User/Member.php
+++ b/src/Discord/Parts/User/Member.php
@@ -419,8 +419,6 @@ class Member extends Part
     /**
      * Returns the user attribute.
      *
-     * @throws \Exception
-     *
      * @return User|null The user that owns the member.
      */
     protected function getUserAttribute(): ?User
@@ -433,7 +431,7 @@ class Member extends Part
             return $user;
         }
 
-        return $this->factory->create(User::class, $this->attributes['user'], true);
+        return $this->factory->part(User::class, (array) $this->attributes['user'], true);
     }
 
     /**

--- a/src/Discord/Parts/User/Member.php
+++ b/src/Discord/Parts/User/Member.php
@@ -28,30 +28,35 @@ use Discord\Parts\Permissions\RolePermission;
 use Discord\Parts\WebSockets\PresenceUpdate;
 use React\Promise\ExtendedPromiseInterface;
 
+use function React\Promise\reject;
+
 /**
  * A member is a relationship between a user and a guild. It contains user-to-guild specific data like roles.
  *
+ * @see https://discord.com/developers/docs/resources/guild#guild-member-object
+ *
+ * @property User|null             $user                         The user part of the member.
+ * @property string|null           $nick                         The nickname of the member.
+ * @property string|null           $avatar                       The avatar URL of the member or null if member has no guild avatar.
+ * @property string|null           $avatar_hash                  The avatar hash of the member or null if member has no guild avatar.
+ * @property Collection|Role[]     $roles                        A collection of Roles that the member has.
+ * @property Carbon|null           $joined_at                    A timestamp of when the member joined the guild.
+ * @property Carbon|null           $premium_since                When the user started boosting the server.
+ * @property bool                  $deaf                         Whether the member is deaf.
+ * @property bool                  $mute                         Whether the member is mute.
+ * @property bool                  $pending                      Whether the user has not yet passed the guild's Membership Screening requirements.
+ * @property string|null           $permissions
+ * @property Carbon|null           $communication_disabled_until When the user's timeout will expire and the user will be able to communicate in the guild again, null or a time in the past if the user is not timed out.
  * @property string                $id                           The unique identifier of the member.
  * @property string                $username                     The username of the member.
  * @property string                $discriminator                The discriminator of the member.
  * @property string                $displayname                  The nickname or username with discriminator of the member.
- * @property User                  $user                         The user part of the member.
- * @property Collection|Role[]     $roles                        A collection of Roles that the member has.
- * @property bool                  $deaf                         Whether the member is deaf.
- * @property bool                  $mute                         Whether the member is mute.
- * @property Carbon|null           $joined_at                    A timestamp of when the member joined the guild.
  * @property Guild                 $guild                        The guild that the member belongs to.
  * @property string                $guild_id                     The unique identifier of the guild that the member belongs to.
  * @property string                $status                       The status of the member.
  * @property Activity              $game                         The game the member is playing.
- * @property string|null           $nick                         The nickname of the member.
- * @property string|null           $avatar                       The avatar URL of the member or null if member has no guild avatar.
- * @property string|null           $avatar_hash                  The avatar hash of the member or null if member has no guild avatar.
- * @property Carbon|null           $premium_since                When the user started boosting the server.
- * @property bool                  $pending                      Whether the user has not yet passed the guild's Membership Screening requirements.
  * @property Collection|Activity[] $activities                   User's current activities.
  * @property object                $client_status                Current client status.
- * @property Carbon|null           $communication_disabled_until When the user's timeout will expire and the user will be able to communicate in the guild again, null or a time in the past if the user is not timed out.
  *
  * @method ExtendedPromiseInterface sendMessage(MessageBuilder $builder)
  * @method ExtendedPromiseInterface sendMessage(string $text, bool $tts = false, Embed|array $embed = null, array $allowed_mentions = null, ?Message $replyTo = null)
@@ -61,7 +66,23 @@ class Member extends Part
     /**
      * @inheritdoc
      */
-    protected $fillable = ['id', 'user', 'roles', 'deaf', 'mute', 'joined_at', 'guild_id', 'status', 'nick', 'avatar', 'premium_since', 'pending', 'activities', 'client_status', 'communication_disabled_until'];
+    protected $fillable = [
+        'user',
+        'nick',
+        'avatar',
+        'roles',
+        'joined_at',
+        'premium_since',
+        'deaf',
+        'mute',
+        'pending',
+        'guild_id',
+        'status',
+        'communication_disabled_until',
+        'id',
+        'activities',
+        'client_status',
+    ];
 
     /**
      * @inheritdoc
@@ -72,11 +93,13 @@ class Member extends Part
      * Updates the member from a new presence update object.
      * This is an internal function and is not meant to be used by a public application.
      *
+     * @internal
+     *
      * @param PresenceUpdate $presence
      *
-     * @return PresenceUpdate Old presence.
      * @throws \Exception
-     * @internal
+     *
+     * @return PresenceUpdate Old presence.
      */
     public function updateFromPresence(PresenceUpdate $presence): Part
     {
@@ -94,8 +117,9 @@ class Member extends Part
      * @param int|null    $daysToDeleteMessages The amount of days to delete messages from.
      * @param string|null $reason
      *
-     * @return ExtendedPromiseInterface
      * @throws \Exception
+     *
+     * @return ExtendedPromiseInterface
      */
     public function ban(?int $daysToDeleteMessages = null, ?string $reason = null): ExtendedPromiseInterface
     {
@@ -113,7 +137,7 @@ class Member extends Part
     public function setNickname(?string $nick = null, ?string $reason = null): ExtendedPromiseInterface
     {
         $payload = [
-            'nick' => $nick ?: '',
+            'nick' => $nick ?? '',
         ];
 
         $headers = [];
@@ -157,6 +181,8 @@ class Member extends Part
      * @param Role|string $role   The role to add to the member.
      * @param string|null $reason Reason for Audit Log.
      *
+     * @throws \RuntimeException
+     *
      * @return ExtendedPromiseInterface
      */
     public function addRole($role, ?string $reason = null): ExtendedPromiseInterface
@@ -167,7 +193,7 @@ class Member extends Part
 
         // We don't want a double up on roles
         if (in_array($role, (array) $this->attributes['roles'])) {
-            return \React\Promise\reject(new \Exception('User already has role.'));
+            return reject(new \RuntimeException('Member already has role.'));
         }
 
         $headers = [];
@@ -179,10 +205,12 @@ class Member extends Part
     }
 
     /**
-     * Removes a role from the user.
+     * Removes a role from the member.
      *
      * @param Role|string $role   The role to remove from the member.
      * @param string|null $reason Reason for Audit Log.
+     *
+     * @throws \RuntimeException
      *
      * @return ExtendedPromiseInterface
      */
@@ -201,9 +229,9 @@ class Member extends Part
             return $this->http->delete(Endpoint::bind(Endpoint::GUILD_MEMBER_ROLE, $this->guild_id, $this->id, $role), null, $headers);
         }
 
-        return \React\Promise\reject(new \Exception('User does not have role.'));
+        return reject(new \RuntimeException('Member does not have role.'));
     }
-    
+
     /**
      * Sends a message to the member.
      *
@@ -216,6 +244,8 @@ class Member extends Part
      * @param array|null            $allowed_mentions Allowed mentions object for the message.
      * @param Message|null          $replyTo          Sends the message as a reply to the given message instance.
      *
+     * @throws \RuntimeException
+     *
      * @return ExtendedPromiseInterface<Message>
      */
     public function sendMessage($message, bool $tts = false, $embed = null, $allowed_mentions = null, ?Message $replyTo = null): ExtendedPromiseInterface
@@ -224,7 +254,7 @@ class Member extends Part
             return $this->user->sendMessage($message, $tts, $embed, $allowed_mentions, $replyTo);
         }
 
-        return \React\promise\reject(new \Exception('Member had no user part.'));
+        return reject(new \RuntimeException('Member had no user part.'));
     }
 
     /**
@@ -302,6 +332,8 @@ class Member extends Part
      *
      * @param Carbon|null $communication_disabled_until When the user's timeout will expire and the user will be able to communicate in the guild again, null or a time in the past if the user is not timed out.
      *
+     * @throws NoPermissionsException
+     *
      * @return ExtendedPromiseInterface
      */
     public function timeoutMember(?Carbon $communication_disabled_until): ExtendedPromiseInterface
@@ -309,7 +341,7 @@ class Member extends Part
         $botperms = $this->guild->members->offsetGet($this->discord->id)->getPermissions();
 
         if (! $botperms->moderate_members) {
-            return \React\promise\reject(new NoPermissionsException('You do not have permission to time out members in the specified guild.'));
+            return reject(new NoPermissionsException('You do not have permission to time out members in the specified guild.'));
         }
 
         return $this->http->patch(Endpoint::bind(Endpoint::GUILD_MEMBER, $this->guild_id, $this->id), ['communication_disabled_until' => isset($communication_disabled_until) ? $communication_disabled_until->toIso8601ZuluString() : null]);
@@ -339,8 +371,9 @@ class Member extends Part
     /**
      * Gets the activities attribute.
      *
-     * @return Collection|Activity[]
      * @throws \Exception
+     *
+     * @return Collection|Activity[]
      */
     protected function getActivitiesAttribute(): Collection
     {
@@ -386,11 +419,16 @@ class Member extends Part
     /**
      * Returns the user attribute.
      *
-     * @return User       The user that owns the member.
      * @throws \Exception
+     *
+     * @return User|null The user that owns the member.
      */
-    protected function getUserAttribute(): User
+    protected function getUserAttribute(): ?User
     {
+        if (! isset($this->attributes['user'])) {
+            return null;
+        }
+
         if ($user = $this->discord->users->get('id', $this->attributes['user']->id)) {
             return $user;
         }
@@ -405,14 +443,15 @@ class Member extends Part
      */
     protected function getGuildAttribute(): ?Guild
     {
-        return $this->discord->guilds->get('id', $this->guild_id);
+        return $this->discord->guilds->offsetGet($this->guild_id);
     }
 
     /**
      * Returns the roles attribute.
      *
-     * @return Collection A collection of roles the member is in.
      * @throws \Exception
+     *
+     * @return Collection A collection of roles the member is in.
      */
     protected function getRolesAttribute(): Collection
     {
@@ -436,8 +475,9 @@ class Member extends Part
     /**
      * Returns the joined at attribute.
      *
-     * @return Carbon|null The timestamp from when the member joined.
      * @throws \Exception
+     *
+     * @return Carbon|null The timestamp from when the member joined.
      */
     protected function getJoinedAtAttribute(): ?Carbon
     {
@@ -540,7 +580,7 @@ class Member extends Part
      *
      * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         if ($this->nick) {
             return "<@!{$this->id}>";

--- a/src/Discord/Parts/User/User.php
+++ b/src/Discord/Parts/User/User.php
@@ -18,8 +18,12 @@ use Discord\Parts\Part;
 use Discord\Parts\Channel\Message;
 use React\Promise\ExtendedPromiseInterface;
 
+use function React\Promise\resolve;
+
 /**
  * A user is a general user that is not attached to a guild.
+ *
+ * @see https://discord.com/developers/docs/resources/user
  *
  * @property string      $id            The unique identifier of the user.
  * @property string      $username      The username of the user.
@@ -68,17 +72,33 @@ class User extends Part
     /**
      * @inheritdoc
      */
-    protected $fillable = ['id', 'username', 'discriminator', 'avatar', 'bot', 'system', 'mfa_enabled', 'banner', 'accent_color', 'locale', 'verified', 'email', 'flags', 'premium_type', 'public_flags'];
+    protected $fillable = [
+        'id',
+        'username',
+        'discriminator',
+        'avatar',
+        'bot',
+        'system',
+        'mfa_enabled',
+        'locale',
+        'verified',
+        'email',
+        'flags',
+        'banner',
+        'accent_color',
+        'premium_type',
+        'public_flags'
+    ];
 
     /**
      * Gets the private channel for the user.
      *
-     * @return ExtendedPromiseInterface
+     * @return ExtendedPromiseInterface<Channel>
      */
     public function getPrivateChannel(): ExtendedPromiseInterface
     {
         if ($channel = $this->discord->private_channels->get('recipient_id', $this->id)) {
-            return \React\Promise\resolve($channel);
+            return resolve($channel);
         }
 
         return $this->http->post(Endpoint::USER_CURRENT_CHANNELS, ['recipient_id' => $this->id])->then(function ($response) {
@@ -113,12 +133,13 @@ class User extends Part
     /**
      * Broadcasts that you are typing to the channel. Lasts for 5 seconds.
      *
-     * @return ExtendedPromiseInterface
      * @throws \Exception
+     *
+     * @return ExtendedPromiseInterface
      */
     public function broadcastTyping(): ExtendedPromiseInterface
     {
-        return $this->getPrivateChannel()->then(function ($channel) {
+        return $this->getPrivateChannel()->then(function (Channel $channel) {
             return $channel->broadcastTyping();
         });
     }
@@ -216,7 +237,7 @@ class User extends Part
     /**
      * Returns a timestamp for when a user's account was created.
      *
-     * @return float
+     * @return int
      */
     public function createdTimestamp()
     {
@@ -238,7 +259,7 @@ class User extends Part
      *
      * @return string A formatted mention.
      */
-    public function __toString()
+    public function __toString(): string
     {
         return "<@{$this->id}>";
     }

--- a/src/Discord/Parts/User/User.php
+++ b/src/Discord/Parts/User/User.php
@@ -237,7 +237,7 @@ class User extends Part
     /**
      * Returns a timestamp for when a user's account was created.
      *
-     * @return int
+     * @return float
      */
     public function createdTimestamp()
     {

--- a/src/Discord/Parts/WebSockets/PresenceUpdate.php
+++ b/src/Discord/Parts/WebSockets/PresenceUpdate.php
@@ -61,7 +61,7 @@ class PresenceUpdate extends Part
             return $user;
         }
 
-        return $this->factory->create(User::class, $this->attributes['user'], true);
+        return $this->factory->part(User::class, (array) $this->attributes['user'], true);
     }
 
     /**

--- a/src/Discord/Parts/WebSockets/TypingStart.php
+++ b/src/Discord/Parts/WebSockets/TypingStart.php
@@ -104,8 +104,9 @@ class TypingStart extends Part
     /**
      * Gets the timestamp attribute.
      *
-     * @return Carbon     The time that the user started typing.
      * @throws \Exception
+     *
+     * @return Carbon     The time that the user started typing.
      */
     protected function getTimestampAttribute(): Carbon
     {

--- a/src/Discord/Parts/WebSockets/TypingStart.php
+++ b/src/Discord/Parts/WebSockets/TypingStart.php
@@ -124,7 +124,7 @@ class TypingStart extends Part
         }
 
         if (isset($this->attributes['member'])) {
-            return $this->factory->create(Member::class, $this->attributes['member'], true);
+            return $this->factory->part(Member::class, (array) $this->attributes['member'], true);
         }
 
         return null;

--- a/src/Discord/Parts/WebSockets/TypingStart.php
+++ b/src/Discord/Parts/WebSockets/TypingStart.php
@@ -22,77 +22,44 @@ use Discord\Parts\User\User;
  * A TypingStart part is used when the `TYPING_START` event is fired on the WebSocket. It contains
  * information such as when the event was fired and then channel it was fired in.
  *
- * @property User|null      $user       The user that started typing.
- * @property Member|null    $member     The member that started typing.
- * @property string         $user_id    The unique identifier of the user that started typing
- * @property Carbon         $timestamp  A timestamp of when the user started typing.
- * @property Channel|Thread $channel    The channel that the user started typing in.
- * @property string         $channel_id The unique identifier of the channel that the user started typing in.
- * @property Guild|null     $guild      The guild that the user started typing in.
- * @property string|null    $guild_id   The unique identifier of the guild that the user started typing in.
+ * @see https://discord.com/developers/docs/topics/gateway#typing-start
+ *
+ * @property string              $channel_id The unique identifier of the channel that the user started typing in.
+ * @property Channel|Thread|null $channel    The channel that the user started typing in.
+ * @property string|null         $guild_id   The unique identifier of the guild that the user started typing in.
+ * @property Guild|null          $guild      The guild that the user started typing in.
+ * @property string              $user_id    The unique identifier of the user that started typing
+ * @property User|null           $user       The user that started typing.
+ * @property Carbon              $timestamp  A timestamp of when the user started typing.
+ * @property Member|null         $member     The member that started typing.
  */
 class TypingStart extends Part
 {
     /**
      * @inheritdoc
      */
-    protected $fillable = ['user_id', 'timestamp', 'channel_id', 'guild_id', 'member'];
+    protected $fillable = ['channel_id', 'guild_id', 'user_id', 'timestamp', 'member'];
 
     /**
      * @inheritdoc
      */
-    protected $visible = ['user', 'channel', 'guild', 'member'];
+    protected $visible = ['channel', 'guild', 'user', 'member'];
 
-    /**
-     * Gets the user attribute.
-     *
-     * @return User The user that started typing.
-     */
-    protected function getUserAttribute(): ?User
-    {
-        return $this->discord->users->get('id', $this->user_id);
-    }
-
-    /**
-     * Gets the timestamp attribute.
-     *
-     * @return Carbon     The time that the user started typing.
-     * @throws \Exception
-     */
-    protected function getTimestampAttribute(): Carbon
-    {
-        return new Carbon(gmdate('r', $this->attributes['timestamp']));
-    }
-
-    /**
-     * Gets the member attribute.
-     *
-     * @return Member
-     * @throws \Exception
-     */
-    protected function getMemberAttribute(): Part
-    {
-        if ($this->guild && $member = $this->guild->members->get('id', $this->user_id)) {
-            return $member;
-        }
-
-        return $this->factory->create(Member::class, $this->attributes['member'], true);
-    }
 
     /**
      * Gets the channel attribute.
      *
-     * @return Channel|Thread The channel that the user started typing in.
+     * @return Channel|Thread|null The channel that the user started typing in.
      */
     protected function getChannelAttribute()
     {
         if ($this->guild) {
-            if ($channel = $this->guild->channels->get('id', $this->channel_id)) {
+            if ($channel = $this->guild->channels->offsetGet($this->channel_id)) {
                 return $channel;
             }
 
             foreach ($this->guild->channels as $channel) {
-                if ($thread = $channel->threads->get('id', $this->channel_id)) {
+                if ($thread = $channel->threads->offsetGet($this->channel_id)) {
                     return $thread;
                 }
             }
@@ -100,7 +67,7 @@ class TypingStart extends Part
             return null;
         }
 
-        if ($channel = $this->discord->private_channels->get('id', $this->channel_id)) {
+        if ($channel = $this->discord->private_channels->offsetGet($this->channel_id)) {
             return $channel;
         }
 
@@ -122,5 +89,44 @@ class TypingStart extends Part
         }
 
         return $this->discord->guilds->get('id', $this->guild_id);
+    }
+
+    /**
+     * Gets the user attribute.
+     *
+     * @return User|null The user that started typing.
+     */
+    protected function getUserAttribute(): ?User
+    {
+        return $this->discord->users->offsetGet($this->user_id);
+    }
+
+    /**
+     * Gets the timestamp attribute.
+     *
+     * @return Carbon     The time that the user started typing.
+     * @throws \Exception
+     */
+    protected function getTimestampAttribute(): Carbon
+    {
+        return new Carbon(gmdate('r', $this->attributes['timestamp']));
+    }
+
+    /**
+     * Gets the member attribute.
+     *
+     * @return Member|null
+     */
+    protected function getMemberAttribute(): ?Member
+    {
+        if ($this->guild && $member = $this->guild->members->offsetGet($this->user_id)) {
+            return $member;
+        }
+
+        if (isset($this->attributes['member'])) {
+            return $this->factory->create(Member::class, $this->attributes['member'], true);
+        }
+
+        return null;
     }
 }

--- a/src/Discord/Parts/WebSockets/VoiceServerUpdate.php
+++ b/src/Discord/Parts/WebSockets/VoiceServerUpdate.php
@@ -17,9 +17,11 @@ use Discord\Parts\Part;
 /**
  * Tells the client that the voice channel's server has changed.
  *
+ * @see https://discord.com/developers/docs/topics/gateway#voice
+ *
  * @property string $token    The new client voice token.
- * @property Guild  $guild    The guild affected by the change.
  * @property string $guild_id The unique identifier of the guild that was affected by the change.
+ * @property Guild  $guild    The guild affected by the change.
  * @property string $endpoint The new voice server endpoint.
  */
 class VoiceServerUpdate extends Part
@@ -36,6 +38,6 @@ class VoiceServerUpdate extends Part
      */
     protected function getGuildAttribute(): Guild
     {
-        return $this->discord->guilds->get('id', $this->guild_id);
+        return $this->discord->guilds->offsetGet($this->guild_id);
     }
 }

--- a/src/Discord/Parts/WebSockets/VoiceStateUpdate.php
+++ b/src/Discord/Parts/WebSockets/VoiceStateUpdate.php
@@ -21,22 +21,24 @@ use Discord\Parts\User\User;
 /**
  * Notifies the client of voice state updates about users.
  *
+ * @see https://discord.com/developers/docs/resources/voice#voice-state-object
+ *
  * @property string|null  $guild_id                   Guild ID that the voice state came from, or null if it is for a DM channel.
- * @property string|null  $channel_id                 Channel ID that the voice state came from, or null if the user is leaving a channel.
- * @property string       $user_id                    User ID the voice state is for.
- * @property Member|null  $member                     Member object the voice state is for, null if the voice state is for a DM channel or the member object is not cached.
  * @property Guild|null   $guild                      Guild that the voice state came from, or null if it is for a DM channel.
+ * @property string|null  $channel_id                 Channel ID that the voice state came from, or null if the user is leaving a channel.
  * @property Channel|null $channel                    Channel that the voice state came from, or null if the user is leaving a channel.
+ * @property string       $user_id                    User ID the voice state is for.
  * @property User|null    $user                       User the voice state is for, or null if it is not cached.
+ * @property Member|null  $member                     Member object the voice state is for, null if the voice state is for a DM channel or the member object is not cached.
  * @property string       $session_id                 Session ID for the voice state.
- * @property bool         $deaf
- * @property bool         $mute
- * @property bool         $self_deaf
- * @property bool         $self_mute
- * @property bool         $self_stream
- * @property bool         $self_video
- * @property bool         $suppress
- * @property Carbon|null  $request_to_speak_timestamp
+ * @property bool         $deaf                       Whether this user is deafened by the server.
+ * @property bool         $mute                       Whether this user is muted by the server.
+ * @property bool         $self_deaf                  Whether this user is locally deafened.
+ * @property bool         $self_mute                  Whether this user is locally muted.
+ * @property bool         $self_stream                Whether this user is streaming using "Go Live".
+ * @property bool         $self_video                 Whether this user's camera is enabled.
+ * @property bool         $suppress                   Whether this user is muted by the current user.
+ * @property Carbon|null  $request_to_speak_timestamp The time at which the user requested to speak.
  */
 class VoiceStateUpdate extends Part
 {
@@ -60,23 +62,13 @@ class VoiceStateUpdate extends Part
     ];
 
     /**
-     * Gets the member attribute.
+     * Gets the guild attribute.
      *
-     * @return Member|null The member attribute.
+     * @return Guild|null The guild attribute.
      */
-    protected function getMemberAttribute(): ?Member
+    protected function getGuildAttribute(): ?Guild
     {
-        if ($this->guild) {
-            if ($member = $this->guild->members->get('id', $this->user_id)) {
-                return $member;
-            }
-        }
-
-        if ($this->attributes['member'] ?? null) {
-            return $this->factory->create(Member::class, $this->attributes['member'], true);
-        }
-
-        return null;
+        return $this->discord->guilds->get('id', $this->guild_id);
     }
 
     /**
@@ -104,7 +96,7 @@ class VoiceStateUpdate extends Part
      */
     protected function getUserAttribute(): ?User
     {
-        if ($user = $this->discord->users->get('id', $this->user_id)) {
+        if ($user = $this->discord->users->offsetGet($this->user_id)) {
             return $user;
         }
 
@@ -116,15 +108,23 @@ class VoiceStateUpdate extends Part
     }
 
     /**
-     * Gets the guild attribute.
+     * Gets the member attribute.
      *
-     * @return Guild|null The guild attribute.
+     * @return Member|null The member attribute.
      */
-    protected function getGuildAttribute(): ?Guild
+    protected function getMemberAttribute(): ?Member
     {
-        return $this->discord->guilds->get('id', $this->guild_id);
+        if ($this->guild && $member = $this->guild->members->offsetGet($this->user_id)) {
+            return $member;
+        }
+
+        if (isset($this->attributes['member'])) {
+            return $this->factory->create(Member::class, $this->attributes['member'], true);
+        }
+
+        return null;
     }
-    
+
     /**
      * Gets the request_to_speak_timestamp attribute.
      *
@@ -132,7 +132,7 @@ class VoiceStateUpdate extends Part
      */
     protected function getRequestToSpeakTimestampAttribute(): ?Carbon
     {
-        if ($this->attributes['request_to_speak_timestamp'] ?? null) {
+        if (isset($this->attributes['request_to_speak_timestamp'])) {
             return new Carbon($this->attributes['request_to_speak_timestamp']);
         }
 

--- a/src/Discord/Parts/WebSockets/VoiceStateUpdate.php
+++ b/src/Discord/Parts/WebSockets/VoiceStateUpdate.php
@@ -119,7 +119,7 @@ class VoiceStateUpdate extends Part
         }
 
         if (isset($this->attributes['member'])) {
-            return $this->factory->create(Member::class, $this->attributes['member'], true);
+            return $this->factory->part(Member::class, (array) $this->attributes['member'], true);
         }
 
         return null;

--- a/src/Discord/Repository/Guild/GuildCommandRepository.php
+++ b/src/Discord/Repository/Guild/GuildCommandRepository.php
@@ -54,17 +54,14 @@ class GuildCommandRepository extends AbstractRepository
     /**
      * Sets overwrite to all application commands in the guild.
      *
-     * @param Part      $part      A role or user.
+     * @see https://discord.com/developers/docs/interactions/application-commands#batch-edit-application-command-permissions
+     *
      * @param Overwrite $overwrite An overwrite object.
      *
      * @return ExtendedPromiseInterface
      */
-    public function setOverwrite(Part $part, Overwrite $overwrite): ExtendedPromiseInterface
+    public function setOverwrite(Overwrite $overwrite): ExtendedPromiseInterface
     {
-        if (!($part instanceof Role || $part instanceof User || $part instanceof Member)) {
-            return \React\Promise\reject(new InvalidOverwriteException('Given part was not one of role or user.'));
-        }
-
-        return $this->http->put(Endpoint::bind(Endpoint::GUILD_APPLICATION_COMMAND_PERMISSIONS, $this->vars['application_id'], $this->vars['guild_']), $overwrite->getRawAttributes());
+        return $this->http->put(Endpoint::bind(Endpoint::GUILD_APPLICATION_COMMANDS_PERMISSIONS, $this->vars['application_id'], $this->vars['guild_id']), $overwrite->getRawAttributes());
     }
 }

--- a/src/Discord/Repository/Guild/GuildCommandRepository.php
+++ b/src/Discord/Repository/Guild/GuildCommandRepository.php
@@ -53,6 +53,8 @@ class GuildCommandRepository extends AbstractRepository
      *
      * @param Overwrite $overwrite An overwrite object.
      *
+     * @deprecated 7.0.0
+     *
      * @return ExtendedPromiseInterface
      */
     public function setOverwrite(Overwrite $overwrite): ExtendedPromiseInterface

--- a/src/Discord/Repository/Guild/GuildCommandRepository.php
+++ b/src/Discord/Repository/Guild/GuildCommandRepository.php
@@ -11,14 +11,9 @@
 
 namespace Discord\Repository\Guild;
 
-use Discord\Exceptions\InvalidOverwriteException;
 use Discord\Http\Endpoint;
-use Discord\Parts\Guild\Role;
 use Discord\Parts\Interactions\Command\Command;
 use Discord\Parts\Interactions\Command\Overwrite;
-use Discord\Parts\Part;
-use Discord\Parts\User\Member;
-use Discord\Parts\User\User;
 use Discord\Repository\AbstractRepository;
 use React\Promise\ExtendedPromiseInterface;
 

--- a/src/Discord/Repository/Guild/OverwriteRepository.php
+++ b/src/Discord/Repository/Guild/OverwriteRepository.php
@@ -40,6 +40,4 @@ class OverwriteRepository extends AbstractRepository
      * @inheritdoc
      */
     protected $class = Overwrite::class;
-
-    // TODO PUT endpoints
 }


### PR DESCRIPTION
This PR tries to add exception where possible, as well correcting existing throwable and its phpdoc

Based on this https://www.php.net/manual/en/spl.exceptions.php#spl.exceptions.tree the closest exception should be used, for example the command builder had `RangeException` while it should be `LengthException` to adhere the `LogicException` where the code must be fixed at compile time and not `RuntimeException` where the code may have error during run time, due to command builder is being written at compile time.

A `RunTimeException` inside `Promise` of a `Http` request should be also changed to `reject()` instead of `throw`

Also for checking permission if creating request is allowed or not.

Currently have completed with Interactions (Commands and Message Components), will check other classes later.

Also added missing attributes from several Part classes, the phpdoc property attributes is sorted following the API Documentation, and the fillable is sorted by the JSON payload data