### PR TITLE
Add Member::setRoles() and Fix to ignore potential null guild on events

### DIFF
--- a/src/Discord/Parts/User/Member.php
+++ b/src/Discord/Parts/User/Member.php
@@ -118,7 +118,7 @@ class Member extends Part
      * @see BanRepository::ban()
      *
      * @param int|null    $daysToDeleteMessages The amount of days to delete messages from.
-     * @param string|null $reason
+     * @param string|null $reason               Reason of the Ban.
      *
      * @throws \Exception
      *
@@ -397,12 +397,13 @@ class Member extends Part
      * Sets timeout on a member.
      *
      * @param Carbon|null $communication_disabled_until When the user's timeout will expire and the user will be able to communicate in the guild again, null or a time in the past if the user is not timed out.
+     * @param string|null $reason                       Reason for Audit Log.
      *
      * @throws NoPermissionsException
      *
      * @return ExtendedPromiseInterface
      */
-    public function timeoutMember(?Carbon $communication_disabled_until): ExtendedPromiseInterface
+    public function timeoutMember(?Carbon $communication_disabled_until, ?string $reason = null): ExtendedPromiseInterface
     {
         $botperms = $this->guild->members->offsetGet($this->discord->id)->getPermissions();
 
@@ -410,7 +411,12 @@ class Member extends Part
             return reject(new NoPermissionsException('You do not have permission to time out members in the specified guild.'));
         }
 
-        return $this->http->patch(Endpoint::bind(Endpoint::GUILD_MEMBER, $this->guild_id, $this->id), ['communication_disabled_until' => isset($communication_disabled_until) ? $communication_disabled_until->toIso8601ZuluString() : null]);
+        $headers = [];
+        if (isset($reason)) {
+            $headers['X-Audit-Log-Reason'] = $reason;
+        }
+
+        return $this->http->patch(Endpoint::bind(Endpoint::GUILD_MEMBER, $this->guild_id, $this->id), ['communication_disabled_until' => isset($communication_disabled_until) ? $communication_disabled_until->toIso8601ZuluString() : null], $headers);
     }
 
     /**

--- a/src/Discord/Parts/User/Member.php
+++ b/src/Discord/Parts/User/Member.php
@@ -244,10 +244,10 @@ class Member extends Part
      *
      * @see https://discord.com/developers/docs/resources/guild#modify-guild-member
      *
-     * @param Role[]|array<string> $roles  The roles to set to the member.
-     * @param string|null          $reason Reason for Audit Log.
+     * @param Role[]|string[] $roles  The roles to set to the member.
+     * @param string|null     $reason Reason for Audit Log.
      *
-     * @return ExtendedPromiseInterface
+     * @return ExtendedPromiseInterface<Member>
      */
     public function setRoles(array $roles, ?string $reason = null): ExtendedPromiseInterface
     {

--- a/src/Discord/Parts/User/Member.php
+++ b/src/Discord/Parts/User/Member.php
@@ -262,7 +262,7 @@ class Member extends Part
             $headers['X-Audit-Log-Reason'] = $reason;
         }
 
-        return $this->http->put(Endpoint::bind(Endpoint::GUILD_MEMBER, $this->guild_id, $this->id, $roles), null, $headers);
+        return $this->http->patch(Endpoint::bind(Endpoint::GUILD_MEMBER, $this->guild_id, $this->id), ['roles' => $roles], $headers);
     }
 
     /**

--- a/src/Discord/Parts/User/Member.php
+++ b/src/Discord/Parts/User/Member.php
@@ -240,6 +240,32 @@ class Member extends Part
     }
 
     /**
+     * Updates member roles.
+     *
+     * @see https://discord.com/developers/docs/resources/guild#modify-guild-member
+     *
+     * @param Role[]|array<string> $roles  The roles to set to the member.
+     * @param string|null          $reason Reason for Audit Log.
+     *
+     * @return ExtendedPromiseInterface
+     */
+    public function setRoles(array $roles, ?string $reason = null): ExtendedPromiseInterface
+    {
+        foreach ($roles as $i => $role) {
+            if ($role instanceof Role) {
+                $roles[$i] = $role->id;
+            }
+        }
+
+        $headers = [];
+        if (isset($reason)) {
+            $headers['X-Audit-Log-Reason'] = $reason;
+        }
+
+        return $this->http->put(Endpoint::bind(Endpoint::GUILD_MEMBER, $this->guild_id, $this->id, $roles), null, $headers);
+    }
+
+    /**
      * Sends a message to the member.
      *
      * Takes a `MessageBuilder` or content of the message for the first parameter. If the first parameter

--- a/src/Discord/WebSockets/Events/GuildMemberUpdate.php
+++ b/src/Discord/WebSockets/Events/GuildMemberUpdate.php
@@ -25,7 +25,7 @@ class GuildMemberUpdate extends Event
      */
     public function handle(Deferred &$deferred, $data): void
     {
-        $oldMember = null;
+        $memberPart = $oldMember = null;
 
         if ($guild = $this->discord->guilds->get('id', $data->guild_id)) {
             if ($oldMember = $guild->members->get('id', $data->user->id)) {
@@ -37,10 +37,12 @@ class GuildMemberUpdate extends Event
             }
         }
 
-        if (! $oldMember) {
+        if (! $memberPart) {
             /** @var Member */
             $memberPart = $this->factory->create(Member::class, $data, true);
-            $guild->members->pushItem($memberPart);
+            if ($guild = $memberPart->guild) {
+                $guild->members->pushItem($memberPart);
+            }
         }
 
         $this->cacheUser($data->user);

--- a/src/Discord/WebSockets/Events/GuildRoleUpdate.php
+++ b/src/Discord/WebSockets/Events/GuildRoleUpdate.php
@@ -27,7 +27,7 @@ class GuildRoleUpdate extends Event
     {
         $adata = (array) $data->role;
         $adata['guild_id'] = $data->guild_id;
-        $oldRole = null;
+        $rolePart = $oldRole = null;
 
         if ($guild = $this->discord->guilds->get('id', $data->guild_id)) {
             if ($oldRole = $guild->roles->get('id', $data->role->id)) {
@@ -39,10 +39,12 @@ class GuildRoleUpdate extends Event
             }
         }
 
-        if (! $oldRole) {
+        if (! $rolePart) {
             /** @var Role */
             $rolePart = $this->factory->create(Role::class, $adata, true);
-            $guild->roles->pushItem($rolePart);
+            if ($guild = $rolePart->guild) {
+                $guild->roles->pushItem($rolePart);
+            }
         }
 
         $deferred->resolve([$rolePart, $oldRole]);

--- a/src/Discord/WebSockets/Events/GuildScheduledEventUpdate.php
+++ b/src/Discord/WebSockets/Events/GuildScheduledEventUpdate.php
@@ -25,7 +25,7 @@ class GuildScheduledEventUpdate extends Event
      */
     public function handle(Deferred &$deferred, $data): void
     {
-        $oldScheduledEvent = null;
+        $scheduledEventPart = $oldScheduledEvent = null;
 
         if ($guild = $this->discord->guilds->get('id', $data->guild_id)) {
             if ($oldScheduledEvent = $guild->guild_scheduled_events->get('id', $data->id)) {
@@ -37,7 +37,7 @@ class GuildScheduledEventUpdate extends Event
             }
         }
 
-        if (! $oldScheduledEvent) {
+        if (! $scheduledEventPart) {
             /** @var ScheduledEvent */
             $scheduledEventPart = $this->factory->create(ScheduledEvent::class, $data, true);
             if ($guild = $scheduledEventPart->guild) {

--- a/src/Discord/WebSockets/Events/IntegrationUpdate.php
+++ b/src/Discord/WebSockets/Events/IntegrationUpdate.php
@@ -25,7 +25,7 @@ class IntegrationUpdate extends Event
      */
     public function handle(Deferred &$deferred, $data): void
     {
-        $oldIntegration = null;
+        $integrationPart = $oldIntegration = null;
 
         if ($guild = $this->discord->guilds->get('id', $data->guild_id)) {
             if ($oldIntegration = $guild->integrations->get('id', $data->id)) {
@@ -37,7 +37,7 @@ class IntegrationUpdate extends Event
             }
         }
 
-        if (! $oldIntegration) {
+        if (! $integrationPart) {
             /** @var Integration */
             $integrationPart = $this->factory->create(Integration::class, $data, true);
             if ($guild = $integrationPart->guild) {

--- a/src/Discord/WebSockets/Events/StageInstanceUpdate.php
+++ b/src/Discord/WebSockets/Events/StageInstanceUpdate.php
@@ -25,7 +25,7 @@ class StageInstanceUpdate extends Event
      */
     public function handle(Deferred &$deferred, $data): void
     {
-        $oldStageInstance = null;
+        $stageInstancePart = $oldStageInstance = null;
 
         if ($guild = $this->discord->guilds->get('id', $data->guild_id)) {
             if ($oldStageInstance = $guild->stage_instances->get('id', $data->id)) {
@@ -37,7 +37,7 @@ class StageInstanceUpdate extends Event
             }
         }
 
-        if (! $oldStageInstance) {
+        if (! $stageInstancePart) {
             /** @var StageInstance */
             $stageInstancePart = $this->factory->create(StageInstance::class, $data, true);
             if ($guild = $stageInstancePart->guild) {

--- a/src/Discord/WebSockets/Events/ThreadUpdate.php
+++ b/src/Discord/WebSockets/Events/ThreadUpdate.php
@@ -22,7 +22,7 @@ class ThreadUpdate extends Event
 {
     public function handle(Deferred &$deferred, $data)
     {
-        $oldThread = null;
+        $threadPart = $oldThread = null;
 
         if ($guild = $this->discord->guilds->get('id', $data->guild_id)) {
             if ($parent = $guild->channels->get('id', $data->parent_id)) {
@@ -36,7 +36,7 @@ class ThreadUpdate extends Event
             }
         }
 
-        if (! $oldThread) {
+        if (! $threadPart) {
             /** @var Thread */
             $threadPart = $this->factory->create(Thread::class, $data, true);
             if ($parent = $threadPart->parent) {


### PR DESCRIPTION
This PR adds:

- `Member::setRoles()` so you can replace whole roles of a member with a new one, instead of multiple call to `Member::addRole()` and `Member::removeRole()`
   - It is actually already possible with `$member->roles = [...roles]` and `save()` but this will change in next version.
- Add audit log `$reason` argument to `Member::timeoutMember()`
- Unknown event bug fixes #733

Tested