### PR TITLE
DiscordCommandClient.php: don't add trailing space to usage

### DIFF
--- a/src/Discord/DiscordCommandClient.php
+++ b/src/Discord/DiscordCommandClient.php
@@ -386,10 +386,6 @@ class DiscordCommandClient extends Discord
 
         $options = $resolver->resolve($options);
 
-        if (! empty($options['usage'])) {
-            $options['usage'] .= ' ';
-        }
-
         return $options;
     }
 


### PR DESCRIPTION
The trailing space added to the `usage` property of a command does not
serve any purpose. It is a holdover from when `usage` was being used
to construct a full command-line string:

```php
$helpString = "{$prefix}{$this->command} {$this->usage}- {$this->description}\r\n";
```

This was removed in b3e0e900ce in favor of printing `usage` as-is, and
so the added space no longer makes any sense.

You can see the extra space here:
![image](https://user-images.githubusercontent.com/846186/170887426-64adc258-246e-4f2d-885f-74adc2ad5eff.png)
