### PR TITLE
Add old thread in Thread Update event, also fix events again

### DIFF
--- a/src/Discord/WebSockets/Events/GuildScheduledEventUpdate.php
+++ b/src/Discord/WebSockets/Events/GuildScheduledEventUpdate.php
@@ -40,6 +40,9 @@ class GuildScheduledEventUpdate extends Event
         if (! $oldScheduledEvent) {
             /** @var ScheduledEvent */
             $scheduledEventPart = $this->factory->create(ScheduledEvent::class, $data, true);
+            if ($guild = $scheduledEventPart->guild) {
+                $guild->guild_scheduled_events->pushItem($scheduledEventPart);
+            }
         }
 
         if (isset($data->creator)) {

--- a/src/Discord/WebSockets/Events/GuildUpdate.php
+++ b/src/Discord/WebSockets/Events/GuildUpdate.php
@@ -33,6 +33,7 @@ class GuildUpdate extends Event
         } else {
             /** @var Guild */
             $guildPart = $this->factory->create(Guild::class, $data, true);
+            $this->discord->guilds->pushItem($guildPart);
         }
 
         $deferred->resolve([$guildPart, $oldGuild]);

--- a/src/Discord/WebSockets/Events/IntegrationUpdate.php
+++ b/src/Discord/WebSockets/Events/IntegrationUpdate.php
@@ -40,6 +40,9 @@ class IntegrationUpdate extends Event
         if (! $oldIntegration) {
             /** @var Integration */
             $integrationPart = $this->factory->create(Integration::class, $data, true);
+            if ($guild = $integrationPart->guild) {
+                $guild->integrations->pushItem($integrationPart);
+            }
         }
 
         if (isset($data->user)) {

--- a/src/Discord/WebSockets/Events/StageInstanceUpdate.php
+++ b/src/Discord/WebSockets/Events/StageInstanceUpdate.php
@@ -40,6 +40,9 @@ class StageInstanceUpdate extends Event
         if (! $oldStageInstance) {
             /** @var StageInstance */
             $stageInstancePart = $this->factory->create(StageInstance::class, $data, true);
+            if ($guild = $stageInstancePart->guild) {
+                $guild->stage_instances->pushItem($stageInstancePart);
+            }
         }
 
         $deferred->resolve([$stageInstancePart, $oldStageInstance]);

--- a/src/Discord/WebSockets/Events/ThreadListSync.php
+++ b/src/Discord/WebSockets/Events/ThreadListSync.php
@@ -11,6 +11,7 @@
 
 namespace Discord\WebSockets\Events;
 
+use Discord\Helpers\Collection;
 use Discord\Helpers\Deferred;
 use Discord\Parts\Thread\Member;
 use Discord\Parts\Thread\Thread;
@@ -24,22 +25,33 @@ class ThreadListSync extends Event
     public function handle(Deferred &$deferred, $data)
     {
         $guild = $this->discord->guilds->get('id', $data->guild_id);
+        $threads = Collection::for(Thread::class);
         $members = (array) $data->members;
 
         foreach ($data->threads as $thread) {
-            /** @var Thread */
-            $thread = $this->factory->create(Thread::class, $thread, true);
-
-            foreach ($members as $member) {
-                if ($member->id == $thread->id) {
-                    $thread->members->push($this->factory->create(Member::class, $members[$thread->id], true));
-                    break;
+            if ($channel = $guild->channels->get('id', $thread->parent_id)) {
+                if ($threadPart = $channel->threads->get('id', $thread->id)) {
+                    $threadPart->fill((array) $thread);
                 }
             }
 
-            $guild->threads->push($thread);
+            if (! $threadPart) {
+                /** @var Thread */
+                $threadPart = $this->factory->create(Thread::class, $thread, true);
+                if ($channel = $threadPart->parent) {
+                    $channel->threads->pushItem($threadPart);
+                }
+            }
+
+            foreach ($members as $member) {
+                if ($member->id == $thread->id) {
+                    $threadPart->members->pushItem($this->factory->create(Member::class, $member, true));
+                }
+            }
+
+            $threads->pushItem($threadPart);
         }
 
-        $deferred->resolve();
+        $deferred->resolve($threads);
     }
 }

--- a/src/Discord/WebSockets/Events/ThreadUpdate.php
+++ b/src/Discord/WebSockets/Events/ThreadUpdate.php
@@ -12,6 +12,7 @@
 namespace Discord\WebSockets\Events;
 
 use Discord\Helpers\Deferred;
+use Discord\Parts\Thread\Thread;
 use Discord\WebSockets\Event;
 
 /**
@@ -21,16 +22,28 @@ class ThreadUpdate extends Event
 {
     public function handle(Deferred &$deferred, $data)
     {
-        $thread = null;
+        $oldThread = null;
 
         if ($guild = $this->discord->guilds->get('id', $data->guild_id)) {
             if ($parent = $guild->channels->get('id', $data->parent_id)) {
-                if ($thread = $parent->threads->get('id', $data->id)) {
-                    $thread->fill((array) $data);
+                if ($oldThread = $parent->threads->get('id', $data->id)) {
+                    // Swap
+                    $threadPart = $oldThread;
+                    $oldThread = clone $oldThread;
+
+                    $threadPart->fill((array) $data);
                 }
             }
         }
 
-        $deferred->resolve($thread);
+        if (! $oldThread) {
+            /** @var Thread */
+            $threadPart = $this->factory->create(Thread::class, $data, true);
+            if ($parent = $threadPart->parent) {
+                $parent->threads->pushItem($threadPart);
+            }
+        }
+
+        $deferred->resolve($oldThread);
     }
 }

--- a/src/Discord/WebSockets/Events/ThreadUpdate.php
+++ b/src/Discord/WebSockets/Events/ThreadUpdate.php
@@ -44,6 +44,6 @@ class ThreadUpdate extends Event
             }
         }
 
-        $deferred->resolve($oldThread);
+        $deferred->resolve([$threadPart, $oldThread]);
     }
 }


### PR DESCRIPTION
Follow up to #715

- Thread update is not nullable
- Added old thread in `Event::THREAD_UPDATE`
- Fix some update events not caching new data into repository