### PR TITLE
Few fixes in threads

### DIFF
--- a/src/Discord/Parts/Channel/Channel.php
+++ b/src/Discord/Parts/Channel/Channel.php
@@ -770,7 +770,7 @@ class Channel extends Part
      *
      * @param string      $name                  The name of the thread.
      * @param bool        $private               Whether the thread should be private. cannot start a private thread in a news channel channel.
-     * @param int         $auto_archive_duration Number of minutes of inactivity until the thread is auto-archived. one of 60, 1440, 4320, 10080.
+     * @param int|null    $auto_archive_duration Number of minutes of inactivity until the thread is auto-archived. null for never or one of 60, 1440, 4320, 10080.
      * @param string|null $reason                Reason for Audit Log.
      *
      * @throws \RuntimeException
@@ -778,7 +778,7 @@ class Channel extends Part
      *
      * @return ExtendedPromiseInterface<Thread>
      */
-    public function startThread(string $name, bool $private = false, int $auto_archive_duration = 1440, ?string $reason = null): ExtendedPromiseInterface
+    public function startThread(string $name, bool $private = false, ?int $auto_archive_duration = null, ?string $reason = null): ExtendedPromiseInterface
     {
         if ($private && ! $this->guild->feature_private_threads) {
             return reject(new \RuntimeException('Guild does not have access to private threads.'));
@@ -796,8 +796,8 @@ class Channel extends Part
             return reject(new \RuntimeException('You cannot start a thread in this type of channel.'));
         }
 
-        if (! in_array($auto_archive_duration, [60, 1440, 4320, 10080])) {
-            return reject(new \UnexpectedValueException('`auto_archive_duration` must be one of 60, 1440, 4320, 10080.'));
+        if (! in_array($auto_archive_duration, [null, 60, 1440, 4320, 10080])) {
+            return reject(new \UnexpectedValueException('`auto_archive_duration` must be null or one of 60, 1440, 4320, 10080.'));
         }
 
         $headers = [];

--- a/src/Discord/Parts/Channel/Message.php
+++ b/src/Discord/Parts/Channel/Message.php
@@ -605,8 +605,8 @@ class Message extends Part
      */
     public function startThread(string $name, ?int $auto_archive_duration = null, ?string $reason = null): ExtendedPromiseInterface
     {
-        if (! $this->guild) {
-            return reject(new \RuntimeException('You can only start threads on guild text channels.'));
+        if (! in_array($this->channel->type, [Channel::TYPE_TEXT, Channel::TYPE_NEWS])) {
+            return reject(new \RuntimeException('You can only start threads on guild text channels or news channels.'));
         }
 
         if (! in_array($auto_archive_duration, [null, 60, 1440, 4320, 10080])) {

--- a/src/Discord/Parts/Channel/Message.php
+++ b/src/Discord/Parts/Channel/Message.php
@@ -595,7 +595,7 @@ class Message extends Part
      * @see https://discord.com/developers/docs/resources/channel#start-thread-with-message
      *
      * @param string      $name                  The name of the thread.
-     * @param int         $auto_archive_duration Number of minutes of inactivity until the thread is auto-archived. One of 60, 1440, 4320, 10080.
+     * @param int|null    $auto_archive_duration Number of minutes of inactivity until the thread is auto-archived. null for never or one of 60, 1440, 4320, 10080.
      * @param string|null $reason                Reason for Audit Log.
      *
      * @throws \RuntimeException
@@ -603,14 +603,14 @@ class Message extends Part
      *
      * @return ExtendedPromiseInterface<Thread>
      */
-    public function startThread(string $name, int $auto_archive_duration = 1440, ?string $reason = null): ExtendedPromiseInterface
+    public function startThread(string $name, ?int $auto_archive_duration = null, ?string $reason = null): ExtendedPromiseInterface
     {
         if (! $this->guild) {
             return reject(new \RuntimeException('You can only start threads on guild text channels.'));
         }
 
-        if (! in_array($auto_archive_duration, [60, 1440, 4320, 10080])) {
-            return reject(new \UnexpectedValueException('`auto_archive_duration` must be one of 60, 1440, 4320, 10080.'));
+        if (! in_array($auto_archive_duration, [null, 60, 1440, 4320, 10080])) {
+            return reject(new \UnexpectedValueException('`auto_archive_duration` must be null or one of 60, 1440, 4320, 10080.'));
         }
 
         $headers = [];


### PR DESCRIPTION
Allow create threads with null `auto_archive_duration` for nom auto-archiving threads. (https://github.com/discord/discord-api-docs/commit/fb317e48cd868a5813c8e47c4ae09060d7c56bcf)

Improve channel type validation for [threads from message](https://discord.com/developers/docs/resources/channel#start-thread-from-message).