### PR TITLE
Add MessageReaction to MessageReactionRemoveEmoji

### DIFF
--- a/docs/src/pages/api/03_events.md
+++ b/docs/src/pages/api/03_events.md
@@ -111,20 +111,12 @@ $discord->on(Event::MESSAGE_REACTION_REMOVE_ALL, function (MessageReaction $reac
 ### Message Reaction Remove Emoji
 
 Called with an object when all reactions of an emoji are removed from a message.
-This event is still to be implemented.
+Unlike Message Reaction Remove, this event contains no users or members.
 Requires the `Intents::GUILD_MESSAGE_REACTIONS` intent.
 
 ```php
-$discord->on(Event::MESSAGE_REACTION_REMOVE_EMOJI, function ($reaction, Discord $discord) {
-    // {
-    //     "channel_id": "",
-    //     "guild_id": "",
-    //     "message_id": "",
-    //     "emoji": {
-    //         "id": "",
-    //         "name": ""
-    //     }
-    // }
+$discord->on(Event::MESSAGE_REACTION_REMOVE_EMOJI, function (MessageReaction $reaction, Discord $discord) {
+    // ...
 });
 ```
 

--- a/src/Discord/Parts/WebSockets/MessageReaction.php
+++ b/src/Discord/Parts/WebSockets/MessageReaction.php
@@ -21,6 +21,7 @@ use Discord\Parts\User\Member;
 use Discord\Parts\User\User;
 use React\Promise\ExtendedPromiseInterface;
 
+use function React\Promise\reject;
 use function React\Promise\resolve;
 
 /**
@@ -28,7 +29,7 @@ use function React\Promise\resolve;
  * Different from `Reaction` in the fact that `Reaction` represents a specific reaction
  * to a message by _multiple_ members.
  *
- * @property string         $user_id     ID of the user that performed the reaction.
+ * @property string|null    $user_id     ID of the user that performed the reaction.
  * @property User|null      $user        User that performed the reaction.
  * @property string         $channel_id  ID of the channel that the reaction was performed in.
  * @property Channel|Thread $channel     Channel that the reaction was performed in.
@@ -220,6 +221,8 @@ class MessageReaction extends Part
      *
      * @param int|null $type The type of deletion to perform.
      *
+     * @throws \UnexpectedValueException
+     *
      * @return ExtendedPromiseInterface
      */
     public function delete(?int $type = null): ExtendedPromiseInterface
@@ -246,7 +249,10 @@ class MessageReaction extends Part
                 break;
             case Message::REACT_DELETE_ID:
             default:
-                $url = Endpoint::bind(Endpoint::USER_MESSAGE_REACTION, $this->channel_id, $this->message_id, $reaction, $this->user_id);
+                if (! $userid = $this->user_id ?? $this->user->id) {
+                    return reject(new \UnexpectedValueException('This reaction has no user id'));
+                }
+                $url = Endpoint::bind(Endpoint::USER_MESSAGE_REACTION, $this->channel_id, $this->message_id, $reaction, $userid);
                 break;
         }
 

--- a/src/Discord/WebSockets/Events/MessageReactionRemoveEmoji.php
+++ b/src/Discord/WebSockets/Events/MessageReactionRemoveEmoji.php
@@ -13,6 +13,7 @@ namespace Discord\WebSockets\Events;
 
 use Discord\WebSockets\Event;
 use Discord\Helpers\Deferred;
+use Discord\Parts\WebSockets\MessageReaction;
 
 class MessageReactionRemoveEmoji extends Event
 {
@@ -21,16 +22,15 @@ class MessageReactionRemoveEmoji extends Event
      */
     public function handle(Deferred &$deferred, $data): void
     {
-        if ($channel = $this->discord->getChannel($data->channel_id)) {
-            if ($message = $channel->messages->offsetGet($data->message_id)) {
-                foreach ($message->reactions as $key => $react) {
-                    if ($react->id == $data->id) {
-                        unset($message->reactions[$key]);
-                    }
-                }
+        $reaction = new MessageReaction($this->discord, (array) $data, true);
+
+        if ($message = $reaction->message) {
+            $react = $reaction->emoji->toReactionString();
+            if ($message->reactions->offsetExists($react)) {
+                $message->reactions->offsetUnset($react);
             }
         }
 
-        $deferred->resolve($data);
+        $deferred->resolve($reaction);
     }
 }


### PR DESCRIPTION
Implements `MessageReaction` Part for `Event::MESSAGE_REACTION_REMOVE_EMOJI`

Also Fixes #687 

Tested with unicode emoji & custom emoji