### PR TITLE
Add query params in AbstractRepository::freshen() 

### DIFF
--- a/src/Discord/Repository/AbstractRepository.php
+++ b/src/Discord/Repository/AbstractRepository.php
@@ -80,10 +80,12 @@ abstract class AbstractRepository extends Collection
     /**
      * Freshens the repository collection.
      *
+     * @param array $queryparams Query string params to add to the request (no validation)
+     *
      * @return ExtendedPromiseInterface
      * @throws \Exception
      */
-    public function freshen(): ExtendedPromiseInterface
+    public function freshen(array $queryparams = []): ExtendedPromiseInterface
     {
         if (! isset($this->endpoints['all'])) {
             return \React\Promise\reject(new \Exception('You cannot freshen this repository.'));
@@ -91,6 +93,10 @@ abstract class AbstractRepository extends Collection
 
         $endpoint = new Endpoint($this->endpoints['all']);
         $endpoint->bindAssoc($this->vars);
+
+        foreach ($queryparams as $query => $param) {
+            $endpoint->addQuery($query, $param);
+        }
 
         return $this->http->get($endpoint)->then(function ($response) {
             $this->clear();

--- a/src/Discord/Repository/Guild/ScheduledEventRepository.php
+++ b/src/Discord/Repository/Guild/ScheduledEventRepository.php
@@ -50,34 +50,6 @@ class ScheduledEventRepository extends AbstractRepository
      * 
      * @param bool $with_user_count Whether to include number of users subscribed to each event
      */
-    public function freshen(bool $with_user_count = false): ExtendedPromiseInterface
-    {
-        if (! $with_user_count) return parent::freshen();
-
-        $endpoint = new Endpoint($this->endpoints['all']);
-        $endpoint->bindAssoc($this->vars);
-
-        $endpoint->addQuery('with_user_count', $with_user_count);
-
-        return $this->http->get($endpoint)->then(function ($response) {
-            $this->clear();
-
-            foreach ($response as $value) {
-                $value = array_merge($this->vars, (array) $value);
-                $part = $this->factory->create($this->class, $value, true);
-
-                $this->push($part);
-            }
-
-            return $this;
-        });
-    }
-
-    /**
-     * @inheritdoc
-     * 
-     * @param bool $with_user_count Whether to include number of users subscribed to each event
-     */
     public function fetch(string $id, bool $fresh = false, bool $with_user_count = false): ExtendedPromiseInterface
     {
         if (! $with_user_count) return parent::fetch($id, $fresh);


### PR DESCRIPTION
This PR adds query parameter array arguments to the `freshen()` function, so you can can do this:
```php
$guild->members->freshen(['limit' => 1000])->done(function ($members) use ($discord) {
    var_dump($members->count());
});
```
`$members` contains 1000 if the server has 1000 members, also can be used to specify snowflake as pagination `after`.


Right now when you do this:
```php
$guild->members->freshen()->done(function ($members) use ($discord) {
    var_dump($members->count());
});
```
`$members` will always contain 1 because that's the default query parameter when requesting for member list.
https://discord.com/developers/docs/resources/guild#membership-screening-object-query-string-params


This break changes in the not-yet released (v7.x) feature `ScheduledEvents::freshen()`, previously if you had `with_user_count` set to true:
```php
$guild->scheduled_events->freshen(true);
```

It will become:
```php
$guild->scheduled_events->freshen(['with_user_count' => true]);
```
The change to remove the override function is required because the repository extends to `AbstractRepository`

No breaking changes for other repository as the argument is optional default to empty array.


It has been tested and can be merged right away.