### PR TITLE
Add a helper function to search array within promise

### DIFF
--- a/src/Discord/functions.php
+++ b/src/Discord/functions.php
@@ -11,12 +11,16 @@
 
 namespace Discord;
 
+use ArrayIterator;
+use Discord\Helpers\Deferred;
 use Discord\Parts\Channel\Channel;
 use Discord\Parts\Channel\Message;
 use Discord\Parts\Guild\Role;
 use Discord\Parts\Part;
 use Discord\Parts\User\Member;
 use Discord\Parts\User\User;
+use React\EventLoop\LoopInterface;
+use React\Promise\ExtendedPromiseInterface;
 use Symfony\Component\OptionsResolver\Options;
 
 /**
@@ -257,4 +261,39 @@ function normalizePartId($id_field = 'id')
 function escapeMarkdown(string $text): string
 {
     return addcslashes($text, '#*:>@_`|~');
+}
+
+/**
+ * Run a deferred search in array
+ *
+ * @param array|object  $array     Traversable, use $collection->getIterator() if searching in Collection
+ * @param callable      $callback  The filter function to run
+ * @param LoopInterface $loop      Loop interface, use $discord->getLoop()
+ * @param callable      $canceller The function to cancel the search
+ *
+ * @return ExtendedPromiseInterface
+ */
+function deferFind($array, callable $callback, $loop, ?callable $canceller = null): ExtendedPromiseInterface
+{
+    $deferred = new Deferred($canceller);
+    $iterator = new ArrayIterator($array);
+
+    $loop->addPeriodicTimer(0.001, function ($timer) use ($loop, $deferred, $iterator, $callback) {
+        if (! $iterator->valid()) {
+            $loop->cancelTimer($timer);
+            $deferred->reject();
+            return;
+        }
+
+        $current = $iterator->current();
+        if ($callback($current)) {
+            $loop->cancelTimer($timer);
+            $deferred->resolve($current);
+            return;
+        }
+
+        $iterator->next();
+    });
+
+    return $deferred->promise();
 }


### PR DESCRIPTION
This will be useful in place of `Collection::find()` which is non-blocking (i.e. array is large), example:
```php
deferFind($discord->users->getIterator(), function (User $user) {
    return $user->name.'#'.$user->discriminator == 'Robo_N1X#1821';
}, $discord->getLoop())->done(function (User $user) {
    // found Me in $user
});
```

Can be tested in `dev-defer-find` branch

Need opinion for the arguments order