### PR TITLE
Add user caching from event

### DIFF
--- a/src/Discord/WebSockets/Event.php
+++ b/src/Discord/WebSockets/Event.php
@@ -150,6 +150,21 @@ abstract class Event
      */
     abstract public function handle(Deferred &$deferred, $data);
 
+    /**
+     * Cache User repository from Event data
+     *
+     * @param object $userdata
+     */
+    protected function cacheUser($userdata)
+    {
+        // User caching
+        if ($user = $this->discord->users->get('id', $userdata->id)) {
+            $user->fill((array) $userdata);
+        } else {
+            $this->discord->users->pushItem($this->factory->part(\Discord\Parts\User\User::class, (array) $userdata, true));
+        }
+    }
+
     public function __debugInfo(): array
     {
         return [];

--- a/src/Discord/WebSockets/Events/GuildBanAdd.php
+++ b/src/Discord/WebSockets/Events/GuildBanAdd.php
@@ -14,7 +14,6 @@ namespace Discord\WebSockets\Events;
 use Discord\Parts\Guild\Ban;
 use Discord\WebSockets\Event;
 use Discord\Helpers\Deferred;
-use Discord\Parts\User\User;
 
 class GuildBanAdd extends Event
 {
@@ -30,12 +29,7 @@ class GuildBanAdd extends Event
             $this->discord->guilds->push($guild);
         }
 
-        // User caching
-        if ($user = $this->discord->users->get('id', $data->user->id)) {
-            $user->fill((array) $data->user);
-        } else {
-            $this->discord->users->pushItem($this->factory->part(User::class, (array) $data->user, true));
-        }
+        $this->cacheUser($data->user);
 
         $deferred->resolve($ban);
     }

--- a/src/Discord/WebSockets/Events/GuildBanAdd.php
+++ b/src/Discord/WebSockets/Events/GuildBanAdd.php
@@ -14,6 +14,7 @@ namespace Discord\WebSockets\Events;
 use Discord\Parts\Guild\Ban;
 use Discord\WebSockets\Event;
 use Discord\Helpers\Deferred;
+use Discord\Parts\User\User;
 
 class GuildBanAdd extends Event
 {
@@ -27,6 +28,13 @@ class GuildBanAdd extends Event
         if ($guild = $ban->guild) {
             $guild->bans->push($ban);
             $this->discord->guilds->push($guild);
+        }
+
+        // User caching
+        if ($user = $this->discord->users->get('id', $data->user->id)) {
+            $user->fill((array) $data->user);
+        } else {
+            $this->discord->users->pushItem($this->factory->part(User::class, (array) $data->user, true));
         }
 
         $deferred->resolve($ban);

--- a/src/Discord/WebSockets/Events/GuildBanRemove.php
+++ b/src/Discord/WebSockets/Events/GuildBanRemove.php
@@ -14,6 +14,7 @@ namespace Discord\WebSockets\Events;
 use Discord\Parts\Guild\Ban;
 use Discord\WebSockets\Event;
 use Discord\Helpers\Deferred;
+use Discord\Parts\User\User;
 
 class GuildBanRemove extends Event
 {
@@ -27,6 +28,13 @@ class GuildBanRemove extends Event
         if ($guild = $ban->guild) {
             $guild->bans->pull($ban->user->id);
             $this->discord->guilds->push($guild);
+        }
+
+        // User caching
+        if ($user = $this->discord->users->get('id', $data->user->id)) {
+            $user->fill((array) $data->user);
+        } else {
+            $this->discord->users->pushItem($this->factory->part(User::class, (array) $data->user, true));
         }
 
         $deferred->resolve($ban);

--- a/src/Discord/WebSockets/Events/GuildBanRemove.php
+++ b/src/Discord/WebSockets/Events/GuildBanRemove.php
@@ -14,7 +14,6 @@ namespace Discord\WebSockets\Events;
 use Discord\Parts\Guild\Ban;
 use Discord\WebSockets\Event;
 use Discord\Helpers\Deferred;
-use Discord\Parts\User\User;
 
 class GuildBanRemove extends Event
 {
@@ -30,12 +29,7 @@ class GuildBanRemove extends Event
             $this->discord->guilds->push($guild);
         }
 
-        // User caching
-        if ($user = $this->discord->users->get('id', $data->user->id)) {
-            $user->fill((array) $data->user);
-        } else {
-            $this->discord->users->pushItem($this->factory->part(User::class, (array) $data->user, true));
-        }
+        $this->cacheUser($data->user);
 
         $deferred->resolve($ban);
     }

--- a/src/Discord/WebSockets/Events/GuildEmojisUpdate.php
+++ b/src/Discord/WebSockets/Events/GuildEmojisUpdate.php
@@ -15,7 +15,6 @@ use Discord\Helpers\Collection;
 use Discord\WebSockets\Event;
 use Discord\Helpers\Deferred;
 use Discord\Parts\Guild\Emoji;
-use Discord\Parts\User\User;
 
 class GuildEmojisUpdate extends Event
 {
@@ -35,11 +34,7 @@ class GuildEmojisUpdate extends Event
         foreach ($data->emojis as $emoji) {
             if (isset($emoji->user)) {
                 // User caching from emoji uploader
-                if ($user = $this->discord->users->get('id', $emoji->user->id)) {
-                    $user->fill((array) $emoji->user);
-                } else {
-                    $this->discord->users->pushItem($this->factory->part(User::class, (array) $emoji->user, true));
-                }
+                $this->cacheUser($emoji->user);
             } elseif ($oldPart = $oldParts->offsetGet($emoji->id)) {
                 $emoji->user = $oldPart->user;
             }

--- a/src/Discord/WebSockets/Events/GuildMemberAdd.php
+++ b/src/Discord/WebSockets/Events/GuildMemberAdd.php
@@ -30,7 +30,13 @@ class GuildMemberAdd extends Event
             ++$guild->member_count;
         }
 
-        $this->discord->users->push($member->user);
+        // User caching
+        if ($user = $this->discord->users->get('id', $data->user->id)) {
+            $user->fill((array) $data->user);
+        } else {
+            $this->discord->users->pushItem($member->user);
+        }
+
         $deferred->resolve($member);
     }
 }

--- a/src/Discord/WebSockets/Events/GuildMemberAdd.php
+++ b/src/Discord/WebSockets/Events/GuildMemberAdd.php
@@ -30,12 +30,7 @@ class GuildMemberAdd extends Event
             ++$guild->member_count;
         }
 
-        // User caching
-        if ($user = $this->discord->users->get('id', $data->user->id)) {
-            $user->fill((array) $data->user);
-        } else {
-            $this->discord->users->pushItem($member->user);
-        }
+        $this->cacheUser($data->user);
 
         $deferred->resolve($member);
     }

--- a/src/Discord/WebSockets/Events/GuildMemberRemove.php
+++ b/src/Discord/WebSockets/Events/GuildMemberRemove.php
@@ -14,6 +14,7 @@ namespace Discord\WebSockets\Events;
 use Discord\Parts\User\Member;
 use Discord\WebSockets\Event;
 use Discord\Helpers\Deferred;
+use Discord\Parts\User\User;
 
 class GuildMemberRemove extends Event
 {
@@ -29,6 +30,13 @@ class GuildMemberRemove extends Event
             --$guild->member_count;
 
             $this->discord->guilds->push($guild);
+        }
+
+        // User caching
+        if ($user = $this->discord->users->get('id', $data->user->id)) {
+            $user->fill((array) $data->user);
+        } else {
+            $this->discord->users->pushItem($this->factory->part(User::class, (array) $data->user, true));
         }
 
         $deferred->resolve($member);

--- a/src/Discord/WebSockets/Events/GuildMemberRemove.php
+++ b/src/Discord/WebSockets/Events/GuildMemberRemove.php
@@ -14,7 +14,6 @@ namespace Discord\WebSockets\Events;
 use Discord\Parts\User\Member;
 use Discord\WebSockets\Event;
 use Discord\Helpers\Deferred;
-use Discord\Parts\User\User;
 
 class GuildMemberRemove extends Event
 {
@@ -32,12 +31,7 @@ class GuildMemberRemove extends Event
             $this->discord->guilds->push($guild);
         }
 
-        // User caching
-        if ($user = $this->discord->users->get('id', $data->user->id)) {
-            $user->fill((array) $data->user);
-        } else {
-            $this->discord->users->pushItem($this->factory->part(User::class, (array) $data->user, true));
-        }
+        $this->cacheUser($data->user);
 
         $deferred->resolve($member);
     }

--- a/src/Discord/WebSockets/Events/GuildMemberUpdate.php
+++ b/src/Discord/WebSockets/Events/GuildMemberUpdate.php
@@ -34,8 +34,11 @@ class GuildMemberUpdate extends Event
             $guild->members->push($memberPart);
         }
 
+        // User caching
         if ($user = $this->discord->users->get('id', $data->user->id)) {
             $user->fill((array) $data->user);
+        } else {
+            $this->discord->users->pushItem($this->factory->part(User::class, (array) $data->user, true));
         }
 
         $deferred->resolve([$memberPart, $old]);

--- a/src/Discord/WebSockets/Events/GuildMemberUpdate.php
+++ b/src/Discord/WebSockets/Events/GuildMemberUpdate.php
@@ -34,12 +34,7 @@ class GuildMemberUpdate extends Event
             $guild->members->push($memberPart);
         }
 
-        // User caching
-        if ($user = $this->discord->users->get('id', $data->user->id)) {
-            $user->fill((array) $data->user);
-        } else {
-            $this->discord->users->pushItem($this->factory->part(User::class, (array) $data->user, true));
-        }
+        $this->cacheUser($data->user);
 
         $deferred->resolve([$memberPart, $old]);
     }

--- a/src/Discord/WebSockets/Events/GuildScheduledEventCreate.php
+++ b/src/Discord/WebSockets/Events/GuildScheduledEventCreate.php
@@ -14,6 +14,7 @@ namespace Discord\WebSockets\Events;
 use Discord\WebSockets\Event;
 use Discord\Helpers\Deferred;
 use Discord\Parts\Guild\ScheduledEvent;
+use Discord\Parts\User\User;
 
 class GuildScheduledEventCreate extends Event
 {
@@ -27,6 +28,15 @@ class GuildScheduledEventCreate extends Event
 
         if ($guild = $this->discord->guilds->get('id', $scheduled_event->guild_id)) {
             $guild->guild_scheduled_events->push($scheduled_event);
+        }
+
+        // User caching
+        if (isset($data->creator)) {
+            if ($user = $this->discord->users->get('id', $data->creator->id)) {
+                $user->fill((array) $data->creator);
+            } else {
+                $this->discord->users->pushItem($this->factory->part(User::class, (array) $data->creator, true));
+            }
         }
 
         $deferred->resolve($scheduled_event);

--- a/src/Discord/WebSockets/Events/GuildScheduledEventCreate.php
+++ b/src/Discord/WebSockets/Events/GuildScheduledEventCreate.php
@@ -14,7 +14,6 @@ namespace Discord\WebSockets\Events;
 use Discord\WebSockets\Event;
 use Discord\Helpers\Deferred;
 use Discord\Parts\Guild\ScheduledEvent;
-use Discord\Parts\User\User;
 
 class GuildScheduledEventCreate extends Event
 {
@@ -30,13 +29,8 @@ class GuildScheduledEventCreate extends Event
             $guild->guild_scheduled_events->push($scheduled_event);
         }
 
-        // User caching
         if (isset($data->creator)) {
-            if ($user = $this->discord->users->get('id', $data->creator->id)) {
-                $user->fill((array) $data->creator);
-            } else {
-                $this->discord->users->pushItem($this->factory->part(User::class, (array) $data->creator, true));
-            }
+            $this->cacheUser($data->creator);
         }
 
         $deferred->resolve($scheduled_event);

--- a/src/Discord/WebSockets/Events/GuildScheduledEventDelete.php
+++ b/src/Discord/WebSockets/Events/GuildScheduledEventDelete.php
@@ -14,7 +14,6 @@ namespace Discord\WebSockets\Events;
 use Discord\WebSockets\Event;
 use Discord\Helpers\Deferred;
 use Discord\Parts\Guild\ScheduledEvent;
-use Discord\Parts\User\User;
 
 class GuildScheduledEventDelete extends Event
 {
@@ -30,13 +29,8 @@ class GuildScheduledEventDelete extends Event
             $guild->guild_scheduled_events->pull($scheduled_event->id);
         }
 
-        // User caching
         if (isset($data->creator)) {
-            if ($user = $this->discord->users->get('id', $data->creator->id)) {
-                $user->fill((array) $data->creator);
-            } else {
-                $this->discord->users->pushItem($this->factory->part(User::class, (array) $data->creator, true));
-            }
+            $this->cacheUser($data->creator);
         }
 
         $deferred->resolve($scheduled_event);

--- a/src/Discord/WebSockets/Events/GuildScheduledEventDelete.php
+++ b/src/Discord/WebSockets/Events/GuildScheduledEventDelete.php
@@ -14,6 +14,7 @@ namespace Discord\WebSockets\Events;
 use Discord\WebSockets\Event;
 use Discord\Helpers\Deferred;
 use Discord\Parts\Guild\ScheduledEvent;
+use Discord\Parts\User\User;
 
 class GuildScheduledEventDelete extends Event
 {
@@ -27,6 +28,15 @@ class GuildScheduledEventDelete extends Event
 
         if ($guild = $scheduled_event->guild) {
             $guild->guild_scheduled_events->pull($scheduled_event->id);
+        }
+
+        // User caching
+        if (isset($data->creator)) {
+            if ($user = $this->discord->users->get('id', $data->creator->id)) {
+                $user->fill((array) $data->creator);
+            } else {
+                $this->discord->users->pushItem($this->factory->part(User::class, (array) $data->creator, true));
+            }
         }
 
         $deferred->resolve($scheduled_event);

--- a/src/Discord/WebSockets/Events/GuildScheduledEventUpdate.php
+++ b/src/Discord/WebSockets/Events/GuildScheduledEventUpdate.php
@@ -14,7 +14,6 @@ namespace Discord\WebSockets\Events;
 use Discord\WebSockets\Event;
 use Discord\Helpers\Deferred;
 use Discord\Parts\Guild\ScheduledEvent;
-use Discord\Parts\User\User;
 
 class GuildScheduledEventUpdate extends Event
 {
@@ -31,14 +30,7 @@ class GuildScheduledEventUpdate extends Event
             $guild->guild_scheduled_events->push($scheduled_event);
         }
 
-        // User caching
-        if (isset($data->creator)) {
-            if ($user = $this->discord->users->get('id', $data->creator->id)) {
-                $user->fill((array) $data->creator);
-            } else {
-                $this->discord->users->pushItem($this->factory->part(User::class, (array) $data->creator, true));
-            }
-        }
+        $this->cacheUser($data->creator);
 
         $deferred->resolve([$scheduled_event, $old]);
     }

--- a/src/Discord/WebSockets/Events/GuildScheduledEventUpdate.php
+++ b/src/Discord/WebSockets/Events/GuildScheduledEventUpdate.php
@@ -14,6 +14,7 @@ namespace Discord\WebSockets\Events;
 use Discord\WebSockets\Event;
 use Discord\Helpers\Deferred;
 use Discord\Parts\Guild\ScheduledEvent;
+use Discord\Parts\User\User;
 
 class GuildScheduledEventUpdate extends Event
 {
@@ -28,6 +29,15 @@ class GuildScheduledEventUpdate extends Event
         if ($guild = $this->discord->guilds->get('id', $scheduled_event->guild_id)) {
             $old = $guild->guild_scheduled_events->get('id', $scheduled_event->id);
             $guild->guild_scheduled_events->push($scheduled_event);
+        }
+
+        // User caching
+        if (isset($data->creator)) {
+            if ($user = $this->discord->users->get('id', $data->creator->id)) {
+                $user->fill((array) $data->creator);
+            } else {
+                $this->discord->users->pushItem($this->factory->part(User::class, (array) $data->creator, true));
+            }
         }
 
         $deferred->resolve([$scheduled_event, $old]);

--- a/src/Discord/WebSockets/Events/GuildStickersUpdate.php
+++ b/src/Discord/WebSockets/Events/GuildStickersUpdate.php
@@ -15,7 +15,6 @@ use Discord\Helpers\Collection;
 use Discord\WebSockets\Event;
 use Discord\Helpers\Deferred;
 use Discord\Parts\Guild\Sticker;
-use Discord\Parts\User\User;
 
 class GuildStickersUpdate extends Event
 {
@@ -35,11 +34,7 @@ class GuildStickersUpdate extends Event
         foreach ($data->stickers as $sticker) {
             if (isset($sticker->user)) {
                 // User caching from sticker uploader
-                if ($user = $this->discord->users->get('id', $sticker->user->id)) {
-                    $user->fill((array) $sticker->user);
-                } else {
-                    $this->discord->users->pushItem($this->factory->part(User::class, (array) $sticker->user, true));
-                }
+                $this->cacheUser($sticker->user);
             } elseif($oldPart = $oldParts->offsetGet($sticker->id)) {
                 $sticker->user = $oldPart->user;
             }

--- a/src/Discord/WebSockets/Events/IntegrationCreate.php
+++ b/src/Discord/WebSockets/Events/IntegrationCreate.php
@@ -30,7 +30,7 @@ class IntegrationCreate extends Event
         }
 
         // User caching
-        if (! isset($data->user)) {
+        if (isset($data->user)) {
             if ($user = $this->discord->users->get('id', $data->user->id)) {
                 $user->fill((array) $data->user);
             } else {

--- a/src/Discord/WebSockets/Events/IntegrationCreate.php
+++ b/src/Discord/WebSockets/Events/IntegrationCreate.php
@@ -29,13 +29,8 @@ class IntegrationCreate extends Event
             $guild->integrations->pushItem($integration);
         }
 
-        // User caching
         if (isset($data->user)) {
-            if ($user = $this->discord->users->get('id', $data->user->id)) {
-                $user->fill((array) $data->user);
-            } else {
-                $this->discord->users->pushItem($this->factory->part(User::class, (array) $data->user, true));
-            }
+            $this->cacheUser($data->user);
         }
 
         $deferred->resolve($integration);

--- a/src/Discord/WebSockets/Events/IntegrationUpdate.php
+++ b/src/Discord/WebSockets/Events/IntegrationUpdate.php
@@ -30,7 +30,7 @@ class IntegrationUpdate extends Event
         }
 
         // User caching
-        if (! isset($data->user)) {
+        if (isset($data->user)) {
             if ($user = $this->discord->users->get('id', $data->user->id)) {
                 $user->fill((array) $data->user);
             } else {

--- a/src/Discord/WebSockets/Events/IntegrationUpdate.php
+++ b/src/Discord/WebSockets/Events/IntegrationUpdate.php
@@ -29,13 +29,8 @@ class IntegrationUpdate extends Event
             $guild->integrations->pushItem($integration);
         }
 
-        // User caching
         if (isset($data->user)) {
-            if ($user = $this->discord->users->get('id', $data->user->id)) {
-                $user->fill((array) $data->user);
-            } else {
-                $this->discord->users->pushItem($this->factory->part(User::class, (array) $data->user, true));
-            }
+            $this->cacheUser($data->user);
         }
 
         $deferred->resolve($integration);

--- a/src/Discord/WebSockets/Events/InteractionCreate.php
+++ b/src/Discord/WebSockets/Events/InteractionCreate.php
@@ -58,22 +58,14 @@ class InteractionCreate extends Event
             }
         }
 
-        // User caching from member
         if (isset($data->member->user)) {
-            if ($user = $this->discord->users->get('id', $data->member->user->id)) {
-                $user->fill((array) $data->member->user);
-            } else {
-                $this->discord->users->pushItem($this->factory->part(User::class, (array) $data->member->user, true));
-            }
+            // User caching from member
+            $this->cacheUser($data->member->user);
         }
 
-        // User caching
         if (isset($data->user)) {
-            if ($user = $this->discord->users->get('id', $data->user->id)) {
-                $user->fill((array) $data->user);
-            } else {
-                $this->discord->users->pushItem($this->factory->part(User::class, (array) $data->user, true));
-            }
+            // User caching from user dm
+            $this->cacheUser($data->user);
         }
 
         $deferred->resolve($interaction);

--- a/src/Discord/WebSockets/Events/InteractionCreate.php
+++ b/src/Discord/WebSockets/Events/InteractionCreate.php
@@ -30,8 +30,7 @@ class InteractionCreate extends Event
             if ($userPart = $this->discord->users->get('id', $snowflake)) {
                 $userPart->fill((array) $user);
             } else {
-                $userPart = $this->factory->create(User::class, $user, true);
-                $this->discord->users->pushItem($userPart);
+                $this->discord->users->pushItem($this->factory->part(User::class, (array) $user, true));
             }
         }
 
@@ -56,6 +55,24 @@ class InteractionCreate extends Event
                 if ($this->discord->application_commands[$interaction->data['name']]->suggest($interaction)) {
                     return;
                 }
+            }
+        }
+
+        // User caching from member
+        if (isset($data->member->user)) {
+            if ($user = $this->discord->users->get('id', $data->member->user->id)) {
+                $user->fill((array) $data->member->user);
+            } else {
+                $this->discord->users->pushItem($this->factory->part(User::class, (array) $data->member->user, true));
+            }
+        }
+
+        // User caching
+        if (isset($data->user)) {
+            if ($user = $this->discord->users->get('id', $data->user->id)) {
+                $user->fill((array) $data->user);
+            } else {
+                $this->discord->users->pushItem($this->factory->part(User::class, (array) $data->user, true));
             }
         }
 

--- a/src/Discord/WebSockets/Events/InviteCreate.php
+++ b/src/Discord/WebSockets/Events/InviteCreate.php
@@ -14,6 +14,7 @@ namespace Discord\WebSockets\Events;
 use Discord\Parts\Guild\Invite;
 use Discord\WebSockets\Event;
 use Discord\Helpers\Deferred;
+use Discord\Parts\User\User;
 
 class InviteCreate extends Event
 {
@@ -23,6 +24,24 @@ class InviteCreate extends Event
     public function handle(Deferred &$deferred, $data): void
     {
         $invite = $this->factory->create(Invite::class, $data, true);
+
+        // User caching from inviter
+        if (isset($data->inviter)) {
+            if ($user = $this->discord->users->get('id', $data->inviter->id)) {
+                $user->fill((array) $data->inviter);
+            } else {
+                $this->discord->users->pushItem($this->factory->part(User::class, (array) $data->inviter, true));
+            }
+        }
+
+        // User caching from target user
+        if (isset($data->target_user)) {
+            if ($user = $this->discord->users->get('id', $data->target_user->id)) {
+                $user->fill((array) $data->target_user);
+            } else {
+                $this->discord->users->pushItem($this->factory->part(User::class, (array) $data->target_user, true));
+            }
+        }
 
         $deferred->resolve($invite);
     }

--- a/src/Discord/WebSockets/Events/InviteCreate.php
+++ b/src/Discord/WebSockets/Events/InviteCreate.php
@@ -14,7 +14,6 @@ namespace Discord\WebSockets\Events;
 use Discord\Parts\Guild\Invite;
 use Discord\WebSockets\Event;
 use Discord\Helpers\Deferred;
-use Discord\Parts\User\User;
 
 class InviteCreate extends Event
 {
@@ -25,22 +24,14 @@ class InviteCreate extends Event
     {
         $invite = $this->factory->create(Invite::class, $data, true);
 
-        // User caching from inviter
         if (isset($data->inviter)) {
-            if ($user = $this->discord->users->get('id', $data->inviter->id)) {
-                $user->fill((array) $data->inviter);
-            } else {
-                $this->discord->users->pushItem($this->factory->part(User::class, (array) $data->inviter, true));
-            }
+            // User caching from inviter
+            $this->cacheUser($data->inviter);
         }
 
-        // User caching from target user
         if (isset($data->target_user)) {
-            if ($user = $this->discord->users->get('id', $data->target_user->id)) {
-                $user->fill((array) $data->target_user);
-            } else {
-                $this->discord->users->pushItem($this->factory->part(User::class, (array) $data->target_user, true));
-            }
+            // User caching from target user
+            $this->cacheUser($data->target_user);
         }
 
         $deferred->resolve($invite);

--- a/src/Discord/WebSockets/Events/MessageReactionAdd.php
+++ b/src/Discord/WebSockets/Events/MessageReactionAdd.php
@@ -14,7 +14,7 @@ namespace Discord\WebSockets\Events;
 use Discord\Parts\WebSockets\MessageReaction;
 use Discord\WebSockets\Event;
 use Discord\Helpers\Deferred;
-use Discord\Parts\Channel\Reaction;
+use Discord\Parts\User\User;
 
 class MessageReactionAdd extends Event
 {
@@ -50,6 +50,15 @@ class MessageReactionAdd extends Event
                         'emoji' => $reaction->emoji->getRawAttributes(),
                     ], true));
                 }
+            }
+        }
+
+        // User caching
+        if (isset($data->member->user)) {
+            if ($user = $this->discord->users->get('id', $data->member->user->id)) {
+                $user->fill((array) $data->member->user);
+            } else {
+                $this->discord->users->pushItem($this->factory->part(User::class, (array) $data->member->user, true));
             }
         }
 

--- a/src/Discord/WebSockets/Events/MessageReactionAdd.php
+++ b/src/Discord/WebSockets/Events/MessageReactionAdd.php
@@ -14,7 +14,6 @@ namespace Discord\WebSockets\Events;
 use Discord\Parts\WebSockets\MessageReaction;
 use Discord\WebSockets\Event;
 use Discord\Helpers\Deferred;
-use Discord\Parts\User\User;
 
 class MessageReactionAdd extends Event
 {
@@ -53,13 +52,8 @@ class MessageReactionAdd extends Event
             }
         }
 
-        // User caching
         if (isset($data->member->user)) {
-            if ($user = $this->discord->users->get('id', $data->member->user->id)) {
-                $user->fill((array) $data->member->user);
-            } else {
-                $this->discord->users->pushItem($this->factory->part(User::class, (array) $data->member->user, true));
-            }
+            $this->cacheUser($data->member->user);
         }
 
         $deferred->resolve($reaction);

--- a/src/Discord/WebSockets/Events/TypingStart.php
+++ b/src/Discord/WebSockets/Events/TypingStart.php
@@ -14,7 +14,6 @@ namespace Discord\WebSockets\Events;
 use Discord\Parts\WebSockets\TypingStart as TypingStartPart;
 use Discord\WebSockets\Event;
 use Discord\Helpers\Deferred;
-use Discord\Parts\User\User;
 
 class TypingStart extends Event
 {
@@ -25,13 +24,8 @@ class TypingStart extends Event
     {
         $typing = $this->factory->create(TypingStartPart::class, $data, true);
 
-        // User caching
         if (isset($data->member->user)) {
-            if ($user = $this->discord->users->get('id', $data->member->user->id)) {
-                $user->fill((array) $data->member->user);
-            } else {
-                $this->discord->users->pushItem($this->factory->part(User::class, (array) $data->member->user, true));
-            }
+            $this->cacheUser($data->member->user);
         }
 
         $deferred->resolve($typing);

--- a/src/Discord/WebSockets/Events/TypingStart.php
+++ b/src/Discord/WebSockets/Events/TypingStart.php
@@ -14,6 +14,7 @@ namespace Discord\WebSockets\Events;
 use Discord\Parts\WebSockets\TypingStart as TypingStartPart;
 use Discord\WebSockets\Event;
 use Discord\Helpers\Deferred;
+use Discord\Parts\User\User;
 
 class TypingStart extends Event
 {
@@ -23,6 +24,15 @@ class TypingStart extends Event
     public function handle(Deferred &$deferred, $data): void
     {
         $typing = $this->factory->create(TypingStartPart::class, $data, true);
+
+        // User caching
+        if (isset($data->member->user)) {
+            if ($user = $this->discord->users->get('id', $data->member->user->id)) {
+                $user->fill((array) $data->member->user);
+            } else {
+                $this->discord->users->pushItem($this->factory->part(User::class, (array) $data->member->user, true));
+            }
+        }
 
         $deferred->resolve($typing);
     }

--- a/src/Discord/WebSockets/Events/VoiceStateUpdate.php
+++ b/src/Discord/WebSockets/Events/VoiceStateUpdate.php
@@ -14,7 +14,6 @@ namespace Discord\WebSockets\Events;
 use Discord\Parts\WebSockets\VoiceStateUpdate as VoiceStateUpdatePart;
 use Discord\WebSockets\Event;
 use Discord\Helpers\Deferred;
-use Discord\Parts\User\User;
 
 class VoiceStateUpdate extends Event
 {
@@ -51,12 +50,7 @@ class VoiceStateUpdate extends Event
             $this->discord->guilds->offsetSet($state->guild->id, $state->guild);
         }
 
-        // User caching
-        if ($user = $this->discord->users->get('id', $data->member->user->id)) {
-            $user->fill((array) $data->member->user);
-        } else {
-            $this->discord->users->pushItem($this->factory->part(User::class, (array) $data->member->user, true));
-        }
+        $this->cacheUser($data->member->user);
 
         $deferred->resolve([$state, $old_state]);
     }

--- a/src/Discord/WebSockets/Events/VoiceStateUpdate.php
+++ b/src/Discord/WebSockets/Events/VoiceStateUpdate.php
@@ -14,6 +14,7 @@ namespace Discord\WebSockets\Events;
 use Discord\Parts\WebSockets\VoiceStateUpdate as VoiceStateUpdatePart;
 use Discord\WebSockets\Event;
 use Discord\Helpers\Deferred;
+use Discord\Parts\User\User;
 
 class VoiceStateUpdate extends Event
 {
@@ -48,6 +49,13 @@ class VoiceStateUpdate extends Event
             }
 
             $this->discord->guilds->offsetSet($state->guild->id, $state->guild);
+        }
+
+        // User caching
+        if ($user = $this->discord->users->get('id', $data->member->user->id)) {
+            $user->fill((array) $data->member->user);
+        } else {
+            $this->discord->users->pushItem($this->factory->part(User::class, (array) $data->member->user, true));
         }
 
         $deferred->resolve([$state, $old_state]);


### PR DESCRIPTION
#518 

Setter is necessary to apply when explicitly send from the event.

- ~~CHANNEL_CREATE~~
- ~~CHANNEL_DELETE~~
- ~~CHANNEL_PINS_UPDATE~~
- ~~CHANNEL_UPDATE~~
- [x] GUILD_BAN_ADD
- [x] GUILD_BAN_REMOVE
- _**GUILD_CREATE**_
- ~~GUILD_DELETE~~
- [x] GUILD_EMOJIS_UPDATE
- ~~GUILD_INTEGRATIONS_UPDATE~~
- [x] **GUILD_MEMBER_ADD**
- [x] GUILD_MEMBER_UPDATE
- [x] GUILD_MEMBER_REMOVE
- ~~GUILD_ROLE_CREATE~~
- ~~GUILD_ROLE_UPDATE~~
- ~~GUILD_ROLE_DELETE~~
- [x] GUILD_SCHEDULED_EVENT_CREATE
- [x] GUILD_SCHEDULED_EVENT_DELETE
- [x] GUILD_SCHEDULED_EVENT_UPDATE
- ~~GUILD_SCHEDULED_EVENT_USER_ADD~~
- ~~GUILD_SCHEDULED_EVENT_USER_REMOVE~~
- [x] GUILD_STICKERS_UPDATE
- ~~GUILD_UPDATE~~
- [x] INTEGRATION_CREATE
- ~~INTEGRATION_DELETE~~
- [x] INTEGRATION_UPDATE
- [x] **_INTERACTION_CREATE_**
- [x] _INVITE_CREATE_
- ~~INVITE_DELETE~~
- [ ] _MESSAGE_CREATE_?
- ~~MESSAGE_DELETE~~
- ~~MESSAGE_DELETE_BULK~~
- [x] _MESSAGE_REACTION_ADD_
- ~~MESSAGE_REACTION_REMOVE~~
- ~~MESSAGE_REACTION_REMOVE_ALL~~
- ~~MESSAGE_REACTION_REMOVE_EMOJI~~
- [ ] _MESSAGE_UPDATE_?
- ~~_**PRESENCE_UPDATE**_~~
- ~~STAGE_INSTANCE_CREATE~~
- ~~STAGE_INSTANCE_DELETE~~
- ~~STAGE_INSTANCE_UPDATE~~
- [ ] ?_THREAD_CREATE_
- ~~THREAD_DELETE~~
- [ ] _THREAD_LIST_SYNC_
- [ ] _THREAD_MEMBER_UPDATE_?
- [ ] _THREAD_MEMBERS_UPDATE_?
- ~~THREAD_UPDATE~~
- [x] _TYPING_START_
- ~~VOICE_SERVER_UPDATE~~
- [x] _VOICE_STATE_UPDATE_
- ~~WEBHOOKS_UPDATE~~

Marked in **bold** is already present in setter.
Marked in _italic_ is already present in getter.
Suffixed with ? may have partial data.

Thread member is way less than partial member:
https://discord.com/developers/docs/resources/channel#thread-member-object