### PR TITLE
Make Thread createable, add invitable, deprecate archiver_id, and fix metadata

### DIFF
--- a/src/Discord/Parts/Thread/Thread.php
+++ b/src/Discord/Parts/Thread/Thread.php
@@ -35,6 +35,7 @@ use Traversable;
  * Represents a Discord thread.
  *
  * @property string            $id                    The ID of the thread.
+ * @property string            $type                  The type of thread.
  * @property string            $guild_id              The ID of the guild which the thread belongs to.
  * @property string            $name                  The name of the thread.
  * @property string            $last_message_id       The ID of the last message sent in the thread.
@@ -50,10 +51,8 @@ use Traversable;
  * @property Channel|null      $parent                The channel which the thread was created in.
  * @property bool              $archived              Whether the thread has been archived.
  * @property bool              $locked                Whether the thread has been locked.
- * @property int               $auto_archive_duration The number of minutes of inactivity until the thread is automatically archived.
- * @property string|null       $archiver_id           The ID of the user that archived the thread, if any.
- * @property User|null         $archiver              The user that archived the thread, if any.
- * @property Member|null       $archiver_member       The corresponding member object for the user that archived the thread, if any.
+ * @property int|null          $auto_archive_duration The number of minutes of inactivity until the thread is automatically archived.
+ * @property int|null          $flags                 Channel flags combined as a bitfield.
  * @property Carbon            $archive_timestamp     The time that the thread's archive status was changed.
  * @property MessageRepository $messages              Repository of messages sent in the thread.
  * @property MemberRepository  $members               Repository of members in the thread.
@@ -68,6 +67,7 @@ class Thread extends Part
      */
     protected $fillable = [
         'id',
+        'type',
         'guild_id',
         'name',
         'last_message_id',
@@ -78,6 +78,7 @@ class Thread extends Part
         'message_count',
         'member_count',
         'thread_metadata',
+        'flags',
     ];
 
     /**
@@ -89,12 +90,10 @@ class Thread extends Part
         'owner_member',
         'parent',
         'archived',
-        'locked',
         'auto_archive_duration',
-        'archiver_id',
-        'archiver',
-        'archiver_member',
         'archive_timestamp',
+        'locked',
+        'invitable',
     ];
 
     /**
@@ -174,7 +173,7 @@ class Thread extends Part
      */
     protected function getArchivedAttribute(): bool
     {
-        return $this->thread_metadata->archived;
+        return $this->thread_metadata->archived ?? false;
     }
 
     /**
@@ -188,18 +187,30 @@ class Thread extends Part
     }
 
     /**
+     * Returns whether the thread is archived.
+     *
+     * @return bool|null
+     */
+    protected function getInvitableAttribute(): ?bool
+    {
+        return $this->thread_metadata->invitable;
+    }
+
+    /**
      * Returns the number of minutes of inactivity required for the thread
      * to auto archive.
      *
-     * @return int
+     * @return int|null
      */
-    protected function getAutoArchiveDurationAttribute(): int
+    protected function getAutoArchiveDurationAttribute(): ?int
     {
         return $this->thread_metadata->auto_archive_duration;
     }
 
     /**
      * Returns the ID of the user who archived the thread.
+     *
+     * @deprecated 7.1.0 Removed from API
      *
      * @return string|null
      */
@@ -215,7 +226,7 @@ class Thread extends Part
      */
     protected function setArchivedAttribute(bool $value)
     {
-        $this->thread_metadata->archived = $value;
+        $this->attributes['thread_metadata']->archived = $value;
     }
 
     /**
@@ -225,7 +236,7 @@ class Thread extends Part
      */
     protected function setLockedAttribute(bool $value)
     {
-        $this->thread_metadata->locked = $value;
+        $this->attributes['thread_metadata']->locked = $value;
     }
 
     /**
@@ -235,11 +246,13 @@ class Thread extends Part
      */
     protected function setAutoArchiveDurationAttribute(int $value)
     {
-        $this->thread_metadata->auto_archive_duration = $value;
+        $this->attributes['thread_metadata']->auto_archive_duration = $value;
     }
 
     /**
      * Returns the user who archived the thread.
+     *
+     * @deprecated 7.1.0 Removed from API
      *
      * @return User|null
      */
@@ -254,6 +267,8 @@ class Thread extends Part
 
     /**
      * Returns the member object for the user who archived the thread.
+     *
+     * @deprecated 7.1.0 Removed from API
      *
      * @return Member|null
      */
@@ -739,15 +754,40 @@ class Thread extends Part
     /**
      * @inheritdoc
      */
+    public function getCreatableAttributes(): array
+    {
+        $attr = [
+            'name' => $this->name,
+            'auto_archive_duration' => $this->auto_archive_duration,
+            'type' => $this->type,
+            'rate_limit_per_user' => $this->rate_limit_per_user,
+        ];
+
+        if ($this->type == Channel::TYPE_PRIVATE_THREAD) {
+            $attr['invitable'] = $this->invitable;
+        }
+
+        return $attr;
+    }
+
+    /**
+     * @inheritdoc
+     */
     public function getUpdatableAttributes(): array
     {
-        return [
+        $attr = [
             'name' => $this->name,
             'rate_limit_per_user' => $this->rate_limit_per_user,
             'archived' => $this->archived,
             'auto_archive_duration' => $this->auto_archive_duration,
             'locked' => $this->locked,
         ];
+
+        if ($this->type == Channel::TYPE_PRIVATE_THREAD) {
+            $attr['invitable'] = $this->invitable;
+        }
+
+        return $attr;
     }
 
     /**

--- a/src/Discord/Repository/Channel/ThreadRepository.php
+++ b/src/Discord/Repository/Channel/ThreadRepository.php
@@ -37,6 +37,7 @@ class ThreadRepository extends AbstractRepository
         'get' => Endpoint::THREAD,
         'update' => Endpoint::THREAD,
         'delete' => Endpoint::THREAD,
+        'create' => Endpoint::CHANNEL_THREADS
     ];
 
     /**


### PR DESCRIPTION
- Add createable attributes for `Thread` class (i.e. `$channel->threads->save($thread)`, also add `type` and `flags` attributes from Channel as it is included from the [Thread create](https://github.com/discord-payloads/discord-payloads/blob/master/events/guild/thread/thread_create.json) and [Thread update](https://github.com/discord-payloads/discord-payloads/blob/master/events/guild/thread/thread_update.json) gateway events.
- Deprecate the undocumented `archiver_id` as well `archiver` and `archiver_member` attributes - https://github.com/discord/discord-api-docs/pull/3108
- Add the missing `invitable`, attribute (exclusive for private threads) - https://github.com/discord/discord-api-docs/pull/3600
- Fix the `thread_metadata` when not created yet, which was causing null to its children properties. `archived` defaults to false.

Tested.