### PR TITLE
Update Invite handling

### DIFF
--- a/src/Discord/Parts/Channel/Channel.php
+++ b/src/Discord/Parts/Channel/Channel.php
@@ -1085,6 +1085,16 @@ class Channel extends Part
     }
 
     /**
+     * Returns if allow invite.
+     *
+     * @return bool if we can make invite or not.
+     */
+    public function allowInvite()
+    {
+        return in_array($this->type, [self::TYPE_TEXT, self::TYPE_VOICE, self::TYPE_NEWS, self::TYPE_STAGE_CHANNEL]);
+    }
+
+    /**
      * @inheritdoc
      */
     public function getCreatableAttributes(): array

--- a/src/Discord/Parts/Channel/Channel.php
+++ b/src/Discord/Parts/Channel/Channel.php
@@ -32,6 +32,7 @@ use Discord\Helpers\Deferred;
 use Discord\Http\Endpoint;
 use Discord\Http\Exceptions\NoPermissionsException;
 use Discord\Parts\Thread\Thread;
+use Discord\Repository\Channel\InviteRepository;
 use Discord\Repository\Channel\ThreadRepository;
 use React\Promise\ExtendedPromiseInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -76,6 +77,7 @@ use function React\Promise\resolve;
  * @property MessageRepository   $messages                      Text channel only - messages sent in the channel.
  * @property WebhookRepository   $webhooks                      Webhooks in the channel.
  * @property ThreadRepository    $threads                       Threads that belong to the channel.
+ * @property InviteRepository    $invites                       Invites in the channel.
  *
  * @method ExtendedPromiseInterface sendMessage(MessageBuilder $builder)
  * @method ExtendedPromiseInterface sendMessage(string $text, bool $tts = false, Embed|array $embed = null, array $allowed_mentions = null, ?Message $replyTo = null)
@@ -135,6 +137,7 @@ class Channel extends Part
         'messages' => MessageRepository::class,
         'webhooks' => WebhookRepository::class,
         'threads' => ThreadRepository::class,
+        'invites' => InviteRepository::class,
     ];
 
     /**

--- a/src/Discord/Parts/Channel/Invite.php
+++ b/src/Discord/Parts/Channel/Invite.php
@@ -9,11 +9,12 @@
  * with this source code in the LICENSE.md file.
  */
 
-namespace Discord\Parts\Guild;
+namespace Discord\Parts\Channel;
 
 use Carbon\Carbon;
 use Discord\Http\Endpoint;
-use Discord\Parts\Channel\Channel;
+use Discord\Parts\Guild\Guild;
+use Discord\Parts\Guild\ScheduledEvent;
 use Discord\Parts\Part;
 use Discord\Parts\User\User;
 use React\Promise\ExtendedPromiseInterface;
@@ -156,7 +157,7 @@ class Invite extends Part
      *
      * @return Channel    The Channel that you have been invited to.
      */
-    protected function getChannelAttribute(): ?Channel
+    protected function getChannelAttribute(): Channel
     {
         if (isset($this->attributes['channel_id']) && $channel = $this->discord->getChannel($this->attributes['channel_id'])) {
             return $channel;

--- a/src/Discord/Parts/Guild/Guild.php
+++ b/src/Discord/Parts/Guild/Guild.php
@@ -16,6 +16,7 @@ use Discord\Exceptions\FileNotFoundException;
 use Discord\Helpers\Collection;
 use Discord\Http\Endpoint;
 use Discord\Http\Exceptions\NoPermissionsException;
+use Discord\Parts\Channel\Invite;
 use Discord\Parts\Part;
 use Discord\Parts\User\Member;
 use Discord\Parts\User\User;

--- a/src/Discord/Parts/Guild/Guild.php
+++ b/src/Discord/Parts/Guild/Guild.php
@@ -16,6 +16,7 @@ use Discord\Exceptions\FileNotFoundException;
 use Discord\Helpers\Collection;
 use Discord\Http\Endpoint;
 use Discord\Http\Exceptions\NoPermissionsException;
+use Discord\Parts\Channel\Channel;
 use Discord\Parts\Channel\Invite;
 use Discord\Parts\Part;
 use Discord\Parts\User\Member;
@@ -1003,6 +1004,31 @@ class Guild extends Part
     public function getWidget(): ExtendedPromiseInterface
     {
         return $this->factory->part(Widget::class, ['id' => $this->id])->fetch();
+    }
+
+    /**
+     * Attempts to create an Invite to a channel in this guild where possible.
+     *
+     * @see Channel::createInvite()
+     *
+     * @throws \RuntimeException
+     * @throws NoPermissionsException
+     *
+     * @return ExtendedPromiseInterface<Invite>
+     */
+    public function createInvite(...$args): ExtendedPromiseInterface
+    {
+        /** @var Member */
+        $botMember = $this->members->offsetGet($this->discord->id);
+        $channel = $this->channels->find(function (Channel $channel) use ($botMember) {
+            return $channel->allowInvite() && $botMember->getPermissions($channel)->create_instant_invite;
+        });
+
+        if (! $channel) {
+            return reject(new \RuntimeException("No channels found to create an Invite to the specified guild."));
+        }
+
+        return $channel->createInvite($args);
     }
 
     /**

--- a/src/Discord/Repository/Channel/InviteRepository.php
+++ b/src/Discord/Repository/Channel/InviteRepository.php
@@ -12,7 +12,7 @@
 namespace Discord\Repository\Channel;
 
 use Discord\Http\Endpoint;
-use Discord\Parts\Guild\Invite;
+use Discord\Parts\Channel\Invite;
 use Discord\Repository\AbstractRepository;
 
 /**

--- a/src/Discord/Repository/Guild/InviteRepository.php
+++ b/src/Discord/Repository/Guild/InviteRepository.php
@@ -12,7 +12,7 @@
 namespace Discord\Repository\Guild;
 
 use Discord\Http\Endpoint;
-use Discord\Parts\Guild\Invite;
+use Discord\Parts\Channel\Invite;
 use Discord\Repository\AbstractRepository;
 
 /**

--- a/src/Discord/WebSockets/Events/InviteCreate.php
+++ b/src/Discord/WebSockets/Events/InviteCreate.php
@@ -11,9 +11,9 @@
 
 namespace Discord\WebSockets\Events;
 
-use Discord\Parts\Guild\Invite;
 use Discord\WebSockets\Event;
 use Discord\Helpers\Deferred;
+use Discord\Parts\Channel\Invite;
 
 /**
  * @see https://discord.com/developers/docs/topics/gateway#invite-create
@@ -25,7 +25,12 @@ class InviteCreate extends Event
      */
     public function handle(Deferred &$deferred, $data): void
     {
+        /** @var Invite */
         $invite = $this->factory->create(Invite::class, $data, true);
+
+        if ($channel = $invite->channel) {
+            $channel->invites->pushItem($invite);
+        }
 
         if (isset($data->inviter)) {
             // User caching from inviter

--- a/src/Discord/WebSockets/Events/InviteDelete.php
+++ b/src/Discord/WebSockets/Events/InviteDelete.php
@@ -24,6 +24,14 @@ class InviteDelete extends Event
      */
     public function handle(Deferred &$deferred, $data): void
     {
-        $deferred->resolve($data);
+        $invitePart = null;
+
+        if ($guild = $this->discord->guilds->get('id', $data->guild_id)) {
+            if ($channel = $guild->channels->get('id', $data->channel_id)) {
+                $invitePart = $channel->invites->pull($data->code);
+            }
+        }
+
+        $deferred->resolve($invitePart ?? $data);
     }
 }

--- a/tests/Parts/Channel/ChannelTest.php
+++ b/tests/Parts/Channel/ChannelTest.php
@@ -16,7 +16,7 @@ use Discord\Discord;
 use Discord\Helpers\Collection;
 use Discord\Parts\Channel\Channel;
 use Discord\Parts\Channel\Message;
-use Discord\Parts\Guild\Invite;
+use Discord\Parts\Channel\Invite;
 
 /**
  * @covers \Discord\Parts\Channel\Channel


### PR DESCRIPTION
This PR:

- Adds unused `InviteRepository` to `Channel`
- Make use of $channel->invites repository on `Event::INVITE_CREATE` and `Event::INVITE_DELETE`
- Refactor: Moved the Invite part class from Guild to Channel.
- Adds an helper to `createInvite()` from a `Guild`

Breaking:
`use Discord\Parts\Guild\Invite;` is now `use Discord\Parts\Channel\Invite;`


Tested, ~~however it seems that the `Event::INVITE_CREATE` and `Event::INVITE_DELETE` does not trigger sometimes, I had to enable all perms for the Bot and restart but not sure which actually the cause...~~ requires Manage channel permission for the events to work