### PR TITLE
Add Modal for message component & Attachment for slash command

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "ext-zlib": "*",
         "discord-php/http": "^9.0.9",
         "react/child-process": "^0.6.2",
-        "discord/interactions": "^2.1"
+        "discord/interactions": "^2.2"
     },
     "require-dev": {
         "symfony/var-dumper": "*",

--- a/src/Discord/Builders/Components/ActionRow.php
+++ b/src/Discord/Builders/Components/ActionRow.php
@@ -12,6 +12,9 @@
 namespace Discord\Builders\Components;
 
 /**
+ * An Action Row is a non-interactive container component for other types of components.
+ * It has a type: 1 and a sub-array of components of other types.
+ *
  * @see https://discord.com/developers/docs/interactions/message-components#action-rows
  */
 class ActionRow extends Component

--- a/src/Discord/Builders/Components/Button.php
+++ b/src/Discord/Builders/Components/Button.php
@@ -20,6 +20,9 @@ use React\Promise\PromiseInterface;
 use function Discord\poly_strlen;
 
 /**
+ * Buttons are interactive components that render on messages.
+ * They can be clicked by users, and send an interaction to your app when clicked.
+ *
  * @see https://discord.com/developers/docs/interactions/message-components#buttons
  */
 class Button extends Component

--- a/src/Discord/Builders/Components/Component.php
+++ b/src/Discord/Builders/Components/Component.php
@@ -14,6 +14,8 @@ namespace Discord\Builders\Components;
 use JsonSerializable;
 
 /**
+ * Components are a new field on the message object, so you can use them whether you're sending messages or responding to a slash command or other interaction.
+ *
  * @see https://discord.com/developers/docs/interactions/message-components#what-is-a-component
  */
 abstract class Component implements JsonSerializable
@@ -21,6 +23,7 @@ abstract class Component implements JsonSerializable
     public const TYPE_ACTION_ROW = 1;
     public const TYPE_BUTTON = 2;
     public const TYPE_SELECT_MENU = 3;
+    public const TYPE_TEXT_INPUT = 4;
 
     /**
      * Generates a UUID which can be used for component custom IDs.

--- a/src/Discord/Builders/Components/Option.php
+++ b/src/Discord/Builders/Components/Option.php
@@ -16,6 +16,8 @@ use Discord\Parts\Guild\Emoji;
 use function Discord\poly_strlen;
 
 /**
+ * Option for select menu component
+ *
  * @see https://discord.com/developers/docs/interactions/message-components#select-menu-object-select-option-structure
  */
 class Option extends Component

--- a/src/Discord/Builders/Components/SelectMenu.php
+++ b/src/Discord/Builders/Components/SelectMenu.php
@@ -24,7 +24,7 @@ use function Discord\poly_strlen;
  * On desktop, clicking on a select menu opens a dropdown-style UI
  * On mobile, tapping a select menu opens up a half-sheet with the options.
  *
- *  @see https://discord.com/developers/docs/interactions/message-components#select-menus
+ * @see https://discord.com/developers/docs/interactions/message-components#select-menus
  */
 class SelectMenu extends Component
 {

--- a/src/Discord/Builders/Components/SelectMenu.php
+++ b/src/Discord/Builders/Components/SelectMenu.php
@@ -20,7 +20,11 @@ use React\Promise\PromiseInterface;
 use function Discord\poly_strlen;
 
 /**
- * @see https://discord.com/developers/docs/interactions/message-components#select-menus
+ * Select menus are another interactive component that renders on messages.
+ * On desktop, clicking on a select menu opens a dropdown-style UI
+ * On mobile, tapping a select menu opens up a half-sheet with the options.
+ *
+ *  @see https://discord.com/developers/docs/interactions/message-components#select-menus
  */
 class SelectMenu extends Component
 {

--- a/src/Discord/Builders/Components/TextInput.php
+++ b/src/Discord/Builders/Components/TextInput.php
@@ -1,0 +1,444 @@
+<?php
+
+/*
+ * This file is a part of the DiscordPHP project.
+ *
+ * Copyright (c) 2015-present David Cole <david.cole1340@gmail.com>
+ *
+ * This file is subject to the MIT license that is bundled
+ * with this source code in the LICENSE.md file.
+ */
+
+namespace Discord\Builders\Components;
+
+use Discord\Discord;
+use Discord\Parts\Interactions\Interaction;
+use Discord\WebSockets\Event;
+use React\Promise\PromiseInterface;
+
+use function Discord\poly_strlen;
+
+/**
+ * Text inputs are an interactive component that render on modals. They can be used to collect short-form or long-form text.
+ *
+ * @see https://discord.com/developers/docs/interactions/message-components#text-inputs
+ */
+class TextInput extends Component
+{
+    public const STYLE_SHORT = 1;
+    public const STYLE_PARAGRAPH = 2;
+
+    /**
+     * Custom ID to identify the text input.
+     *
+     * @var string
+     */
+    private $custom_id;
+
+    /**
+     * Style of text input.
+     *
+     * @var int
+     */
+    private $style = 1;
+
+    /**
+     * Label for the text input.
+     *
+     * @var string|null
+     */
+    private $label;
+
+    /**
+     * Minimum input length for a text input, min 0, max 4000
+     *
+     * @var int|null
+     */
+    private $min_length;
+
+    /**
+     * Maximum input length for a text input, min 1, max 4000
+     *
+     * @var int|null
+     */
+    private $max_length;
+
+    /**
+     * Whether the text input is required.
+     *
+     * @var bool
+     */
+    private $required = false;
+
+    /**
+     * Pre-filled value for text input. Max 4000 characters
+     *
+     * @var string|null
+     */
+    private $value;
+
+    /**
+     * Placeholder string to display if text input is empty. Maximum 100 characters.
+     *
+     * @var string|null
+     */
+    private $placeholder;
+
+    /**
+     * Callback used to listen for `INTERACTION_CREATE` events.
+     *
+     * @var callable|null
+     */
+    private $listener;
+
+    /**
+     * Discord instance when the listener is set.
+     *
+     * @var Discord|null
+     */
+    private $discord;
+
+    /**
+     * Creates a new text input.
+     *
+     * @param string|null $custom_id The custom ID of the text input. If not given, an UUID will be used
+     */
+    public function __construct(?string $custom_id)
+    {
+        $this->setCustomId($custom_id ?? $this->generateUuid());
+    }
+
+    /**
+     * Creates a new text input.
+     *
+     * @param string|null $custom_id The custom ID of the text input.
+     *
+     * @return self
+     */
+    public static function new(?string $custom_id = null): self
+    {
+        return new self($custom_id);
+    }
+
+    /**
+     * Sets the custom ID for the text input
+     *
+     * @param string $custom_id
+     *
+     * @throws \LengthException
+     *
+     * @return $this
+     */
+    public function setCustomId($custom_id): self
+    {
+        if (poly_strlen($custom_id) > 100) {
+            throw new \LengthException('Custom ID must be maximum 100 characters.');
+        }
+
+        $this->custom_id = $custom_id;
+
+        return $this;
+    }
+
+    /**
+     * Sets the style of the text button.
+     *
+     * @param int $style
+     *
+     * @throws \InvalidArgumentException
+     *
+     * @return $this
+     */
+    public function setStyle(int $style): self
+    {
+        if (! in_array($style, [self::STYLE_SHORT, self::STYLE_PARAGRAPH])) {
+            throw new \InvalidArgumentException('Invalid text input style.');
+        }
+
+        $this->style = $style;
+
+        return $this;
+    }
+
+    /**
+     * Sets the label of the text input.
+     *
+     * @param string|null $label Label of the text input. Maximum 80 characters.
+     *
+     * @throws \LengthException
+     *
+     * @return $this
+     */
+    public function setLabel(?string $label): self
+    {
+        if (isset($label) && poly_strlen($label) > 80) {
+            throw new \LengthException('Label must be maximum 80 characters.');
+        }
+
+        $this->label = $label;
+
+        return $this;
+    }
+
+    /**
+     * Sets the minimum input length for a text input.
+     * Minimum 0 and maximum 4000. Null to set as default.
+     *
+     * @param int|null $min_length
+     *
+     * @throws \LengthException
+     *
+     * @return $this
+     */
+    public function setMinLength(?int $min_length): self
+    {
+        if (isset($min_length) && ($min_length < 0 || $min_length > 4000)) {
+            throw new \LengthException('Length must be between 0 and 4000 inclusive.');
+        }
+
+        $this->min_length = $min_length;
+
+        return $this;
+    }
+
+    /**
+     * Sets the maximum input length for a text input.
+     * Minimum 1 and maximum 4000. Null to set as default.
+     *
+     * @param int|null $max_length
+     *
+     * @throws \LengthException
+     *
+     * @return $this
+     */
+    public function setMaxLength(?int $max_length): self
+    {
+        if (isset($max_length) && ($max_length < 1 || $max_length > 4000)) {
+            throw new \LengthException('Length must be between 1 and 4000 inclusive.');
+        }
+
+        $this->max_length = $max_length;
+
+        return $this;
+    }
+
+    /**
+     * Sets the placeholder string to display if nothing is selected.
+     * Maximum 100 characters. Null to clear placeholder.
+     *
+     * @param string|null $placeholder
+     *
+     * @throws \LengthException
+     *
+     * @return $this
+     */
+    public function setPlaceholder(?string $placeholder): self
+    {
+        if (isset($placeholder) && strlen($placeholder) > 100) {
+            throw new \LengthException('Placeholder string must be less than or equal to 100 characters.');
+        }
+
+        $this->placeholder = $placeholder;
+
+        return $this;
+    }
+
+    /**
+     * Set if this component is required to be filled, default false.
+     *
+     * @param bool $required
+     *
+     * @return $this
+     */
+    public function setRequired(bool $required): self
+    {
+        $this->required = $required;
+
+        return $this;
+    }
+
+    /**
+     * Sets a pre-filled value for the text input.
+     *
+     * @param string|null $value A pre-filled value, max 4000 characters.
+     *
+     * @throws \LengthException
+     *
+     * @return $this
+     */
+    public function setValue(?string $value): self
+    {
+        if (isset($value) && poly_strlen($value) > 4000) {
+            throw new \LengthException('Pre-filled value must be maximum 4000 characters.');
+        }
+
+        $this->value = $value;
+
+        return $this;
+    }
+
+    /**
+     * Sets the callable listener for the text input. The `$callback` will be called when submitted.
+     *
+     * If you do not respond to or acknowledge the `Interaction`, it will be acknowledged for you.
+     * Note that if you intend to respond to or acknowledge the interaction inside a promise, you should
+     * return a promise that resolves *after* you respond or acknowledge.
+     *
+     * The callback will only be called once with the `$oneOff` parameter set to true.
+     * This can be changed to false, and the callback will be called each time the text input is submitted.
+     * To remove the listener, you can pass `$callback` as null.
+     *
+     * The text input listener will not persist when the bot restarts.
+     *
+     * @param callable $callback Callback to call when the text input is submitted. Will be called with the interaction object.
+     * @param Discord  $discord  Discord client.
+     * @param bool     $oneOff   Whether the listener should be removed after the text input is submitted for the first time.
+     *
+     * @throws \LogicException
+     *
+     * @return $this
+     */
+    public function setListener(?callable $callback, Discord $discord, bool $oneOff = false): self
+    {
+        if (! isset($this->custom_id)) {
+            $this->custom_id = $this->generateUuid();
+        }
+
+        // Remove any existing listener
+        if ($this->listener) {
+            $this->discord->removeListener(Event::INTERACTION_CREATE, $this->listener);
+        }
+
+        $this->discord = $discord;
+
+        if ($callback == null) {
+            return $this;
+        }
+
+        $this->listener = function (Interaction $interaction) use ($callback, $oneOff) {
+            if ($interaction->data->component_type == Component::TYPE_TEXT_INPUT && $interaction->data->custom_id == $this->custom_id) {
+                $response = $callback($interaction);
+                $ack = function () use ($interaction) {
+                    // attempt to acknowledge interaction if it has not already been responded to.
+                    try {
+                        $interaction->acknowledge();
+                    } catch (\Exception $e) {
+                    }
+                };
+
+                if ($response instanceof PromiseInterface) {
+                    $response->then($ack);
+                } else {
+                    $ack();
+                }
+
+                if ($oneOff) {
+                    $this->removeListener();
+                }
+            }
+        };
+
+        $discord->on(Event::INTERACTION_CREATE, $this->listener);
+
+        return $this;
+    }
+
+    /**
+     * Removes the listener from the text input.
+     *
+     * @return $this
+     */
+    public function removeListener(): self
+    {
+        return $this->setListener(null, $this->discord);
+    }
+
+    /**
+     * Returns the Custom ID of the text input.
+     *
+     * @return string
+     */
+    public function getCustomId(): string
+    {
+        return $this->custom_id;
+    }
+
+    /**
+     * Returns the placeholder string of the text input.
+     *
+     * @return string|null
+     */
+    public function getPlaceholder(): ?string
+    {
+        return $this->placeholder;
+    }
+
+    /**
+     * Returns the minimum number of options that must be selected.
+     *
+     * @return int|null
+     */
+    public function getMinLength(): ?int
+    {
+        return $this->min_length;
+    }
+
+    /**
+     * Returns the maximum number of options that must be selected.
+     *
+     * @return int|null
+     */
+    public function getMaxLength(): ?int
+    {
+        return $this->max_length;
+    }
+
+    /**
+     * Returns wether the text input is disabled.
+     *
+     * @return bool|null
+     */
+    public function isRequired(): ?bool
+    {
+        return $this->required;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function jsonSerialize(): array
+    {
+        $content = [
+            'type' => Component::TYPE_TEXT_INPUT,
+            'custom_id' => $this->custom_id,
+            'style' => $this->style,
+            'label' => $this->label,
+        ];
+
+        if (isset($this->min_length)) {
+            $content['min_length'] = $this->min_length;
+        }
+
+        if (isset($this->max_length)) {
+            if (isset($this->min_length) && $this->min_length > $this->max_length) {
+                throw new \OutOfBoundsException('Minimum length cannot be higher than maximum length');
+            }
+
+            $content['max_length'] = $this->max_length;
+        }
+
+        if ($this->required) {
+            $content['required'] = true;
+        }
+
+        if (isset($value)) {
+            $content['value'] = $this->value;
+        }
+
+        if (isset($this->placeholder)) {
+            $content['placeholder'] = $this->placeholder;
+        }
+
+        return $content;
+    }
+}

--- a/src/Discord/Builders/Components/TextInput.php
+++ b/src/Discord/Builders/Components/TextInput.php
@@ -342,7 +342,7 @@ class TextInput extends Component
             $content['required'] = true;
         }
 
-        if (isset($value)) {
+        if (isset($this->value)) {
             $content['value'] = $this->value;
         }
 

--- a/src/Discord/Builders/Components/TextInput.php
+++ b/src/Discord/Builders/Components/TextInput.php
@@ -12,9 +12,6 @@
 namespace Discord\Builders\Components;
 
 use Discord\Discord;
-use Discord\Parts\Interactions\Interaction;
-use Discord\WebSockets\Event;
-use React\Promise\PromiseInterface;
 
 use function Discord\poly_strlen;
 

--- a/src/Discord/Builders/Components/TextInput.php
+++ b/src/Discord/Builders/Components/TextInput.php
@@ -11,8 +11,6 @@
 
 namespace Discord\Builders\Components;
 
-use Discord\Discord;
-
 use function Discord\poly_strlen;
 
 /**
@@ -37,7 +35,7 @@ class TextInput extends Component
      *
      * @var int
      */
-    private $style = 1;
+    private $style;
 
     /**
      * Label for the text input.
@@ -80,20 +78,6 @@ class TextInput extends Component
      * @var string|null
      */
     private $placeholder;
-
-    /**
-     * Callback used to listen for `INTERACTION_CREATE` events.
-     *
-     * @var callable|null
-     */
-    private $listener;
-
-    /**
-     * Discord instance when the listener is set.
-     *
-     * @var Discord|null
-     */
-    private $discord;
 
     /**
      * Creates a new text input.
@@ -154,7 +138,7 @@ class TextInput extends Component
      */
     public function setStyle(int $style): self
     {
-        if (! in_array($style, [self::STYLE_SHORT, self::STYLE_PARAGRAPH])) {
+        if ($style < 1 || $style > 2) {
             throw new \InvalidArgumentException('Invalid text input style.');
         }
 

--- a/src/Discord/Builders/Components/TextInput.php
+++ b/src/Discord/Builders/Components/TextInput.php
@@ -45,7 +45,7 @@ class TextInput extends Component
     /**
      * Label for the text input.
      *
-     * @var string|null
+     * @var string
      */
     private $label;
 
@@ -163,15 +163,15 @@ class TextInput extends Component
     /**
      * Sets the label of the text input.
      *
-     * @param string|null $label Label of the text input. Maximum 80 characters.
+     * @param string $label Label of the text input. Maximum 80 characters.
      *
      * @throws \LengthException
      *
      * @return $this
      */
-    public function setLabel(?string $label): self
+    public function setLabel(string $label): self
     {
-        if (isset($label) && poly_strlen($label) > 80) {
+        if (poly_strlen($label) > 80) {
             throw new \LengthException('Label must be maximum 80 characters.');
         }
 

--- a/src/Discord/Builders/Components/TextInput.php
+++ b/src/Discord/Builders/Components/TextInput.php
@@ -101,23 +101,29 @@ class TextInput extends Component
     /**
      * Creates a new text input.
      *
+     * @param string      $label     The label of the text input.
+     * @param int         $style     The style of the text input.
      * @param string|null $custom_id The custom ID of the text input. If not given, an UUID will be used
      */
-    public function __construct(?string $custom_id)
+    public function __construct(string $label, int $style, ?string $custom_id)
     {
+        $this->setLabel($label);
+        $this->setStyle($style);
         $this->setCustomId($custom_id ?? $this->generateUuid());
     }
 
     /**
      * Creates a new text input.
      *
+     * @param string      $label     The label of the text input.
+     * @param int         $style     The style of the text input.
      * @param string|null $custom_id The custom ID of the text input.
      *
      * @return self
      */
-    public static function new(?string $custom_id = null): self
+    public static function new(string $label, int $style, ?string $custom_id = null): self
     {
-        return new self($custom_id);
+        return new self($label, $style, $custom_id);
     }
 
     /**
@@ -141,7 +147,7 @@ class TextInput extends Component
     }
 
     /**
-     * Sets the style of the text button.
+     * Sets the style of the text input.
      *
      * @param int $style
      *
@@ -275,82 +281,6 @@ class TextInput extends Component
         $this->value = $value;
 
         return $this;
-    }
-
-    /**
-     * Sets the callable listener for the text input. The `$callback` will be called when submitted.
-     *
-     * If you do not respond to or acknowledge the `Interaction`, it will be acknowledged for you.
-     * Note that if you intend to respond to or acknowledge the interaction inside a promise, you should
-     * return a promise that resolves *after* you respond or acknowledge.
-     *
-     * The callback will only be called once with the `$oneOff` parameter set to true.
-     * This can be changed to false, and the callback will be called each time the text input is submitted.
-     * To remove the listener, you can pass `$callback` as null.
-     *
-     * The text input listener will not persist when the bot restarts.
-     *
-     * @param callable $callback Callback to call when the text input is submitted. Will be called with the interaction object.
-     * @param Discord  $discord  Discord client.
-     * @param bool     $oneOff   Whether the listener should be removed after the text input is submitted for the first time.
-     *
-     * @throws \LogicException
-     *
-     * @return $this
-     */
-    public function setListener(?callable $callback, Discord $discord, bool $oneOff = false): self
-    {
-        if (! isset($this->custom_id)) {
-            $this->custom_id = $this->generateUuid();
-        }
-
-        // Remove any existing listener
-        if ($this->listener) {
-            $this->discord->removeListener(Event::INTERACTION_CREATE, $this->listener);
-        }
-
-        $this->discord = $discord;
-
-        if ($callback == null) {
-            return $this;
-        }
-
-        $this->listener = function (Interaction $interaction) use ($callback, $oneOff) {
-            if ($interaction->data->component_type == Component::TYPE_TEXT_INPUT && $interaction->data->custom_id == $this->custom_id) {
-                $response = $callback($interaction);
-                $ack = function () use ($interaction) {
-                    // attempt to acknowledge interaction if it has not already been responded to.
-                    try {
-                        $interaction->acknowledge();
-                    } catch (\Exception $e) {
-                    }
-                };
-
-                if ($response instanceof PromiseInterface) {
-                    $response->then($ack);
-                } else {
-                    $ack();
-                }
-
-                if ($oneOff) {
-                    $this->removeListener();
-                }
-            }
-        };
-
-        $discord->on(Event::INTERACTION_CREATE, $this->listener);
-
-        return $this;
-    }
-
-    /**
-     * Removes the listener from the text input.
-     *
-     * @return $this
-     */
-    public function removeListener(): self
-    {
-        return $this->setListener(null, $this->discord);
     }
 
     /**

--- a/src/Discord/Builders/MessageBuilder.php
+++ b/src/Discord/Builders/MessageBuilder.php
@@ -14,6 +14,7 @@ namespace Discord\Builders;
 use Discord\Builders\Components\ActionRow;
 use Discord\Builders\Components\Component;
 use Discord\Builders\Components\SelectMenu;
+use Discord\Builders\Components\TextInput;
 use Discord\Exceptions\FileNotFoundException;
 use Discord\Helpers\Multipart;
 use Discord\Http\Exceptions\RequestFailedException;
@@ -278,6 +279,10 @@ class MessageBuilder implements JsonSerializable
     {
         if (! ($component instanceof ActionRow || $component instanceof SelectMenu)) {
             throw new \InvalidArgumentException('You can only add action rows and select menus as components to messages. Put your other components inside an action row.');
+        }
+
+        if ($component instanceof TextInput) {
+            throw new \InvalidArgumentException('You cannot add text input for message.');
         }
 
         if (count($this->components) >= 5) {

--- a/src/Discord/Builders/MessageBuilder.php
+++ b/src/Discord/Builders/MessageBuilder.php
@@ -281,10 +281,6 @@ class MessageBuilder implements JsonSerializable
             throw new \InvalidArgumentException('You can only add action rows and select menus as components to messages. Put your other components inside an action row.');
         }
 
-        if ($component instanceof TextInput) {
-            throw new \InvalidArgumentException('You cannot add text input for message.');
-        }
-
         if (count($this->components) >= 5) {
             throw new \OverflowException('You can only add 5 components to a message');
         }

--- a/src/Discord/Parts/Channel/Attachment.php
+++ b/src/Discord/Parts/Channel/Attachment.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * This file is a part of the DiscordPHP project.
+ *
+ * Copyright (c) 2015-present David Cole <david.cole1340@gmail.com>
+ *
+ * This file is subject to the MIT license that is bundled
+ * with this source code in the LICENSE.md file.
+ */
+
+namespace Discord\Parts\Channel;
+
+use Discord\Parts\Part;
+
+/**
+ * A message attachment
+ *
+ * @see https://discord.com/developers/docs/resources/channel#attachment-object
+ *
+ * @property string      $id           Attachment ID.
+ * @property string      $filename     Name of file attached.
+ * @property string|null $description  Description for the file.
+ * @property string|null $content_type The attachment's media type.
+ * @property int         $size         Size of file in bytes.
+ * @property string      $url          Source url of file.
+ * @property string|null $proxy_url    A proxied url of file.
+ * @property int|null    $height       Height of file (if image).
+ * @property int|null    $width        Width of file (if image).
+ * @property bool|null   $ephemeral    Whether this attachment is ephemeral.
+ */
+class Attachment extends Part
+{
+    /**
+     * @inheritdoc
+     */
+    protected $fillable = [
+        'id',
+        'filename',
+        'description',
+        'content_type',
+        'size',
+        'url',
+        'proxy_url',
+        'height',
+        'width',
+        'ephemeral'
+    ];
+}

--- a/src/Discord/Parts/Channel/Message.php
+++ b/src/Discord/Parts/Channel/Message.php
@@ -26,6 +26,7 @@ use Discord\Helpers\Deferred;
 use Discord\Http\Endpoint;
 use Discord\Parts\Guild\Guild;
 use Discord\Parts\Guild\Sticker;
+use Discord\Parts\Interactions\Request\Component;
 use Discord\Parts\Thread\Thread;
 use Discord\Repository\Channel\ReactionRepository;
 use React\Promise\ExtendedPromiseInterface;
@@ -37,49 +38,49 @@ use function React\Promise\reject;
  *
  * @see https://discord.com/developers/docs/resources/channel#message-object
  *
- * @property string                  $id                                     The unique identifier of the message.
- * @property string                  $channel_id                             The unique identifier of the channel that the message was went in.
- * @property Channel|Thread|null     $channel                                The channel that the message was sent in.
- * @property string|null             $guild_id                               The unique identifier of the guild that the channel the message was sent in belongs to.
- * @property Guild|null              $guild                                  The guild that the message was sent in.
- * @property User|null               $author                                 The author of the message. Will be a webhook if sent from one.
- * @property string                  $user_id                                The user id of the author.
- * @property Member|null             $member                                 The member that sent this message, or null if it was in a private message.
- * @property string                  $content                                The content of the message if it is a normal message.
- * @property Carbon                  $timestamp                              A timestamp of when the message was sent.
- * @property Carbon|null             $edited_timestamp                       A timestamp of when the message was edited, or null.
- * @property bool                    $tts                                    Whether the message was sent as a text-to-speech message.
- * @property bool                    $mention_everyone                       Whether the message contained an @everyone mention.
- * @property Collection|User[]       $mentions                               A collection of the users mentioned in the message.
- * @property Collection|Role[]       $mention_roles                          A collection of roles that were mentioned in the message.
- * @property Collection|Channel[]    $mention_channels                       Collection of mentioned channels.
- * @property Collection|Attachment[] $attachments                            Collection of attachment objects.
- * @property Collection|Embed[]      $embeds                                 A collection of embed objects.
- * @property ReactionRepository      $reactions                              Collection of reactions on the message.
- * @property string|null             $nonce                                  A randomly generated string that provides verification for the client. Not required.
- * @property bool                    $pinned                                 Whether the message is pinned to the channel.
- * @property string|null             $webhook_id                             ID of the webhook that made the message, if any.
- * @property int                     $type                                   The type of message.
- * @property object|null             $activity                               Current message activity. Requires rich presence.
- * @property object|null             $application                            Application of message. Requires rich presence.
- * @property string|null             $application_id                         If the message is a response to an Interaction, this is the id of the interaction's application.
- * @property object|null             $message_reference                      Message that is referenced by this message.
- * @property int|null                $flags                                  Message flags.
- * @property Message|null            $referenced_message                     The message that is referenced in a reply.
- * @property object|null             $interaction                            The interaction which triggered the message (application commands).
- * @property Thread|null             $thread                                 The thread that the message was sent in.
- * @property array|null              $components                             Sent if the message contains components like buttons, action rows, or other interactive components.
- * @property Collection|Sticker[]    $sticker_items                          Stickers attached to the message.
- * @property bool                    $crossposted                            Message has been crossposted.
- * @property bool                    $is_crosspost                           Message is a crosspost from another channel.
- * @property bool                    $suppress_embeds                        Do not include embeds when serializing message.
- * @property bool                    $source_message_deleted                 Source message for this message has been deleted.
- * @property bool                    $urgent                                 Message is urgent.
- * @property bool                    $has_thread                             Whether this message has an associated thread, with the same id as the message.
- * @property bool                    $ephemeral                              Whether this message is only visible to the user who invoked the Interaction.
- * @property bool                    $loading                                Whether this message is an Interaction Response and the bot is "thinking".
- * @property bool                    $failed_to_mention_some_roles_in_thread This message failed to mention some roles and add their members to the thread.
- * @property string|null             $link                                   Returns a link to the message.
+ * @property string                      $id                                     The unique identifier of the message.
+ * @property string                      $channel_id                             The unique identifier of the channel that the message was went in.
+ * @property Channel|Thread|null         $channel                                The channel that the message was sent in.
+ * @property string|null                 $guild_id                               The unique identifier of the guild that the channel the message was sent in belongs to.
+ * @property Guild|null                  $guild                                  The guild that the message was sent in.
+ * @property User|null                   $author                                 The author of the message. Will be a webhook if sent from one.
+ * @property string                      $user_id                                The user id of the author.
+ * @property Member|null                 $member                                 The member that sent this message, or null if it was in a private message.
+ * @property string                      $content                                The content of the message if it is a normal message.
+ * @property Carbon                      $timestamp                              A timestamp of when the message was sent.
+ * @property Carbon|null                 $edited_timestamp                       A timestamp of when the message was edited, or null.
+ * @property bool                        $tts                                    Whether the message was sent as a text-to-speech message.
+ * @property bool                        $mention_everyone                       Whether the message contained an @everyone mention.
+ * @property Collection|User[]           $mentions                               A collection of the users mentioned in the message.
+ * @property Collection|Role[]           $mention_roles                          A collection of roles that were mentioned in the message.
+ * @property Collection|Channel[]        $mention_channels                       Collection of mentioned channels.
+ * @property Collection|Attachment[]     $attachments                            Collection of attachment objects.
+ * @property Collection|Embed[]          $embeds                                 A collection of embed objects.
+ * @property ReactionRepository          $reactions                              Collection of reactions on the message.
+ * @property string|null                 $nonce                                  A randomly generated string that provides verification for the client. Not required.
+ * @property bool                        $pinned                                 Whether the message is pinned to the channel.
+ * @property string|null                 $webhook_id                             ID of the webhook that made the message, if any.
+ * @property int                         $type                                   The type of message.
+ * @property object|null                 $activity                               Current message activity. Requires rich presence.
+ * @property object|null                 $application                            Application of message. Requires rich presence.
+ * @property string|null                 $application_id                         If the message is a response to an Interaction, this is the id of the interaction's application.
+ * @property object|null                 $message_reference                      Message that is referenced by this message.
+ * @property int|null                    $flags                                  Message flags.
+ * @property Message|null                $referenced_message                     The message that is referenced in a reply.
+ * @property object|null                 $interaction                            The interaction which triggered the message (application commands).
+ * @property Thread|null                 $thread                                 The thread that the message was sent in.
+ * @property Collection|Component[]|null $components                             Sent if the message contains components like buttons, action rows, or other interactive components.
+ * @property Collection|Sticker[]|null   $sticker_items                          Stickers attached to the message.
+ * @property bool                        $crossposted                            Message has been crossposted.
+ * @property bool                        $is_crosspost                           Message is a crosspost from another channel.
+ * @property bool                        $suppress_embeds                        Do not include embeds when serializing message.
+ * @property bool                        $source_message_deleted                 Source message for this message has been deleted.
+ * @property bool                        $urgent                                 Message is urgent.
+ * @property bool                        $has_thread                             Whether this message has an associated thread, with the same id as the message.
+ * @property bool                        $ephemeral                              Whether this message is only visible to the user who invoked the Interaction.
+ * @property bool                        $loading                                Whether this message is an Interaction Response and the bot is "thinking".
+ * @property bool                        $failed_to_mention_some_roles_in_thread This message failed to mention some roles and add their members to the thread.
+ * @property string|null                 $link                                   Returns a link to the message.
  */
 class Message extends Part
 {
@@ -521,15 +522,39 @@ class Message extends Part
     }
 
     /**
+     * Returns the components attribute.
+     *
+     * @return Collection|Component[]|null
+     */
+    protected function getComponentsAttribute(): ?Collection
+    {
+        if (! isset($this->attributes['components'])) {
+            return null;
+        }
+
+        $components = Collection::for(Component::class, null);
+
+        foreach ($this->attributes['components'] as $component) {
+            $components->pushItem($this->factory->create(Component::class, $component, true));
+        }
+
+        return $components;
+    }
+
+    /**
      * Returns the sticker_items attribute.
      *
-     * @return Sticker[]|Collection
+     * @return Collection|Sticker[]|null
      */
-    protected function getStickerItemsAttribute(): Collection
+    protected function getStickerItemsAttribute(): ?Collection
     {
+        if (! isset($this->attributes['sticker_items'])) {
+            return null;
+        }
+
         $sticker_items = Collection::for(Sticker::class);
 
-        foreach ($this->attributes['sticker_items'] ?? [] as $sticker) {
+        foreach ($this->attributes['sticker_items'] as $sticker) {
             $sticker_items->push($this->factory->create(Sticker::class, $sticker, true));
         }
 

--- a/src/Discord/Parts/Channel/Message.php
+++ b/src/Discord/Parts/Channel/Message.php
@@ -37,49 +37,49 @@ use function React\Promise\reject;
  *
  * @see https://discord.com/developers/docs/resources/channel#message-object
  *
- * @property string               $id                                     The unique identifier of the message.
- * @property string               $channel_id                             The unique identifier of the channel that the message was went in.
- * @property Channel|Thread|null  $channel                                The channel that the message was sent in.
- * @property string|null          $guild_id                               The unique identifier of the guild that the channel the message was sent in belongs to.
- * @property Guild|null           $guild                                  The guild that the message was sent in.
- * @property User|null            $author                                 The author of the message. Will be a webhook if sent from one.
- * @property string               $user_id                                The user id of the author.
- * @property Member|null          $member                                 The member that sent this message, or null if it was in a private message.
- * @property string               $content                                The content of the message if it is a normal message.
- * @property Carbon               $timestamp                              A timestamp of when the message was sent.
- * @property Carbon|null          $edited_timestamp                       A timestamp of when the message was edited, or null.
- * @property bool                 $tts                                    Whether the message was sent as a text-to-speech message.
- * @property bool                 $mention_everyone                       Whether the message contained an @everyone mention.
- * @property Collection|User[]    $mentions                               A collection of the users mentioned in the message.
- * @property Collection|Role[]    $mention_roles                          A collection of roles that were mentioned in the message.
- * @property Collection|Channel[] $mention_channels                       Collection of mentioned channels.
- * @property array|null           $attachments                            An array of attachment objects.
- * @property Collection|Embed[]   $embeds                                 A collection of embed objects.
- * @property ReactionRepository   $reactions                              Collection of reactions on the message.
- * @property string|null          $nonce                                  A randomly generated string that provides verification for the client. Not required.
- * @property bool                 $pinned                                 Whether the message is pinned to the channel.
- * @property string|null          $webhook_id                             ID of the webhook that made the message, if any.
- * @property int                  $type                                   The type of message.
- * @property object|null          $activity                               Current message activity. Requires rich presence.
- * @property object|null          $application                            Application of message. Requires rich presence.
- * @property string|null          $application_id                         If the message is a response to an Interaction, this is the id of the interaction's application.
- * @property object|null          $message_reference                      Message that is referenced by this message.
- * @property int|null             $flags                                  Message flags.
- * @property Message|null         $referenced_message                     The message that is referenced in a reply.
- * @property object|null          $interaction                            The interaction which triggered the message (application commands).
- * @property Thread|null          $thread                                 The thread that the message was sent in.
- * @property array|null           $components                             Sent if the message contains components like buttons, action rows, or other interactive components.
- * @property Collection|Sticker[] $sticker_items                          Stickers attached to the message.
- * @property bool                 $crossposted                            Message has been crossposted.
- * @property bool                 $is_crosspost                           Message is a crosspost from another channel.
- * @property bool                 $suppress_embeds                        Do not include embeds when serializing message.
- * @property bool                 $source_message_deleted                 Source message for this message has been deleted.
- * @property bool                 $urgent                                 Message is urgent.
- * @property bool                 $has_thread                             Whether this message has an associated thread, with the same id as the message.
- * @property bool                 $ephemeral                              Whether this message is only visible to the user who invoked the Interaction.
- * @property bool                 $loading                                Whether this message is an Interaction Response and the bot is "thinking".
- * @property bool                 $failed_to_mention_some_roles_in_thread This message failed to mention some roles and add their members to the thread.
- * @property string|null          $link                                   Returns a link to the message.
+ * @property string                  $id                                     The unique identifier of the message.
+ * @property string                  $channel_id                             The unique identifier of the channel that the message was went in.
+ * @property Channel|Thread|null     $channel                                The channel that the message was sent in.
+ * @property string|null             $guild_id                               The unique identifier of the guild that the channel the message was sent in belongs to.
+ * @property Guild|null              $guild                                  The guild that the message was sent in.
+ * @property User|null               $author                                 The author of the message. Will be a webhook if sent from one.
+ * @property string                  $user_id                                The user id of the author.
+ * @property Member|null             $member                                 The member that sent this message, or null if it was in a private message.
+ * @property string                  $content                                The content of the message if it is a normal message.
+ * @property Carbon                  $timestamp                              A timestamp of when the message was sent.
+ * @property Carbon|null             $edited_timestamp                       A timestamp of when the message was edited, or null.
+ * @property bool                    $tts                                    Whether the message was sent as a text-to-speech message.
+ * @property bool                    $mention_everyone                       Whether the message contained an @everyone mention.
+ * @property Collection|User[]       $mentions                               A collection of the users mentioned in the message.
+ * @property Collection|Role[]       $mention_roles                          A collection of roles that were mentioned in the message.
+ * @property Collection|Channel[]    $mention_channels                       Collection of mentioned channels.
+ * @property Collection|Attachment[] $attachments                            Collection of attachment objects.
+ * @property Collection|Embed[]      $embeds                                 A collection of embed objects.
+ * @property ReactionRepository      $reactions                              Collection of reactions on the message.
+ * @property string|null             $nonce                                  A randomly generated string that provides verification for the client. Not required.
+ * @property bool                    $pinned                                 Whether the message is pinned to the channel.
+ * @property string|null             $webhook_id                             ID of the webhook that made the message, if any.
+ * @property int                     $type                                   The type of message.
+ * @property object|null             $activity                               Current message activity. Requires rich presence.
+ * @property object|null             $application                            Application of message. Requires rich presence.
+ * @property string|null             $application_id                         If the message is a response to an Interaction, this is the id of the interaction's application.
+ * @property object|null             $message_reference                      Message that is referenced by this message.
+ * @property int|null                $flags                                  Message flags.
+ * @property Message|null            $referenced_message                     The message that is referenced in a reply.
+ * @property object|null             $interaction                            The interaction which triggered the message (application commands).
+ * @property Thread|null             $thread                                 The thread that the message was sent in.
+ * @property array|null              $components                             Sent if the message contains components like buttons, action rows, or other interactive components.
+ * @property Collection|Sticker[]    $sticker_items                          Stickers attached to the message.
+ * @property bool                    $crossposted                            Message has been crossposted.
+ * @property bool                    $is_crosspost                           Message is a crosspost from another channel.
+ * @property bool                    $suppress_embeds                        Do not include embeds when serializing message.
+ * @property bool                    $source_message_deleted                 Source message for this message has been deleted.
+ * @property bool                    $urgent                                 Message is urgent.
+ * @property bool                    $has_thread                             Whether this message has an associated thread, with the same id as the message.
+ * @property bool                    $ephemeral                              Whether this message is only visible to the user who invoked the Interaction.
+ * @property bool                    $loading                                Whether this message is an Interaction Response and the bot is "thinking".
+ * @property bool                    $failed_to_mention_some_roles_in_thread This message failed to mention some roles and add their members to the thread.
+ * @property string|null             $link                                   Returns a link to the message.
  */
 class Message extends Part
 {
@@ -276,6 +276,22 @@ class Message extends Part
         }
 
         return $collection;
+    }
+
+    /**
+     * Returns any attached files.
+     *
+     * @return Collection|Attachment[] Attachment objects.
+     */
+    protected function getAttachmentsAttribute(): Collection
+    {
+        $attachments = Collection::for(Attachment::class);
+
+        foreach ($this->attributes['attachments'] ?? [] as $attachment) {
+            $attachments->pushItem($this->factory->part(Attachment::class, (array) $attachment, true));
+        }
+
+        return $attachments;
     }
 
     /**

--- a/src/Discord/Parts/Interactions/Command/Option.php
+++ b/src/Discord/Parts/Interactions/Command/Option.php
@@ -44,6 +44,7 @@ class Option extends Part
     public const ROLE = 8;
     public const MENTIONABLE = 9; // Includes users and roles
     public const NUMBER = 10; // Any double between -2^53 and 2^53
+    public const ATTACHMENT = 11;
 
     /**
      * @inheritdoc
@@ -108,7 +109,7 @@ class Option extends Part
      */
     public function setType(int $type): self
     {
-        if ($type < 1 || $type > 10) {
+        if ($type < 1 || $type > 11) {
             throw new \InvalidArgumentException('Invalid type provided.');
         }
 

--- a/src/Discord/Parts/Interactions/Interaction.php
+++ b/src/Discord/Parts/Interactions/Interaction.php
@@ -192,8 +192,8 @@ class Interaction extends Part
             return $this->acknowledgeWithResponse();
         }
 
-        if ($this->type != InteractionType::MESSAGE_COMPONENT) {
-            return reject(new \LogicException('You can only acknowledge message component interactions.'));
+        if (! in_array($this->type, [InteractionType::MESSAGE_COMPONENT, InteractionType::MODAL_SUBMIT])) {
+            return reject(new \LogicException('You can only acknowledge message component or modal submit interactions.'));
         }
 
         return $this->respond([
@@ -215,8 +215,8 @@ class Interaction extends Part
      */
     public function acknowledgeWithResponse(bool $ephemeral = false): ExtendedPromiseInterface
     {
-        if (! in_array($this->type, [InteractionType::APPLICATION_COMMAND, InteractionType::MESSAGE_COMPONENT])) {
-            return reject(new \LogicException('You can only acknowledge application command or message component interactions.'));
+        if (! in_array($this->type, [InteractionType::APPLICATION_COMMAND, InteractionType::MESSAGE_COMPONENT, InteractionType::MODAL_SUBMIT])) {
+            return reject(new \LogicException('You can only acknowledge application command, message component, or modal submit interactions.'));
         }
 
         return $this->respond([
@@ -367,8 +367,8 @@ class Interaction extends Part
      */
     public function respondWithMessage(MessageBuilder $builder, bool $ephemeral = false): ExtendedPromiseInterface
     {
-        if (! in_array($this->type, [InteractionType::APPLICATION_COMMAND, InteractionType::MESSAGE_COMPONENT])) {
-            return reject(new \LogicException('You can only acknowledge application command or message component interactions.'));
+        if (! in_array($this->type, [InteractionType::APPLICATION_COMMAND, InteractionType::MESSAGE_COMPONENT, InteractionType::MODAL_SUBMIT])) {
+            return reject(new \LogicException('You can only acknowledge application command, message component, or modal submit interactions.'));
         }
 
         if ($ephemeral) {

--- a/src/Discord/Parts/Interactions/Interaction.php
+++ b/src/Discord/Parts/Interactions/Interaction.php
@@ -11,6 +11,7 @@
 
 namespace Discord\Parts\Interactions;
 
+use Discord\Builders\Components\Component;
 use Discord\Builders\MessageBuilder;
 use Discord\Helpers\Multipart;
 use Discord\Http\Endpoint;
@@ -512,6 +513,35 @@ class Interaction extends Part
         return $this->respond([
             'type' => InteractionResponseType::APPLICATION_COMMAND_AUTOCOMPLETE_RESULT,
             'data' => ['choices' => $choices],
+        ]);
+    }
+
+    /**
+     * Responds to the interaction with a popup modal.
+     *
+     * @see https://discord.com/developers/docs/interactions/receiving-and-responding#responding-to-an-interaction
+     *
+     * @param string            $title      The title of the popup modal
+     * @param string            $custom_id  A developer-defined identifier for the component, max 100 characters
+     * @param array|Component[] $components Action row containing between 1 and 5 (inclusive) components that make up the modal
+     *
+     * @throws \LogicException
+     *
+     * @return ExtendedPromiseInterface
+     */
+    public function showModal(string $title, string $custom_id, array $components): ExtendedPromiseInterface
+    {
+        if (in_array($this->type, [InteractionType::PING, InteractionType::MODAL_SUBMIT])) {
+            return reject(new \LogicException('You cannot pop up a modal from a ping or modal submit interaction.'));
+        }
+
+        return $this->respond([
+            'type' => InteractionResponseType::MODAL,
+            'data' => [
+                'title' => $title,
+                'custom_id' => $custom_id,
+                'components' => $components
+            ],
         ]);
     }
 }

--- a/src/Discord/Parts/Interactions/Interaction.php
+++ b/src/Discord/Parts/Interactions/Interaction.php
@@ -526,7 +526,7 @@ class Interaction extends Part
      *
      * @param string            $title      The title of the popup modal
      * @param string            $custom_id  A developer-defined identifier for the component, max 100 characters
-     * @param array|Component[] $components Action row containing between 1 and 5 (inclusive) components that make up the modal
+     * @param array|Component[] $components Between 1 and 5 (inclusive) components that make up the modal contained in Action Row
      * @param callable|null     $submit     The function to call once modal is submitted.
      * 
      * @throws \LogicException

--- a/src/Discord/Parts/Interactions/Request/Component.php
+++ b/src/Discord/Parts/Interactions/Request/Component.php
@@ -1,0 +1,104 @@
+<?php
+
+/*
+ * This file is a part of the DiscordPHP project.
+ *
+ * Copyright (c) 2015-present David Cole <david.cole1340@gmail.com>
+ *
+ * This file is subject to the MIT license that is bundled
+ * with this source code in the LICENSE.md file.
+ */
+
+namespace Discord\Parts\Interactions\Request;
+
+use Discord\Parts\Guild\Emoji;
+use Discord\Parts\Part;
+use Discord\Repository\Interaction\ComponentRepository;
+
+/**
+ * Represents a component received with a message or interaction.
+ *
+ * @see https://discord.com/developers/docs/interactions/message-components#component-object
+ *
+ * @property int                 $type        Component type.
+ * @property string|null         $custom_id   A developer-defined identifier for the component, max 100 characters. (Buttons, Select Menus)
+ * @property bool|null           $disabled    Whether the component is disabled, default false. (Buttons, Select Menus)
+ * @property int|null            $style       One of button styles. (Buttons)
+ * @property string|null         $label       Text that appears on the button, max 80 characters. (Buttons)
+ * @property Emoji|null          $emoji       Name, id, and animated. (Buttons)
+ * @property string|null         $url         A url for link-style buttons. (Buttons)
+ * @property object[]|null       $options     The choices in the select, max 25. (Select Menus)
+ * @property string|null         $placeholder Custom placeholder text if nothing is selected, max 100 characters. (Select Menus, Text Inputs)
+ * @property int|null            $min_values  The minimum number of items that must be chosen; default 1, min 0, max 25. (Select Menus)
+ * @property int|null            $max_values  The maximum number of items that can be chosen; default 1, max 25. (Select Menus)
+ * @property ComponentRepository $components  A list of child components. (Action Rows)
+ * @property int|null            $min_length  The minimum input length for a text input. (Text Inputs)
+ * @property int|null            $max_length  The maximum input length for a text input. (Text Inputs)
+ * @property bool|null           $required    Whether this component is required to be filled. (Text Inputs)
+ * @property string|null         $value       A pre-filled value for this component. (Text Inputs)
+ */
+class Component extends Part
+{
+    /**
+     * @inheritdoc
+     */
+    protected $fillable = [
+        'type',
+        'custom_id',
+        'disabled',
+        'style',
+        'label',
+        'emoji',
+        'url',
+        'options',
+        'placeholder',
+        'min_values',
+        'max_values',
+        'components',
+        'min_length',
+        'max_length',
+        'required',
+        'value',
+    ];
+
+    /**
+     * @inheritdoc
+     */
+    protected $repositories = [
+        'components' => ComponentRepository::class,
+    ];
+
+    /**
+     * Sets the sub-components of the component.
+     *
+     * @param array $components
+     */
+    protected function setComponentsAttribute($components)
+    {
+        foreach ($components as $component) {
+            $this->components->pushItem($this->factory->create(Component::class, $component, true));
+        }
+    }
+
+    /**
+     * Gets the partial emoji attribute.
+     *
+     * @return Emoji|null
+     */
+    protected function getEmojiAttribute(): ?Emoji
+    {
+        if (isset($this->attributes['emoji'])) {
+            return $this->factory->create(Emoji::class, $this->attributes['emoji'], true);
+        }
+
+        return null;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getRepositoryAttributes(): array
+    {
+        return [];
+    }
+}

--- a/src/Discord/Parts/Interactions/Request/Component.php
+++ b/src/Discord/Parts/Interactions/Request/Component.php
@@ -35,7 +35,7 @@ use Discord\Repository\Interaction\ComponentRepository;
  * @property int|null            $min_length  The minimum input length for a text input. (Text Inputs)
  * @property int|null            $max_length  The maximum input length for a text input. (Text Inputs)
  * @property bool|null           $required    Whether this component is required to be filled. (Text Inputs)
- * @property string|null         $value       A pre-filled value for this component. (Text Inputs)
+ * @property string|null         $value       Value for this component. (Text Inputs)
  */
 class Component extends Part
 {

--- a/src/Discord/Parts/Interactions/Request/InteractionData.php
+++ b/src/Discord/Parts/Interactions/Request/InteractionData.php
@@ -28,6 +28,7 @@ use Discord\Repository\Interaction\OptionRepository;
  * @property int|null         $component_type Type of the component. Not used for slash commands.
  * @property string[]|null    $values         Values selected in a select menu.
  * @property string|null      $target_id      Id the of user or message targetted by a user or message command.
+ * @property object[]|null    $components     The values submitted by the user in modal.
  * @property string|null      $guild_id       ID of the guild passed from Interaction.
  */
 class InteractionData extends Part

--- a/src/Discord/Parts/Interactions/Request/InteractionData.php
+++ b/src/Discord/Parts/Interactions/Request/InteractionData.php
@@ -12,6 +12,7 @@
 namespace Discord\Parts\Interactions\Request;
 
 use Discord\Parts\Part;
+use Discord\Repository\Interaction\ComponentRepository;
 use Discord\Repository\Interaction\OptionRepository;
 
 /**
@@ -19,35 +20,43 @@ use Discord\Repository\Interaction\OptionRepository;
  *
  * @see https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-interaction-data-structure
  *
- * @property string           $id             ID of the invoked command.
- * @property string           $name           Name of the invoked command.
- * @property int              $type           The type of the invoked command.
- * @property Resolved|null    $resolved       Resolved users, members, roles and channels that are relevant.
- * @property OptionRepository $options        Parameters and values from the user.
- * @property string|null      $custom_id      Custom ID the component was created for. Not used for slash commands.
- * @property int|null         $component_type Type of the component. Not used for slash commands.
- * @property string[]|null    $values         Values selected in a select menu.
- * @property string|null      $target_id      Id the of user or message targetted by a user or message command.
- * @property object[]|null    $components     The values submitted by the user in modal.
- * @property string|null      $guild_id       ID of the guild passed from Interaction.
+ * @property string              $id             ID of the invoked command.
+ * @property string              $name           Name of the invoked command.
+ * @property int                 $type           The type of the invoked command.
+ * @property Resolved|null       $resolved       Resolved users, members, roles and channels that are relevant.
+ * @property OptionRepository    $options        Parameters and values from the user.
+ * @property string|null         $custom_id      Custom ID the component was created for. Not used for slash commands.
+ * @property int|null            $component_type Type of the component. Not used for slash commands.
+ * @property string[]|null       $values         Values selected in a select menu.
+ * @property string|null         $target_id      Id the of user or message targetted by a user or message command.
+ * @property ComponentRepository $components     The values submitted by the user in modal.
+ * @property string|null         $guild_id       ID of the guild passed from Interaction.
  */
 class InteractionData extends Part
 {
     /**
      * @inheritdoc
      */
-    protected $fillable = ['id', 'name', 'type', 'resolved', 'options', 'custom_id', 'component_type', 'values', 'target_id', 'guild_id'];
-
-    /**
-     * @inheritdoc
-     */
-    protected $visible = ['options'];
+    protected $fillable = [
+        'id',
+        'name',
+        'type',
+        'resolved',
+        'options',
+        'custom_id',
+        'component_type',
+        'values',
+        'target_id',
+        'components',
+        'guild_id'
+    ];
 
     /**
      * @inheritdoc
      */
     protected $repositories = [
         'options' => OptionRepository::class,
+        'components' => ComponentRepository::class,
     ];
 
     /**
@@ -59,6 +68,18 @@ class InteractionData extends Part
     {
         foreach ($options as $option) {
             $this->options->push($this->factory->create(Option::class, $option, true));
+        }
+    }
+
+    /**
+     * Sets the components of the interaction.
+     *
+     * @param array $components
+     */
+    protected function setComponentsAttribute($components)
+    {
+        foreach ($components as $component) {
+            $this->components->push($this->factory->create(Component::class, $component, true));
         }
     }
 

--- a/src/Discord/Parts/Interactions/Request/Resolved.php
+++ b/src/Discord/Parts/Interactions/Request/Resolved.php
@@ -12,6 +12,7 @@
 namespace Discord\Parts\Interactions\Request;
 
 use Discord\Helpers\Collection;
+use Discord\Parts\Channel\Attachment;
 use Discord\Parts\Channel\Channel;
 use Discord\Parts\Channel\Message;
 use Discord\Parts\Guild\Role;
@@ -30,7 +31,7 @@ use Discord\Parts\User\User;
  * @property Collection|Role[]|null             $roles       The ids and Role objects.
  * @property Collection|Channel[]|Thread[]|null $channels    The ids and partial Channel objects.
  * @property Collection|Message[]|null          $messages    The ids and partial Message objects.
- * @property Collection|object[]|null           $attachments The ids and partial Attachment objects.
+ * @property Collection|Attachment[]|null       $attachments The ids and partial Attachment objects.
  * @property string|null                        $guild_id    ID of the guild passed from Interaction.
  */
 class Resolved extends Part
@@ -191,7 +192,7 @@ class Resolved extends Part
     /**
      * Returns a collection of resolved attachments.
      *
-     * @return Collection|object[]|null Map of Snowflakes to attachments objects
+     * @return Collection|Attachment[]|null Map of Snowflakes to attachments objects
      */
     protected function getAttachmentsAttribute(): ?Collection
     {
@@ -199,6 +200,12 @@ class Resolved extends Part
             return null;
         }
 
-        return new Collection((array) $this->attributes['attachments']);
+        $attachments = Collection::for(Attachment::class);
+
+        foreach ($this->attributes['attachments'] as $attachment) {
+            $attachments->pushItem($this->factory->create(Attachment::class, $attachment, true));
+        }
+
+        return $attachments;
     }
 }

--- a/src/Discord/Parts/Interactions/Request/Resolved.php
+++ b/src/Discord/Parts/Interactions/Request/Resolved.php
@@ -25,19 +25,20 @@ use Discord\Parts\User\User;
  *
  * @see https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-resolved-data-structure
  *
- * @property Collection|User[]|null             $users    The ids and User objects.
- * @property Collection|Member[]|null           $members  The ids and partial Member objects.
- * @property Collection|Role[]|null             $roles    The ids and Role objects.
- * @property Collection|Channel[]|Thread[]|null $channels The ids and partial Channel objects.
- * @property Collection|Message[]|null          $messages The ids and partial Message objects.
- * @property string|null                        $guild_id ID of the guild passed from Interaction.
+ * @property Collection|User[]|null             $users       The ids and User objects.
+ * @property Collection|Member[]|null           $members     The ids and partial Member objects.
+ * @property Collection|Role[]|null             $roles       The ids and Role objects.
+ * @property Collection|Channel[]|Thread[]|null $channels    The ids and partial Channel objects.
+ * @property Collection|Message[]|null          $messages    The ids and partial Message objects.
+ * @property Collection|object[]|null           $attachments The ids and partial Attachment objects.
+ * @property string|null                        $guild_id    ID of the guild passed from Interaction.
  */
 class Resolved extends Part
 {
     /**
      * @inheritdoc
      */
-    protected $fillable = ['users', 'members', 'roles', 'channels', 'messages', 'guild_id'];
+    protected $fillable = ['users', 'members', 'roles', 'channels', 'messages', 'attachments', 'guild_id'];
 
     /**
      * Returns a collection of resolved users.
@@ -185,5 +186,19 @@ class Resolved extends Part
         }
 
         return $collection;
+    }
+
+    /**
+     * Returns a collection of resolved attachments.
+     *
+     * @return Collection|object[]|null Map of Snowflakes to attachments objects
+     */
+    protected function getAttachmentsAttribute(): ?Collection
+    {
+        if (! isset($this->attributes['attachments'])) {
+            return null;
+        }
+
+        return new Collection((array) $this->attributes['attachments']);
     }
 }

--- a/src/Discord/Parts/WebSockets/TypingStart.php
+++ b/src/Discord/Parts/WebSockets/TypingStart.php
@@ -43,8 +43,7 @@ class TypingStart extends Part
     /**
      * @inheritdoc
      */
-    protected $visible = ['channel', 'guild', 'user', 'member'];
-
+    protected $visible = ['channel', 'guild', 'user'];
 
     /**
      * Gets the channel attribute.

--- a/src/Discord/Repository/Interaction/ComponentRepository.php
+++ b/src/Discord/Repository/Interaction/ComponentRepository.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is a part of the DiscordPHP project.
+ *
+ * Copyright (c) 2015-present David Cole <david.cole1340@gmail.com>
+ *
+ * This file is subject to the MIT license that is bundled
+ * with this source code in the LICENSE.md file.
+ */
+
+namespace Discord\Repository\Interaction;
+
+use Discord\Parts\Interactions\Request\Component;
+use Discord\Repository\AbstractRepository;
+
+class ComponentRepository extends AbstractRepository
+{
+    /**
+     * @inheritdoc
+     */
+    protected $class = Component::class;
+
+    /**
+     * @inheritdoc
+     */
+    protected $discrim = null;
+}


### PR DESCRIPTION
This PR adds:

- Modal message component (https://github.com/discord/discord-api-docs/pull/4459)

- Attachment type slash command (https://github.com/discord/discord-api-docs/pull/4253)

For modal requires update from: https://github.com/discord/discord-interactions-php/pull/6