### PR TITLE
Temporary accept phpdocumentor install prompt

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,7 +18,7 @@ jobs:
           extensions: iconv
           tools: phive
       - name: Install phpDocumentor
-        run: phive install phpDocumentor --trust-gpg-keys 6DA3ACC4991FFAE5
+        run: yes | phive install phpDocumentor --trust-gpg-keys 6DA3ACC4991FFAE5
       - name: Build class reference
         run: ./tools/phpDocumentor
       - name: Build documentation


### PR DESCRIPTION
This PR adds temporary [`yes` pipe](https://en.wikipedia.org/wiki/Yes_(Unix)) for the docs workflow when installing phpDocumentor due to the installation requiring a tty to confirm the key import, which cannot be done by CI.

The commit message will trigger the workflow automatically, it has been tested in my own repo branch.

Once merged, make another PR to revert it, since the `yes` prompt could be anything else.
It should not ask prompt anymore until next phpDocumentor update or pgp keys change.