### PR TITLE
fix null guild_id after sendMessage

### DIFF
--- a/src/Discord/Discord.php
+++ b/src/Discord/Discord.php
@@ -86,7 +86,7 @@ class Discord
      *
      * @var string Version.
      */
-    public const VERSION = 'v7.0.6';
+    public const VERSION = 'v7.0.7';
 
     /**
      * The logger.

--- a/src/Discord/Parts/Channel/Channel.php
+++ b/src/Discord/Parts/Channel/Channel.php
@@ -868,6 +868,8 @@ class Channel extends Part
             return reject(new \RuntimeException('You can only send messages to text channels.'));
         }
 
+        $guild_id = $this->guild_id;
+
         if (! $this->is_private) {
             $botperms = $this->getBotPermissions();
 
@@ -892,7 +894,12 @@ class Channel extends Part
             }
 
             return $this->http->post(Endpoint::bind(Endpoint::CHANNEL_MESSAGES, $this->id), $message);
-        })()->then(function ($response) {
+        })()->then(function ($response) use ($guild_id) {
+            // Workaround for sendMessage() no guild_id
+            if ($guild_id && ! isset($response->guild_id)) {
+                $response->guild_id = $guild_id;
+            }
+
             return $this->factory->create(Message::class, $response, true);
         });
     }

--- a/src/Discord/Parts/Channel/Channel.php
+++ b/src/Discord/Parts/Channel/Channel.php
@@ -868,8 +868,6 @@ class Channel extends Part
             return reject(new \RuntimeException('You can only send messages to text channels.'));
         }
 
-        $guild_id = $this->guild_id;
-
         if (! $this->is_private) {
             $botperms = $this->getBotPermissions();
 
@@ -894,10 +892,10 @@ class Channel extends Part
             }
 
             return $this->http->post(Endpoint::bind(Endpoint::CHANNEL_MESSAGES, $this->id), $message);
-        })()->then(function ($response) use ($guild_id) {
+        })()->then(function ($response) {
             // Workaround for sendMessage() no guild_id
-            if ($guild_id && ! isset($response->guild_id)) {
-                $response->guild_id = $guild_id;
+            if ($this->guild_id && ! isset($response->guild_id)) {
+                $response->guild_id = $this->guild_id;
             }
 
             return $this->factory->create(Message::class, $response, true);

--- a/src/Discord/Parts/Channel/Message.php
+++ b/src/Discord/Parts/Channel/Message.php
@@ -363,10 +363,18 @@ class Message extends Part
             return $guild;
         }
 
-        // Workaround for Channel::sendMessage() no guild_id
-        return $this->discord->guilds->find(function (Guild $guild) {
-            return $guild->channels->has($this->channel_id);
-        });
+        if ($guild = $this->channel->guild) {
+            return $guild;
+        }
+
+        if ($this->channel_id) {
+            // Workaround for Channel::sendMessage() no guild_id
+            return $this->discord->guilds->find(function (Guild $guild) {
+                return $guild->channels->has($this->channel_id);
+            });
+        }
+
+        return null;
     }
 
     /**

--- a/src/Discord/Parts/Channel/Message.php
+++ b/src/Discord/Parts/Channel/Message.php
@@ -359,7 +359,14 @@ class Message extends Part
      */
     protected function getGuildAttribute(): ?Guild
     {
-        return $this->discord->guilds->get('id', $this->guild_id);
+        if ($guild = $this->discord->guilds->get('id', $this->guild_id)) {
+            return $guild;
+        }
+
+        // Workaround for Channel::sendMessage() no guild_id
+        return $this->discord->guilds->find(function (Guild $guild) {
+            return $guild->channels->has($this->channel_id);
+        });
     }
 
     /**


### PR DESCRIPTION
This fixes null `sendMessage->done(function ($message) { $message->guild_id; });`
Basically, the CREATE MESSAGE endpoint returns no guild information in response, only the channel id.
It was preventing function like `$message->startThread()` to work, the workaround is:
1. Get the guild from the channel where the message is send
2. Get the guild from cache where it has matching channel id (opposite of getChannel, slower loop)

Credits to discord user Rhododendron#8252 for finding the bug.

Already tested and can be merged away