### PR TITLE
Remove deprecation notice and update requirements info

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ The path to the caextract must be set in the [`php.ini`](https://secure.php.net/
 
 #### Voice Requirements
 
-- 64-bit Linux or Darwin based OS. Voice does not run on Windows.
+- 64-bit Linux or Darwin based OS.
+    - If you are running on Windows, you must be using PHP 8.0.
 - `ext-sodium`
 - FFmpeg
 

--- a/docs/src/pages/api/00_intro.md
+++ b/docs/src/pages/api/00_intro.md
@@ -10,6 +10,7 @@ The class reference has moved. You can now access it [here](http://discord-php.g
 
 - PHP 7.4 CLI
     - Will not run on a webserver (FPM, CGI), you must run through CLI. A bot is a long-running process.
+    - x86 (32-bit) PHP requires ext-gmp extension enabled for handling new Permission values.
 - `ext-json` for JSON parsing.
 - `ext-zlib` for gateway packet compression.
 
@@ -17,6 +18,7 @@ The class reference has moved. You can now access it [here](http://discord-php.g
 
 - One of `ext-uv`, `ext-libev` or `evt-event` (in order of preference) for a faster, and more performant event loop.
 - `ext-mbstring` if you may handle non-english characters.
+- `ext-gmp` if running 32-bit PHP.
 
 #### Voice Requirements
 

--- a/src/Discord/Parts/Interactions/Command/Command.php
+++ b/src/Discord/Parts/Interactions/Command/Command.php
@@ -123,8 +123,6 @@ class Command extends Part
      *
      * @param Overwrite $overwrite An overwrite object.
      *
-     * @deprecated 7.0.0
-     *
      * @return ExtendedPromiseInterface
      */
     public function setOverwrite(Overwrite $overwrite): ExtendedPromiseInterface

--- a/src/Discord/Repository/Guild/GuildCommandRepository.php
+++ b/src/Discord/Repository/Guild/GuildCommandRepository.php
@@ -53,8 +53,6 @@ class GuildCommandRepository extends AbstractRepository
      *
      * @param Overwrite $overwrite An overwrite object.
      *
-     * @deprecated 7.0.0
-     *
      * @return ExtendedPromiseInterface
      */
     public function setOverwrite(Overwrite $overwrite): ExtendedPromiseInterface


### PR DESCRIPTION
Not right now https://github.com/discord/discord-api-docs/pull/4340

No testing necessary so can be merged instantly.