### PR TITLE
VoiceClient updates

### DIFF
--- a/src/Discord/Helpers/Buffer.php
+++ b/src/Discord/Helpers/Buffer.php
@@ -213,6 +213,7 @@ class Buffer extends EventEmitter implements WritableStreamInterface
 
         $this->buffer = [];
         $this->closed = true;
+        $this->readPointer = 0;
         $this->emit('close');
     }
 }

--- a/src/Discord/Voice/VoiceClient.php
+++ b/src/Discord/Voice/VoiceClient.php
@@ -1529,7 +1529,7 @@ class VoiceClient extends EventEmitter
     private function insertSilence(): void
     {
         // https://discord.com/developers/docs/topics/voice-connections#voice-data-interpolation
-        while ($silenceRemaining--) {
+        while ($this->silenceRemaining--) {
              $this->sendBuffer(self::SILENCE_FRAME);
         }
     }

--- a/src/Discord/Voice/VoiceClient.php
+++ b/src/Discord/Voice/VoiceClient.php
@@ -1525,7 +1525,6 @@ class VoiceClient extends EventEmitter
 
     /**
      * Insert 5 frames of silence.
-     *
      */
     private function insertSilence(): void
     {

--- a/src/Discord/Voice/VoiceClient.php
+++ b/src/Discord/Voice/VoiceClient.php
@@ -1119,27 +1119,18 @@ class VoiceClient extends EventEmitter
 
     /**
      * Stops the current sound.
-     *
-     * @return ExtendedPromiseInterface
-     * @throws \Exception
      */
-    public function stop(): ExtendedPromiseInterface
+    public function stop(): void
     {
-        $deferred = new Deferred();
-
         if (! $this->speaking) {
-            $deferred->reject(new \Exception('Audio must be playing to stop it.'));
+            throw new \Exception('Audio must be playing to stop it.'));
 
-            return $deferred->promise();
+            return;
         }
 
         $this->buffer->end();
         $this->insertSilence();
         $this->reset();
-
-        $deferred->resolve();
-
-        return $deferred->promise();
     }
 
     /**

--- a/src/Discord/Voice/VoiceClient.php
+++ b/src/Discord/Voice/VoiceClient.php
@@ -1123,7 +1123,7 @@ class VoiceClient extends EventEmitter
     public function stop(): void
     {
         if (! $this->speaking) {
-            throw new \Exception('Audio must be playing to stop it.'));
+            throw new \Exception('Audio must be playing to stop it.');
 
             return;
         }

--- a/src/Discord/Voice/VoiceClient.php
+++ b/src/Discord/Voice/VoiceClient.php
@@ -1124,8 +1124,6 @@ class VoiceClient extends EventEmitter
     {
         if (! $this->speaking) {
             throw new \Exception('Audio must be playing to stop it.');
-
-            return;
         }
 
         $this->buffer->end();

--- a/src/Discord/Voice/VoiceClient.php
+++ b/src/Discord/Voice/VoiceClient.php
@@ -831,8 +831,6 @@ class VoiceClient extends EventEmitter
                 return;
             }
 
-            $this->interpolation = 5;
-
             // Read opus length
             $buffer->readInt16(1000)->then(function ($opusLength) use ($buffer) {
                 // Read opus data
@@ -1112,6 +1110,7 @@ class VoiceClient extends EventEmitter
         }
 
         $this->isPaused = true;
+        $this->interpolation = 5;
     }
 
     /**
@@ -1141,6 +1140,7 @@ class VoiceClient extends EventEmitter
         }
 
         $this->stopAudio = true;
+        $this->interpolation = 5;
     }
 
     /**


### PR DESCRIPTION
- set readPointer to 0 when closing buffer
- stop writing to the buffer if audio is going to be stopped anyways
- removed $count in playDCAStream as it served no purpose
- when stopping audio, also end/close the buffer
  also send 5 frames of silence as per https://discord.com/developers/docs/topics/voice-connections#voice-data-interpolation
- remove obsolete $this->setSpeaking(false); since $this->reset(); already does that