### PR TITLE
Allow Interaction::sendFollowUpMessage() on InteractionType::MESSAGE_COMPONENT

### DIFF
--- a/src/Discord/Discord.php
+++ b/src/Discord/Discord.php
@@ -86,7 +86,7 @@ class Discord
      *
      * @var string Version.
      */
-    public const VERSION = 'v7.0.2';
+    public const VERSION = 'v7.0.4';
 
     /**
      * The logger.

--- a/src/Discord/Parts/Interactions/Interaction.php
+++ b/src/Discord/Parts/Interactions/Interaction.php
@@ -335,7 +335,7 @@ class Interaction extends Part
      */
     public function sendFollowUpMessage(MessageBuilder $builder, bool $ephemeral = false): ExtendedPromiseInterface
     {
-        if (! $this->responded) {
+        if (! $this->responded && $this->type != InteractionType::MESSAGE_COMPONENT) {
             return reject(new \RuntimeException('Cannot create a follow-up message as the interaction has not been responded to.'));
         }
 


### PR DESCRIPTION
Tested and works on buttons, does not work on commands.

Also bumped version to v7.0.4.