### PR TITLE
Add Thread::archive and Thread::unarchive

### DIFF
--- a/src/Discord/Parts/Thread/Thread.php
+++ b/src/Discord/Parts/Thread/Thread.php
@@ -304,6 +304,26 @@ class Thread extends Part
     }
 
     /**
+     * Archive the thread.
+     *
+     * @return ExtendedPromiseInterface
+     */
+    public function archive(): ExtendedPromiseInterface
+    {
+        return $this->http->patch(Endpoint::bind(Endpoint::THREAD, $this->id), ['archived' => true]);
+    }
+
+    /**
+     * Unarchive the thread.
+     *
+     * @return ExtendedPromiseInterface
+     */
+    public function unarchive(): ExtendedPromiseInterface
+    {
+        return $this->http->patch(Endpoint::bind(Endpoint::THREAD, $this->id), ['archived' => false]);
+    }
+
+    /**
      * Returns the thread's pinned messages.
      *
      * @return ExtendedPromiseInterface<Collection<Message>>


### PR DESCRIPTION
Added methods for bot to archive or unarchive thread, unarchiving thread requires no permission as long the bot is already inside the thread and the thread is not locked.