### PR TITLE
Update TextInput::required default value is true

### DIFF
--- a/src/Discord/Builders/Components/TextInput.php
+++ b/src/Discord/Builders/Components/TextInput.php
@@ -63,7 +63,7 @@ class TextInput extends Component
      *
      * @var bool
      */
-    private $required = false;
+    private $required;
 
     /**
      * Pre-filled value for text input. Max 4000 characters.
@@ -338,8 +338,8 @@ class TextInput extends Component
             $content['max_length'] = $this->max_length;
         }
 
-        if ($this->required) {
-            $content['required'] = true;
+        if (isset($this->required)) {
+            $content['required'] = $this->required;
         }
 
         if (isset($this->value)) {

--- a/src/Discord/Builders/Components/TextInput.php
+++ b/src/Discord/Builders/Components/TextInput.php
@@ -210,7 +210,7 @@ class TextInput extends Component
     }
 
     /**
-     * Sets the placeholder string to display if nothing is selected.
+     * Sets the placeholder string to display if text input is empty.
      * Maximum 100 characters. Null to clear placeholder.
      *
      * @param string|null $placeholder
@@ -285,7 +285,7 @@ class TextInput extends Component
     }
 
     /**
-     * Returns the minimum number of options that must be selected.
+     * Returns the minimum length of the text input.
      *
      * @return int|null
      */
@@ -295,7 +295,7 @@ class TextInput extends Component
     }
 
     /**
-     * Returns the maximum number of options that must be selected.
+     * Returns the maximum length of the text input.
      *
      * @return int|null
      */


### PR DESCRIPTION
https://github.com/discord/discord-api-docs/commit/e246041390a61bf84418d76ef6aaaefaa785558f

Fixes `setRequired(false)`

Can be merged directly.