### PR TITLE
Add dnsConfig options

### DIFF
--- a/docs/src/pages/api/02_basics.md
+++ b/docs/src/pages/api/02_basics.md
@@ -89,6 +89,13 @@ Useful if you want to use other React components. By default, a new loop is crea
     'logger' => new \Monolog\Logger('New logger'),
 ```
 
+`dnsConfig` is an instace of `Config` or a string of name server address. By default, 8.8.8.8 is used. Currently only used for VoiceClient.
+
+```php
+    'dnsConfig' => '1.1.1.1',
+```
+
+
 <hr>
 
 The following options should only be used by large bots that require sharding. If you plan to use sharding, [read up](https://discord.com/developers/docs/topics/gateway#sharding) on how Discord implements it.

--- a/src/Discord/Discord.php
+++ b/src/Discord/Discord.php
@@ -1171,6 +1171,7 @@ class Discord
 
             $data['token'] = $vs->token;
             $data['endpoint'] = $vs->endpoint;
+            $data['dnsConfig'] = $discord->options['dnsConfig'];
             $this->logger->info('received token and endpoint for voice session', ['guild' => $channel->guild_id, 'token' => $vs->token, 'endpoint' => $vs->endpoint]);
 
             if (is_null($logger)) {
@@ -1299,6 +1300,7 @@ class Discord
                 'retrieveBans',
                 'intents',
                 'socket_options',
+                'dnsConfig',
             ])
             ->setDefaults([
                 'loop' => LoopFactory::create(),
@@ -1310,6 +1312,7 @@ class Discord
                 'retrieveBans' => false,
                 'intents' => Intents::getDefaultIntents(),
                 'socket_options' => [],
+                'dnsConfig' => '8.8.8.8'
             ])
             ->setAllowedTypes('token', 'string')
             ->setAllowedTypes('logger', ['null', LoggerInterface::class])
@@ -1320,7 +1323,8 @@ class Discord
             ->setAllowedTypes('storeMessages', 'bool')
             ->setAllowedTypes('retrieveBans', 'bool')
             ->setAllowedTypes('intents', ['array', 'int'])
-            ->setAllowedTypes('socket_options', 'array');
+            ->setAllowedTypes('socket_options', 'array')
+            ->setAllowedTypes('dnsConfig', ['string', \React\Dns\Config::class]);
 
         $options = $resolver->resolve($options);
 

--- a/src/Discord/Discord.php
+++ b/src/Discord/Discord.php
@@ -1324,7 +1324,7 @@ class Discord
             ->setAllowedTypes('retrieveBans', 'bool')
             ->setAllowedTypes('intents', ['array', 'int'])
             ->setAllowedTypes('socket_options', 'array')
-            ->setAllowedTypes('dnsConfig', ['string', \React\Dns\Config::class]);
+            ->setAllowedTypes('dnsConfig', ['string', \React\Dns\Config\Config::class]);
 
         $options = $resolver->resolve($options);
 

--- a/src/Discord/Voice/VoiceClient.php
+++ b/src/Discord/Voice/VoiceClient.php
@@ -319,6 +319,13 @@ class VoiceClient extends EventEmitter
     protected $version = 4;
 
     /**
+     * The Config for DNS Resolver
+     *
+     * @var string|\React\Dns\Config
+     */
+    protected $dnsConfig;
+
+    /**
      * Constructs the Voice Client instance.
      *
      * @param WebSocket       $websocket The main WebSocket client.
@@ -338,6 +345,7 @@ class VoiceClient extends EventEmitter
         $this->mute = $data['mute'];
         $this->endpoint = str_replace([':80', ':443'], '', $data['endpoint']);
         $this->speakingStatus = new Collection([], 'ssrc');
+        $this->dnsConfig = $data['dnsConfig'];
     }
 
     /**
@@ -385,7 +393,7 @@ class VoiceClient extends EventEmitter
     {
         $this->logger->debug('connected to voice websocket');
 
-        $resolver = (new DNSFactory())->createCached('8.8.8.8', $this->loop);
+        $resolver = (new DNSFactory())->createCached($this->dnsConfig, $this->loop);
         $udpfac = new DatagramFactory($this->loop, $resolver);
 
         $this->voiceWebsocket = $ws;


### PR DESCRIPTION
From Discord user @risner#8865, this PR adds a option to change the hardcoded name server used in VoiceClient from discord options `dnsConfig` that accepts \React\Dns\Config object or a string of DNS IP address.

Example taken from https://github.com/reactphp/dns/
```php
$config = React\Dns\Config\Config::loadSystemConfigBlocking();
if (!$config->nameservers) {
    $config->nameservers[] = '8.8.8.8';
}

$discord = new Discord([
    // ...
    'dnsConfig' = $config,
]);
```