### PR TITLE
Fix empty user part on Audit Logs

### DIFF
--- a/src/Discord/Parts/Guild/AuditLog/AuditLog.php
+++ b/src/Discord/Parts/Guild/AuditLog/AuditLog.php
@@ -101,8 +101,8 @@ class AuditLog extends Part
         $collection = Collection::for(User::class);
 
         foreach ($this->attributes['users'] ?? [] as $user) {
-            if ($user = $this->discord->users->get('id', $user->id)) {
-                $collection->push($user);
+            if ($cache_user = $this->discord->users->get('id', $user->id)) {
+                $collection->push($cache_user);
             } else {
                 $collection->push($this->factory->create(User::class, $user, true));
             }


### PR DESCRIPTION
This fix the creation of empty parts when user is not cached.