### PR TITLE
Ban pagination

### DIFF
--- a/src/Discord/Discord.php
+++ b/src/Discord/Discord.php
@@ -86,7 +86,6 @@ class Discord
      *
      * @var string Version.
      */
-
     public const VERSION = 'v7.1.0';
 
     /**

--- a/src/Discord/Discord.php
+++ b/src/Discord/Discord.php
@@ -86,7 +86,7 @@ class Discord
      *
      * @var string Version.
      */
-    public const VERSION = 'v7.0.8';
+    public const VERSION = 'v7.0.9';
 
     /**
      * The logger.

--- a/src/Discord/Parts/Guild/Ban.php
+++ b/src/Discord/Parts/Guild/Ban.php
@@ -19,18 +19,25 @@ use Discord\Parts\User\User;
  *
  * @see https://discord.com/developers/docs/resources/guild#ban-object
  *
- * @property string     $reason   The reason for the ban.
- * @property User       $user     The banned user.
- * @property string     $user_id
- * @property string     $guild_id
- * @property Guild|null $guild
+ * @property string      $reason   The reason for the ban.
+ * @property User        $user     The banned user.
+ * @property string      $user_id
+ * @property string|null $guild_id
+ * @property Guild|null  $guild
  */
 class Ban extends Part
 {
     /**
      * @inheritdoc
      */
-    protected $fillable = ['reason', 'user', 'user_id', 'guild_id'];
+    protected $fillable = [
+        'reason',
+        'user',
+
+        // internally used
+        'user_id',
+        'guild_id'
+    ];
 
     /**
      * Returns the user id of the ban.
@@ -70,7 +77,7 @@ class Ban extends Part
         if (isset($this->attributes['user_id'])) {
             return $this->discord->users->get('id', $this->attributes['user_id']);
         }
-        
+
         if ($user = $this->discord->users->get('id', $this->attributes['user']->id)) {
             return $user;
         }

--- a/src/Discord/WebSockets/Events/GuildCreate.php
+++ b/src/Discord/WebSockets/Events/GuildCreate.php
@@ -132,11 +132,11 @@ class GuildCreate extends Event
 
                     foreach ($rawBans as $ban) {
                         $ban = (array) $ban;
-                        $ban['guild'] = $guildPart;
+                        $ban['guild_id'] = $guildPart->id;
 
                         $banPart = $this->factory->create(Ban::class, $ban, true);
 
-                        $guildPart->bans->offsetSet($banPart->id, $banPart);
+                        $guildPart->bans->offsetSet($banPart->user->id, $banPart);
                     }
 
                     $banPagination($guildPart->bans->last()->user->id);


### PR DESCRIPTION
Fix for 'retrieveBans' after https://github.com/discord/discord-api-docs/commit/808d94b82c04d734b622d23688a3cdbe2e0903ea

why on ready it's only returning one ban in the repository?

```php
$discord->on('ready', function (Discord $discord) {
    echo 'Bot is ready!', PHP_EOL;

    foreach ($discord->guilds as $guild) {
        var_dump($guild->bans);
    }
});
```

Edit: FIXED