### PR TITLE
Little more API updates since previous PR #805

### DIFF
--- a/src/Discord/Builders/CommandAttributes.php
+++ b/src/Discord/Builders/CommandAttributes.php
@@ -29,7 +29,7 @@ use function Discord\poly_strlen;
  * @property string[]|null            $description_localizations  Localization dictionary for the description field. Values follow the same restrictions as description.
  * @property Collection|Option[]|null $options                    The parameters for the command, max 25. Only for Slash command (CHAT_INPUT).
  * @property string                   $default_member_permissions Set of permissions represented as a bit set.
- * @property bool                     $dm_permission              Indicates whether the command is available in DMs with the app, only for globally-scoped commands. By default, commands are visible.
+ * @property bool|null                $dm_permission              Indicates whether the command is available in DMs with the app, only for globally-scoped commands. By default, commands are visible.
  * @property bool                     $default_permission         Whether the command is enabled by default when the app is added to a guild. SOON DEPRECATED.
  */
 trait CommandAttributes {

--- a/src/Discord/Parts/Channel/Channel.php
+++ b/src/Discord/Parts/Channel/Channel.php
@@ -1082,6 +1082,8 @@ class Channel extends Part
             'position' => $this->position,
             'parent_id' => $this->parent_id,
             'nsfw' => $this->nsfw,
+            'rtc_region' => $this->rtc_region,
+            'video_quality_mode' => $this->video_quality_mode,
             'default_auto_archive_duration' => $this->default_auto_archive_duration,
         ];
     }

--- a/src/Discord/Parts/Interactions/Command/Command.php
+++ b/src/Discord/Parts/Interactions/Command/Command.php
@@ -161,7 +161,7 @@ class Command extends Part
      */
     public function getUpdatableAttributes(): array
     {
-        $attr = [
+        return [
             'guild_id' => $this->guild_id ?? null,
             'name' => $this->name,
             'name_localizations' => $this->name_localizations,
@@ -169,16 +169,10 @@ class Command extends Part
             'description_localizations' => $this->description_localizations,
             'options' => $this->attributes['options'] ?? null,
             'default_member_permissions' => $this->default_member_permissions,
+            'dm_permission' => $this->dm_permission,
             'default_permission' => $this->default_permission,
             'type' => $this->type,
         ];
-
-        // Guild command might omit this fillable
-        if (array_key_exists('dm_permission', $this->attributes)) {
-            $attr['dm_permission'] = $this->dm_permission;
-        }
-
-        return $attr;
     }
 
     /**

--- a/src/Discord/Parts/Interactions/Command/Command.php
+++ b/src/Discord/Parts/Interactions/Command/Command.php
@@ -23,12 +23,12 @@ use React\Promise\ExtendedPromiseInterface;
  *
  * @see https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-structure
  *
- * @property string                   $id             The unique identifier of the command.
- * @property string                   $application_id The unique identifier of the parent Application that made the command, if made by one.
- * @property string|null              $guild_id       The unique identifier of the guild that the command belongs to. Null if global.
- * @property Guild|null               $guild          The guild that the command belongs to. Null if global.
- * @property string                   $version        Autoincrementing version identifier updated during substantial record changes.
- * @property OverwriteRepository      $overwrites     Permission overwrites.
+ * @property string              $id             The unique identifier of the command.
+ * @property string              $application_id The unique identifier of the parent Application that made the command, if made by one.
+ * @property string|null         $guild_id       The unique identifier of the guild that the command belongs to. Null if global.
+ * @property Guild|null          $guild          The guild that the command belongs to. Null if global.
+ * @property string              $version        Autoincrementing version identifier updated during substantial record changes.
+ * @property OverwriteRepository $overwrites     Permission overwrites.
  */
 class Command extends Part
 {

--- a/src/Discord/Parts/Interactions/Command/Overwrite.php
+++ b/src/Discord/Parts/Interactions/Command/Overwrite.php
@@ -19,7 +19,7 @@ use Discord\Parts\Part;
  *
  * @see https://discord.com/developers/docs/interactions/application-commands#application-command-permissions-object-guild-application-command-permissions-structure
  *
- * @property string                  $id             The id of the command
+ * @property string                  $id             The id of the command or the application ID if no overwrites
  * @property string                  $application_id The id of the application the command belongs to
  * @property string                  $guild_id       The id of the guild
  * @property Collection|Permission[] $permissions    The permissions for the command in the guild

--- a/src/Discord/Parts/Interactions/Interaction.php
+++ b/src/Discord/Parts/Interactions/Interaction.php
@@ -38,21 +38,21 @@ use function React\Promise\reject;
  *
  * @see https://discord.com/developers/docs/interactions/receiving-and-responding#interactions
  *
- * @property string               $id             ID of the interaction.
- * @property string               $application_id ID of the application the interaction is for.
- * @property int                  $type           Type of interaction.
- * @property InteractionData|null $data           Data associated with the interaction.
- * @property string|null          $guild_id       ID of the guild the interaction was sent from.
- * @property Guild|null           $guild          Guild the interaction was sent from.
- * @property string|null          $channel_id     ID of the channel the interaction was sent from.
- * @property Channel|null         $channel        Channel the interaction was sent from.
- * @property Member|null          $member         Member who invoked the interaction.
- * @property User|null            $user           User who invoked the interaction.
- * @property string               $token          Continuation token for responding to the interaction.
- * @property int                  $version        Version of interaction.
- * @property Message|null         $message        Message that triggered the interactions, when triggered from message components.
- * @property string|null          $locale         The selected language of the invoking user.
- * @property string|null          $guild_locale   The guild's preferred locale, if invoked in a guild.
+ * @property      string               $id             ID of the interaction.
+ * @property      string               $application_id ID of the application the interaction is for.
+ * @property      int                  $type           Type of interaction.
+ * @property      InteractionData|null $data           Data associated with the interaction.
+ * @property      string|null          $guild_id       ID of the guild the interaction was sent from.
+ * @property      Guild|null           $guild          Guild the interaction was sent from.
+ * @property      string|null          $channel_id     ID of the channel the interaction was sent from.
+ * @property      Channel|null         $channel        Channel the interaction was sent from.
+ * @property      Member|null          $member         Member who invoked the interaction.
+ * @property      User|null            $user           User who invoked the interaction.
+ * @property      string               $token          Continuation token for responding to the interaction.
+ * @property-read int                  $version        Version of interaction.
+ * @property      Message|null         $message        Message that triggered the interactions, when triggered from message components.
+ * @property      string|null          $locale         The selected language of the invoking user.
+ * @property      string|null          $guild_locale   The guild's preferred locale, if invoked in a guild.
  */
 class Interaction extends Part
 {

--- a/src/Discord/Parts/Thread/Thread.php
+++ b/src/Discord/Parts/Thread/Thread.php
@@ -52,7 +52,7 @@ use Traversable;
  * @property bool              $archived              Whether the thread has been archived.
  * @property bool              $locked                Whether the thread has been locked.
  * @property int|null          $auto_archive_duration The number of minutes of inactivity until the thread is automatically archived.
- * @property int|null          $flags                 Channel flags combined as a bitfield.
+ * @property int|null          $flags                 Channel flags combined as a bitfield. `PINNED` can only be set for threads in forum channels.
  * @property Carbon            $archive_timestamp     The time that the thread's archive status was changed.
  * @property MessageRepository $messages              Repository of messages sent in the thread.
  * @property MemberRepository  $members               Repository of members in the thread.
@@ -781,6 +781,7 @@ class Thread extends Part
             'archived' => $this->archived,
             'auto_archive_duration' => $this->auto_archive_duration,
             'locked' => $this->locked,
+            'flags' => $this->flags,
         ];
 
         if ($this->type == Channel::TYPE_PRIVATE_THREAD) {


### PR DESCRIPTION
Covers https://github.com/discord/discord-api-docs/compare/170e57e46b0b8b602df29065201d7eceee19d1d6...3f26cb6aec853667e797c810b9fdf5e8abd4c74b (tracking link in every commits)

Partially reverts the https://github.com/discord-php/DiscordPHP/pull/805/commits/89a8ec5c029aa9a9791dee771edf7e1250d801b6 since the key will be always filled automatically by Part after created (i.e. it's always exists in updateable)

And little change to Thread flags can be updated, rtc_region and video_quality_mode createable for Channel, and little more notes for command overwrites in phpdoc.

Tested except the thread (we have no forum 😭)