### PR TITLE
Fix null guild_id on $data->member for WebSocket Events Parts

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,7 +19,7 @@ jobs:
           extensions: iconv
           tools: phive
       - name: Install phpDocumentor
-        run: phive install phpDocumentor --trust-gpg-keys 6DA3ACC4991FFAE5
+        run: phive install phpDocumentor --trust-gpg-keys 67F861C3D889C656,6DA3ACC4991FFAE5
       - name: Build class reference
         run: ./tools/phpDocumentor
       - name: Build documentation

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,7 +3,6 @@ on:
   push:
   release:
     types: [published]
-  workflow_dispatch:
 
 jobs:
   docs:

--- a/src/Discord/Parts/WebSockets/MessageReaction.php
+++ b/src/Discord/Parts/WebSockets/MessageReaction.php
@@ -187,8 +187,6 @@ class MessageReaction extends Part
     /**
      * Gets the member attribute.
      *
-     * @throws \Exception
-     *
      * @return Member|null
      */
     protected function getMemberAttribute(): ?Member
@@ -200,7 +198,7 @@ class MessageReaction extends Part
         }
 
         if (isset($this->attributes['member'])) {
-            return $this->factory->create(Member::class, $this->attributes['member'], true);
+            return $this->factory->part(Member::class, (array) $this->attributes['member'] + ['guild_id' => $this->guild_id], true);
         }
 
         return null;

--- a/src/Discord/Parts/WebSockets/TypingStart.php
+++ b/src/Discord/Parts/WebSockets/TypingStart.php
@@ -125,7 +125,7 @@ class TypingStart extends Part
         }
 
         if (isset($this->attributes['member'])) {
-            return $this->factory->part(Member::class, (array) $this->attributes['member'], true);
+            return $this->factory->part(Member::class, (array) $this->attributes['member'] + ['guild_id' => $this->guild_id], true);
         }
 
         return null;

--- a/src/Discord/Parts/WebSockets/VoiceStateUpdate.php
+++ b/src/Discord/Parts/WebSockets/VoiceStateUpdate.php
@@ -119,7 +119,7 @@ class VoiceStateUpdate extends Part
         }
 
         if (isset($this->attributes['member'])) {
-            return $this->factory->part(Member::class, (array) $this->attributes['member'], true);
+            return $this->factory->part(Member::class, (array) $this->attributes['member'] + ['guild_id' => $this->guild_id], true);
         }
 
         return null;


### PR DESCRIPTION
When the data is received from the event, `Member` Part was not filled with a `guild_id`

Example issue caused (from Kamafeu on Discord):

```php
$discord->on(Event::MESSAGE_REACTION_ADD, function (MessageReaction $reaction) {
    $reaction->member->addRole('role_id');
});
```
```
 [2022-02-03T00:41:10.317807+00:00] DiscordPHP.WARNING: REQ PUT guilds/:guild_id/members/*****/roles/***** failed: Discord\Http\Exceptions\RequestFailedException: Bad Request - {     "code": 50035,     "errors": {         "guild_id": {             "_errors": [                 {                     "code": "NUMBER_TYPE_COERCE",                     "message": "Value \":guild_id\" is not snowflake."                 }             ]         }     },     "message": "Invalid Form Body" }
```

However, accessing from guild works:
```php
$discord->on(Event::MESSAGE_REACTION_ADD, function (MessageReaction $reaction) {
    $reaction->guild->addRole($member, 'role_id');
});
```

This fix applies to:

- Event::MESSAGE_REACTION_ADD
- Event::TYPING_START
- Event::VOICE_STATE_UPDATE

It has been tested.


Also to fix #705, added new phpDocumentor gpg-keys to trust, it's still pointing to the same .asc file as the old one so the old gpg key remains.
