### PR TITLE
Add Guild::updateMFALevel()

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "react/http": "^1.1",
         "ext-json": "*",
         "ext-zlib": "*",
-        "discord-php/http": "^9.0.10",
+        "discord-php/http": "^9.0.11",
         "react/child-process": "^0.6.2",
         "discord/interactions": "^2.2"
     },

--- a/src/Discord/Parts/Channel/Reaction.php
+++ b/src/Discord/Parts/Channel/Reaction.php
@@ -35,7 +35,7 @@ use function React\Promise\resolve;
  * @property string         $message_id The message ID the reaction is for.
  * @property Message|null   $message    The message the reaction is for.
  * @property string         $channel_id The channel ID that the message belongs in.
- * @property Channel|Thread $channel    The channel that the message belongs tol
+ * @property Channel|Thread $channel    The channel that the message belongs to.
  * @property string|null    $guild_id   The guild ID of the guild that owns the channel the message belongs in.
  * @property Guild|null     $guild      The guild that owns the channel the message belongs in.
  */

--- a/src/Discord/Parts/Guild/Guild.php
+++ b/src/Discord/Parts/Guild/Guild.php
@@ -1167,7 +1167,7 @@ class Guild extends Part
      *
      * @param int $level The new MFA level `Guild::MFA_NONE` or `Guild::MFA_ELEVATED`.
      *
-     * @return ExtendedPromiseInterface
+     * @return ExtendedPromiseInterface<Guild> This guild.
      */
     public function updateMFALevel(int $level): ExtendedPromiseInterface
     {

--- a/src/Discord/Parts/Guild/Guild.php
+++ b/src/Discord/Parts/Guild/Guild.php
@@ -1161,7 +1161,7 @@ class Guild extends Part
     }
 
     /**
-     * Modify the Guild `mfa_level`
+     * Modify the Guild `mfa_level`, requires guild ownership.
      *
      * @see https://discord.com/developers/docs/resources/guild#modify-guild-mfa-level
      *

--- a/src/Discord/Parts/Guild/Guild.php
+++ b/src/Discord/Parts/Guild/Guild.php
@@ -1161,6 +1161,24 @@ class Guild extends Part
     }
 
     /**
+     * Modify the Guild `mfa_level`
+     *
+     * @see https://discord.com/developers/docs/resources/guild#modify-guild-mfa-level
+     *
+     * @param int $level The new MFA level `Guild::MFA_NONE` or `Guild::MFA_ELEVATED`.
+     *
+     * @return ExtendedPromiseInterface
+     */
+    public function updateMFALevel(int $level): ExtendedPromiseInterface
+    {
+        return $this->http->post(Endpoint::bind(Endpoint::GUILD_MFA, $this->id), ['level' => $level])->then(function ($response) {
+            $this->mfa_level = $response->level;
+
+            return $this;
+        });
+    }
+
+    /**
      * @inheritdoc
      */
     public function getCreatableAttributes(): array

--- a/src/Discord/Parts/Guild/Guild.php
+++ b/src/Discord/Parts/Guild/Guild.php
@@ -1097,6 +1097,7 @@ class Guild extends Part
      * @param array $options An array of options.
      *                       enabled => whether the widget is enabled
      *                       channel_id => the widget channel id
+     * @param string $reason Reason for Audit Log.
      *
      * @return ExtendedPromiseInterface The updated guild widget object.
      */
@@ -1117,7 +1118,7 @@ class Guild extends Part
             $headers['X-Audit-Log-Reason'] = $reason;
         }
 
-        return $this->http->patch(Endpoint::bind(Endpoint::GUILD_WIDGET_SETTINGS, $this->id), $options)->then(function ($response) {
+        return $this->http->patch(Endpoint::bind(Endpoint::GUILD_WIDGET_SETTINGS, $this->id), $options, $headers)->then(function ($response) {
             $this->widget_enabled = $response->enabled;
             $this->widget_channel_id = $response->channel_id;
 
@@ -1165,13 +1166,19 @@ class Guild extends Part
      *
      * @see https://discord.com/developers/docs/resources/guild#modify-guild-mfa-level
      *
-     * @param int $level The new MFA level `Guild::MFA_NONE` or `Guild::MFA_ELEVATED`.
+     * @param int    $level  The new MFA level `Guild::MFA_NONE` or `Guild::MFA_ELEVATED`.
+     * @param string $reason Reason for Audit Log.
      *
      * @return ExtendedPromiseInterface<Guild> This guild.
      */
-    public function updateMFALevel(int $level): ExtendedPromiseInterface
+    public function updateMFALevel(int $level, ?string $reason = null): ExtendedPromiseInterface
     {
-        return $this->http->post(Endpoint::bind(Endpoint::GUILD_MFA, $this->id), ['level' => $level])->then(function ($response) {
+        $headers = [];
+        if (isset($reason)) {
+            $headers['X-Audit-Log-Reason'] = $reason;
+        }
+
+        return $this->http->post(Endpoint::bind(Endpoint::GUILD_MFA, $this->id), ['level' => $level], $headers)->then(function ($response) {
             $this->mfa_level = $response->level;
 
             return $this;


### PR DESCRIPTION
https://github.com/discord/discord-api-docs/pull/5032

```php
$discord->guilds['guild id here']->updateMFALevel(Guild::MFA_NONE)->done(function (Guild $guild) {
    echo $guild->mfa_level; // Should be equal to MFA_NONE
});
````

Also bumps requirement to [DiscordPHP-Http v9.0.11](https://github.com/discord-php/DiscordPHP-Http/releases/tag/v9.0.11)

Tested, can be merged right away.