### PR TITLE
Update deprecated set bot nickname endpoint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "react/http": "^1.1",
         "ext-json": "*",
         "ext-zlib": "*",
-        "discord-php/http": "^9.0.5",
+        "discord-php/http": "^9.0.9",
         "react/child-process": "^0.6.2",
         "discord/interactions": "^2.1"
     },

--- a/src/Discord/Parts/User/Member.php
+++ b/src/Discord/Parts/User/Member.php
@@ -147,7 +147,7 @@ class Member extends Part
 
         // jake plz
         if ($this->discord->id == $this->id) {
-            return $this->http->patch(Endpoint::bind(Endpoint::GUILD_MEMBER_SELF_NICK, $this->guild_id), $payload, $headers);
+            return $this->http->patch(Endpoint::bind(Endpoint::GUILD_MEMBER_SELF, $this->guild_id), $payload, $headers);
         }
 
         return $this->http->patch(Endpoint::bind(Endpoint::GUILD_MEMBER, $this->guild_id, $this->id), $payload, $headers);


### PR DESCRIPTION
This updates the endpoint used in `Member::setNickname` when used on the Bot itself

It has been tested and can be merged right away