### PR TITLE
make sure to populate private_channels when receiving PMs

### DIFF
--- a/src/Discord/Repository/PrivateChannelRepository.php
+++ b/src/Discord/Repository/PrivateChannelRepository.php
@@ -28,7 +28,9 @@ class PrivateChannelRepository extends AbstractRepository
     /**
      * @inheritdoc
      */
-    protected $endpoints = [];
+    protected $endpoints = [
+        'get' => Endpoint::CHANNEL,
+    ];
 
     /**
      * @inheritdoc

--- a/src/Discord/WebSockets/Events/MessageCreate.php
+++ b/src/Discord/WebSockets/Events/MessageCreate.php
@@ -30,7 +30,7 @@ class MessageCreate extends Event
         $messagePart = $this->factory->create(Message::class, $data, true);
 
         // assume it is a private channel
-        if ($messagePart->channel === null) {
+        if (! isset($data->channel, $messagePart->guild)) {
             /** @var Channel */
             $channel = $this->factory->create(Channel::class, [
                 'id' => $messagePart->channel_id,
@@ -40,14 +40,6 @@ class MessageCreate extends Event
             ], true);
 
             $this->discord->private_channels->pushItem($channel);
-        }
-
-        if ($channel = $messagePart->channel) {
-          if ($channel->type == Channel::TYPE_DM) {
-            if (!$this->discord->private_channels->find(function($x) use ($channel) { $x->id == $channel->id; })) {
-              $this->discord->private_channels->pushItem($channel);
-            }
-          }
         }
 
         if ($this->discord->options['storeMessages']) {

--- a/src/Discord/WebSockets/Events/MessageCreate.php
+++ b/src/Discord/WebSockets/Events/MessageCreate.php
@@ -30,7 +30,7 @@ class MessageCreate extends Event
         $messagePart = $this->factory->create(Message::class, $data, true);
 
         // assume it is a private channel
-        if (! isset($data->channel, $messagePart->guild)) {
+        if (! $messagePart->guild && $messagePart->channel->type == Channel::TYPE_DM) {
             /** @var Channel */
             $channel = $this->factory->create(Channel::class, [
                 'id' => $messagePart->channel_id,

--- a/src/Discord/WebSockets/Events/MessageCreate.php
+++ b/src/Discord/WebSockets/Events/MessageCreate.php
@@ -42,6 +42,14 @@ class MessageCreate extends Event
             $this->discord->private_channels->pushItem($channel);
         }
 
+        if ($channel = $messagePart->channel) {
+          if ($channel->type == Channel::TYPE_DM) {
+            if (!$this->discord->private_channels->find(function($x) use ($channel) { $x->id == $channel->id; })) {
+              $this->discord->private_channels->pushItem($channel);
+            }
+          }
+        }
+
         if ($this->discord->options['storeMessages']) {
             if ($channel = $messagePart->channel) {
                 $channel->messages->pushItem($messagePart);


### PR DESCRIPTION
When receiving a PM, the $discord->private_channels array sometimes does not have the DM channel added. If the channel is later needed (e.g., in an event handler), getChannel will fail because the DM channel was not inserted.

This covers the case of "a channel already exists", whereas "the channel does not exist yet" was already covered by the stanza above.

See #493 which was partially fixed last year.