### PR TITLE
Add experimental compress=zlib-stream gateway packet processing

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,8 +23,7 @@
         "ext-zlib": "*",
         "discord-php/http": "^9.0.10",
         "react/child-process": "^0.6.2",
-        "discord/interactions": "^2.2",
-        "clue/zlib-react": "^1.0||^0.2.2"
+        "discord/interactions": "^2.2"
     },
     "require-dev": {
         "symfony/var-dumper": "*",
@@ -45,7 +44,8 @@
         "ext-libev": "For a faster, and more performant loop.",
         "ext-event": "For a faster, and more performant loop.",
         "ext-mbstring": "For accurate calculations of string length when handling non-english characters.",
-        "ext-gmp": "For Permissions and 64 bit calculations on x86 (32 bit) PHP."
+        "ext-gmp": "For Permissions and 64 bit calculations on x86 (32 bit) PHP.",
+        "clue/zlib-react": "For gateway message transport compression with zlib-stream."
     },
     "scripts": {
         "cs": ["./vendor/bin/php-cs-fixer fix"],

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,8 @@
         "ext-zlib": "*",
         "discord-php/http": "^9.0.10",
         "react/child-process": "^0.6.2",
-        "discord/interactions": "^2.2"
+        "discord/interactions": "^2.2",
+        "clue/zlib-react": "^1.0||^0.2.2"
     },
     "require-dev": {
         "symfony/var-dumper": "*",

--- a/src/Discord/Discord.php
+++ b/src/Discord/Discord.php
@@ -1378,7 +1378,7 @@ class Discord
             ->setAllowedTypes('intents', ['array', 'int'])
             ->setAllowedTypes('socket_options', 'array')
             ->setAllowedTypes('dnsConfig', ['string', \React\Dns\Config\Config::class])
-            ->setAllowedTypes('compress', 'string');
+            ->setAllowedTypes('compress', ['null', 'string']);
 
         $options = $resolver->resolve($options);
 


### PR DESCRIPTION
As suggested on #810 

Reference: https://discord.com/developers/docs/topics/gateway#payload-compression

Adds extra package https://github.com/clue/reactphp-zlib I honestly don't know how to do it another way, none of the [`zlib_decode()`/`gzuncompress()`/`gzinflate()`](https://www.php.net/manual/en/ref.zlib.php) works without this additional lib
The extra library will be changed to optional and only enabled when 'stream' options is set.
 
Experimental opt-in `dev-zlib-stream`