### PR TITLE
Bump version, deprecate invite stage instance, thread updateable

### DIFF
--- a/src/Discord/Builders/MessageBuilder.php
+++ b/src/Discord/Builders/MessageBuilder.php
@@ -17,6 +17,7 @@ use Discord\Builders\Components\SelectMenu;
 use Discord\Exceptions\FileNotFoundException;
 use Discord\Helpers\Multipart;
 use Discord\Http\Exceptions\RequestFailedException;
+use Discord\Parts\Channel\Attachment;
 use Discord\Parts\Channel\Message;
 use Discord\Parts\Embed\Embed;
 use Discord\Parts\Guild\Sticker;
@@ -65,6 +66,13 @@ class MessageBuilder implements JsonSerializable
      * @var array[]
      */
     private $files = [];
+
+    /**
+     * Attachments to send with this message.
+     * 
+     * @var Attachment[]
+     */
+    private $attachments = [];
 
     /**
      * Components to send with this message.
@@ -334,6 +342,50 @@ class MessageBuilder implements JsonSerializable
     }
 
     /**
+     * Adds attachment(s) to the message.
+     *
+     * @param Attachment|string|int $attachment Attachment objects or IDs to add
+     *
+     * @return $this
+     */
+    public function addAttachment(...$attachments): self
+    {
+        foreach ($attachments as $attachment) {
+            if ($attachment instanceof Attachment) {
+                $attachment = $attachment->getRawAttributes();
+            } else {
+                $attachment = ['id' => $attachment];
+            }
+
+            $this->attachments[] = $attachment;
+        }
+
+        return $this;
+    }
+
+    /**
+     * Returns all the attachments in the message.
+     *
+     * @return Attachment[]
+     */
+    public function getAttachments(): array
+    {
+        return $this->attachments;
+    }
+
+    /**
+     * Removes all attachments from the message.
+     *
+     * @return $this
+     */
+    public function clearAttachments(): self
+    {
+        $this->attachments = [];
+
+        return $this;
+    }
+
+    /**
      * Sets the allowed mentions object of the message.
      *
      * @param array $allowed_mentions
@@ -522,6 +574,10 @@ class MessageBuilder implements JsonSerializable
                 'message_id' => $this->replyTo->id,
                 'channel_id' => $this->replyTo->channel_id,
             ];
+        }
+
+        if ($this->attachments) {
+            $content['attachments'] = $this->attachments;
         }
 
         if ($empty) {

--- a/src/Discord/Discord.php
+++ b/src/Discord/Discord.php
@@ -86,7 +86,7 @@ class Discord
      *
      * @var string Version.
      */
-    public const VERSION = 'v7.0.0';
+    public const VERSION = 'v7.0.2';
 
     /**
      * The logger.

--- a/src/Discord/Discord.php
+++ b/src/Discord/Discord.php
@@ -1398,7 +1398,7 @@ class Discord
     public function close(bool $closeLoop = true): void
     {
         $this->closing = true;
-        $this->ws->close(Op::CLOSE_UNKNOWN_ERROR, 'discordphp closing...');
+        $this->ws->close($closeLoop ? Op::CLOSE_UNKNOWN_ERROR : Op::CLOSE_NORMAL, 'discordphp closing...');
         $this->emit('closed', [$this]);
         $this->logger->info('discord closed');
 

--- a/src/Discord/Parts/Channel/Invite.php
+++ b/src/Discord/Parts/Channel/Invite.php
@@ -36,7 +36,6 @@ use React\Promise\ExtendedPromiseInterface;
  * @property int|null            $approximate_presence_count Approximate count of online members, returned from the GET /invites/<code> endpoint when with_counts is true.
  * @property int|null            $approximate_member_count   Approximate count of total members, returned from the GET /invites/<code> endpoint when with_counts is true.
  * @property Carbon|null         $expires_at                 The expiration date of this invite, returned from the GET /invites/<code> endpoint when with_expiration is true.
- * @property object|null         $stage_instance             Stage instance data if there is a public Stage instance in the Stage channel this invite is for.
  * @property ScheduledEvent|null $guild_scheduled_event      Guild scheduled event data, only included if guild_scheduled_event_id contains a valid guild scheduled event id.
  * @property int                 $uses                       How many times the invite has been used.
  * @property int                 $max_uses                   How many times the invite can be used.
@@ -60,7 +59,7 @@ class Invite extends Part
         'approximate_presence_count',
         'approximate_member_count',
         'expires_at',
-        'stage_instance',
+        'stage_instance', // deprecated
         'guild_scheduled_event',
 
         // Extra metadata

--- a/src/Discord/Parts/Embed/Embed.php
+++ b/src/Discord/Parts/Embed/Embed.php
@@ -13,6 +13,7 @@ namespace Discord\Parts\Embed;
 
 use Carbon\Carbon;
 use Discord\Helpers\Collection;
+use Discord\Parts\Channel\Attachment;
 use Discord\Parts\Part;
 use function Discord\poly_strlen;
 
@@ -385,13 +386,17 @@ class Embed extends Part
     /**
      * Set the image of this embed.
      *
-     * @param string $url
+     * @param string|Attachment $url
      *
      * @return $this
      */
     public function setImage($url): self
     {
-        $this->image = ['url' => (string) $url];
+        if ($url instanceof Attachment) {
+            $this->image = ['url' => 'attachment://'.$url->filename];
+        } else {
+            $this->image = ['url' => (string) $url];
+        }
 
         return $this;
     }

--- a/src/Discord/Parts/Thread/Thread.php
+++ b/src/Discord/Parts/Thread/Thread.php
@@ -231,9 +231,9 @@ class Thread extends Part
     /**
      * Set the number of minutes of inactivity required for the thread to auto archive.
      *
-     * @param bool $value
+     * @param int $value
      */
-    protected function setAutoArchiveDurationAttribute($value)
+    protected function setAutoArchiveDurationAttribute(int $value)
     {
         $this->thread_metadata->auto_archive_duration = $value;
     }

--- a/src/Discord/Parts/User/Member.php
+++ b/src/Discord/Parts/User/Member.php
@@ -159,8 +159,8 @@ class Member extends Part
     /**
      * Moves the member to another voice channel.
      *
-     * @param Channel|string $channel The channel to move the member to.
-     * @param string|null    $reason  Reason for Audit Log.
+     * @param Channel|string|null $channel The channel to move the member to.
+     * @param string|null         $reason  Reason for Audit Log.
      *
      * @return ExtendedPromiseInterface
      */


### PR DESCRIPTION
- Bump version to 7.0.2
- Deprecate stage instance attribute in invite https://github.com/discord/discord-api-docs/pull/4479
- Fix phpdoc `Member::moveMember()` parameter `$channel` nullable
- Add updateable attributes for `Thread`, the following functions are separate to be used by Bots without `MANAGE_THREAD` permissions:
  - Add `Thread::rename()`
  - Add `Thread::setAutoArchiveDuration()`
  - Add audit log `$reason` parameters for `Thread::archive()` and `Thread::unarchive()`

Tested.

EDIT: also added Attachment stuff to `MessageBuilder`, this seems required to keep attachment in editing messages or not to append them when creating messages. (The behavior is required in Discord API v10)