### PR TITLE
Gateway Ready no longer sends private channels

### DIFF
--- a/src/Discord/Discord.php
+++ b/src/Discord/Discord.php
@@ -419,18 +419,6 @@ class Discord
 
         $this->logger->debug('client created and session id stored', ['session_id' => $content->session_id, 'user' => $this->client->user->getPublicAttributes()]);
 
-        // Private Channels
-        if ($this->options['pmChannels']) {
-            foreach ($content->private_channels as $channel) {
-                $channelPart = $this->factory->create(Channel::class, $channel, true);
-                $this->private_channels->push($channelPart);
-            }
-
-            $this->logger->info('stored private channels', ['count' => $this->private_channels->count()]);
-        } else {
-            $this->logger->info('did not parse private channels');
-        }
-
         // Guilds
         $event = new GuildCreate(
             $this->http,


### PR DESCRIPTION
As per <https://discord.com/developers/docs/topics/gateway#ready>, the ready event no longer transmits private channels in it's data, thus making this code obsolete. The option pmChannels however is kept in order for the user to decide wether to store newly created private channels or not.