### PR TITLE
Update test code and add missing phpdoc link and build docs

### DIFF
--- a/src/Discord/Builders/Components/ActionRow.php
+++ b/src/Discord/Builders/Components/ActionRow.php
@@ -11,6 +11,9 @@
 
 namespace Discord\Builders\Components;
 
+/**
+ * @see https://discord.com/developers/docs/interactions/message-components#action-rows
+ */
 class ActionRow extends Component
 {
     /**

--- a/src/Discord/Builders/Components/Button.php
+++ b/src/Discord/Builders/Components/Button.php
@@ -19,6 +19,9 @@ use React\Promise\PromiseInterface;
 
 use function Discord\poly_strlen;
 
+/**
+ * @see https://discord.com/developers/docs/interactions/message-components#buttons
+ */
 class Button extends Component
 {
     public const STYLE_PRIMARY = 1;

--- a/src/Discord/Builders/Components/Component.php
+++ b/src/Discord/Builders/Components/Component.php
@@ -13,6 +13,9 @@ namespace Discord\Builders\Components;
 
 use JsonSerializable;
 
+/**
+ * @see https://discord.com/developers/docs/interactions/message-components#what-is-a-component
+ */
 abstract class Component implements JsonSerializable
 {
     public const TYPE_ACTION_ROW = 1;

--- a/src/Discord/Builders/Components/Option.php
+++ b/src/Discord/Builders/Components/Option.php
@@ -15,6 +15,9 @@ use Discord\Parts\Guild\Emoji;
 
 use function Discord\poly_strlen;
 
+/**
+ * @see https://discord.com/developers/docs/interactions/message-components#select-menu-object-select-option-structure
+ */
 class Option extends Component
 {
     /**

--- a/src/Discord/Builders/Components/SelectMenu.php
+++ b/src/Discord/Builders/Components/SelectMenu.php
@@ -19,6 +19,9 @@ use React\Promise\PromiseInterface;
 
 use function Discord\poly_strlen;
 
+/**
+ * @see https://discord.com/developers/docs/interactions/message-components#select-menus
+ */
 class SelectMenu extends Component
 {
     /**

--- a/src/Discord/Parts/Channel/Channel.php
+++ b/src/Discord/Parts/Channel/Channel.php
@@ -348,7 +348,7 @@ class Channel extends Part
      *
      * @param string $id The message snowflake.
      *
-     * @deprecated 7.0.0 Use `$message->messages->fetch($id)`.
+     * @deprecated 7.0.0 Use `$channel->messages->fetch($id)`.
      *
      * @return ExtendedPromiseInterface
      */

--- a/tests/Parts/Channel/ChannelTest.php
+++ b/tests/Parts/Channel/ChannelTest.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
  * with this source code in the LICENSE.md file.
  */
 
+use Discord\Builders\MessageBuilder;
 use Discord\Discord;
 use Discord\Helpers\Collection;
 use Discord\Parts\Channel\Channel;
@@ -81,7 +82,7 @@ final class ChannelTest extends DiscordTestCase
         return wait(function (Discord $discord, $resolve) {
             $this->channel()->sendMessage('testing get message')
                 ->then(function (Message $message) {
-                    return $this->channel()->getMessage($message->id)
+                    return $this->channel()->messages->fetch($message->id)
                         ->then(function (Message $getMessage) use ($message) {
                             $this->assertEquals($getMessage->id, $message->id);
                         });
@@ -215,7 +216,7 @@ final class ChannelTest extends DiscordTestCase
         return wait(function (Discord $discord, $resolve) {
             $this->channel()->sendMessage('testing edit through channel')
                 ->then(function (Message $message) {
-                    return $this->channel()->editMessage($message, 'new content')
+                    return $message->edit(MessageBuilder::new()->setContent('new content'))
                         ->then(function (Message $updatedMessage) use ($message) {
                             $this->assertEquals('new content', $updatedMessage->content);
                             $this->assertEquals($message->id, $updatedMessage->id);
@@ -233,7 +234,7 @@ final class ChannelTest extends DiscordTestCase
         return wait(function (Discord $discord, $resolve) {
             // upload readme
             $baseDir = dirname(dirname(dirname((new ReflectionClass(Discord::class))->getFileName())));
-            $this->channel()->sendFile($baseDir.DIRECTORY_SEPARATOR.'README.md')
+            $this->channel()->sendMessage(MessageBuilder::new()->addFile($baseDir.DIRECTORY_SEPARATOR.'README.md'))
                 ->then(function (Message $message) {
                     $this->assertEquals(1, count($message->attachments));
                 })

--- a/tests/Parts/Channel/Message/EmbedMessageTest.php
+++ b/tests/Parts/Channel/Message/EmbedMessageTest.php
@@ -56,7 +56,7 @@ final class EmbedMessageTest extends DiscordTestCase
                     $this->assertEquals('Embed Description', $embed->description);
                     $this->assertEquals(getColor('lightblue'), $embed->color);
 
-                    http://discord-php.github.io/DiscordPHP/reference/classes/Discord-Parts-Permissions-RolePermission.html          $this->assertInstanceOf(Author::class, $embed->author);
+                    $this->assertInstanceOf(Author::class, $embed->author);
                     $this->assertEquals('DiscordPHP Bot', $embed->author->name);
 
                     $this->assertInstanceOf(Footer::class, $embed->footer);

--- a/tests/Parts/Channel/Message/EmptyMessageTest.php
+++ b/tests/Parts/Channel/Message/EmptyMessageTest.php
@@ -17,7 +17,7 @@ use Discord\Helpers\Collection;
 use Discord\Parts\Channel\Channel;
 use Discord\Parts\Channel\Message;
 use Discord\Parts\Embed\Embed;
-use Discord\Parts\User\Member;
+use Discord\Parts\User\User;
 
 final class EmptyMessageTest extends DiscordTestCase
 {
@@ -141,7 +141,7 @@ final class EmptyMessageTest extends DiscordTestCase
      */
     public function testAuthorAttribute(Message $message)
     {
-        $this->assertInstanceOf(Member::class, $message->author);
+        $this->assertInstanceOf(User::class, $message->author);
         $this->assertEquals($message->author->id, DiscordSingleton::get()->id);
     }
 


### PR DESCRIPTION
The test code was using deprecated functions, such as the `Channel::getMessage()` and non-`MessageBuilder`, also `Message::author` that asserts  to `Member` instead of `User`.

Also fixed phpdoc & add Discord API docs links to message component classes.

Should be fine to be merged right away.