### PR TITLE
Add Member::displayname and User::displayname

### DIFF
--- a/src/Discord/Parts/User/Member.php
+++ b/src/Discord/Parts/User/Member.php
@@ -34,6 +34,7 @@ use React\Promise\ExtendedPromiseInterface;
  * @property string                $id                           The unique identifier of the member.
  * @property string                $username                     The username of the member.
  * @property string                $discriminator                The discriminator of the member.
+ * @property string                $displayname                  The nickname or username with discriminator of the member.
  * @property User                  $user                         The user part of the member.
  * @property Collection|Role[]     $roles                        A collection of Roles that the member has.
  * @property bool                  $deaf                         Whether the member is deaf.
@@ -312,6 +313,16 @@ class Member extends Part
         }
 
         return $this->http->patch(Endpoint::bind(Endpoint::GUILD_MEMBER, $this->guild_id, $this->id), ['communication_disabled_until' => isset($communication_disabled_until) ? $communication_disabled_until->toIso8601ZuluString() : null]);
+    }
+
+    /**
+     * Returns the member nickname or username with the discriminator.
+     *
+     * @return string Nickname#Discriminator
+     */
+    protected function getDisplaynameAttribute(): string
+    {
+        return ($this->nick ?? $this->username) . '#' . $this->discriminator;
     }
 
     /**

--- a/src/Discord/Parts/User/User.php
+++ b/src/Discord/Parts/User/User.php
@@ -24,6 +24,7 @@ use React\Promise\ExtendedPromiseInterface;
  * @property string      $id            The unique identifier of the user.
  * @property string      $username      The username of the user.
  * @property string      $discriminator The discriminator of the user.
+ * @property string      $displayname   The username and discriminator of the user.
  * @property string      $avatar        The avatar URL of the user.
  * @property string      $avatar_hash   The avatar hash of the user.
  * @property bool|null   $bot           Whether the user is a bot.
@@ -120,6 +121,16 @@ class User extends Part
         return $this->getPrivateChannel()->then(function ($channel) {
             return $channel->broadcastTyping();
         });
+    }
+
+    /**
+     * Returns the username with the discriminator.
+     *
+     * @return string Username#Discriminator
+     */
+    protected function getDisplaynameAttribute(): string
+    {
+        return $this->username . '#' . $this->discriminator;
     }
 
     /**


### PR DESCRIPTION
Added new attribute `displayname` to make it easy displaying user name and discriminator tag like `Robo_N1X#0001`, already tested.


* Note: named it "displayname" on purpose instead of "display_name" (let me know if you are against it)