### PR TITLE
Fixed null-pointer exception case.

### DIFF
--- a/src/Discord/Parts/Interactions/Command/Option.php
+++ b/src/Discord/Parts/Interactions/Command/Option.php
@@ -65,12 +65,12 @@ class Option extends Part
     /**
      * Gets the choices attribute.
      *
-     * @return Collection|Choice[]|null A collection of choices.
+     * @return Collection|Choice[] A collection of choices.
      */
-    protected function getChoicesAttribute(): ?Collection
+    protected function getChoicesAttribute(): iterable
     {
         if (! isset($this->attributes['choices'])) {
-            return null;
+            return [];
         }
 
         $choices = Collection::for(Choice::class, null);


### PR DESCRIPTION
Fixed null-pointer exception case. Otherwise, a method like `addChoice()` in the same file which checks against `count($this-choices)` will get `null` value as an input and cause exception.

![image](https://user-images.githubusercontent.com/653569/155579341-d7d725da-f54b-4d94-9f19-35c2f41b9889.png)

![image](https://user-images.githubusercontent.com/653569/155579467-84b80b19-2f1b-44f2-8694-b32873ab394f.png)
