### PR TITLE
Add `$timer` parameter for `delayedReply()` and `delayedDelete()`

### DIFF
--- a/src/Discord/Parts/Channel/Message.php
+++ b/src/Discord/Parts/Channel/Message.php
@@ -29,6 +29,7 @@ use Discord\Parts\Guild\Sticker;
 use Discord\Parts\Interactions\Request\Component;
 use Discord\Parts\Thread\Thread;
 use Discord\Repository\Channel\ReactionRepository;
+use React\EventLoop\TimerInterface;
 use React\Promise\ExtendedPromiseInterface;
 
 use function React\Promise\reject;
@@ -667,14 +668,15 @@ class Message extends Part
      *
      * @param string|MessageBuilder $message Reply message to send after delay.
      * @param int                   $delay   Delay after text will be sent in milliseconds.
+     * @param ?TimerInterface       &$timer  Delay timer passed by reference.
      *
      * @return ExtendedPromiseInterface<Message>
      */
-    public function delayedReply($message, int $delay): ExtendedPromiseInterface
+    public function delayedReply($message, int $delay, ?TimerInterface &$timer = null): ExtendedPromiseInterface
     {
         $deferred = new Deferred();
 
-        $this->discord->getLoop()->addTimer($delay / 1000, function () use ($message, $deferred) {
+        $timer = $this->discord->getLoop()->addTimer($delay / 1000, function () use ($message, $deferred) {
             $this->reply($message)->done([$deferred, 'resolve'], [$deferred, 'reject']);
         });
 
@@ -686,15 +688,16 @@ class Message extends Part
      *
      * @see Message::deleteMessage()
      *
-     * @param int $delay Time to delay the delete by, in milliseconds.
+     * @param int             $delay  Time to delay the delete by, in milliseconds.
+     * @param ?TimerInterface &$timer Delay timer passed by reference.
      *
      * @return ExtendedPromseInterface
      */
-    public function delayedDelete(int $delay): ExtendedPromiseInterface
+    public function delayedDelete(int $delay, ?TimerInterface &$timer = null): ExtendedPromiseInterface
     {
         $deferred = new Deferred();
 
-        $this->discord->getLoop()->addTimer($delay / 1000, function () use ($deferred) {
+        $timer = $this->discord->getLoop()->addTimer($delay / 1000, function () use ($deferred) {
             $this->delete([$deferred, 'resolve'], [$deferred, 'reject']);
         });
 

--- a/src/Discord/Parts/Channel/Message.php
+++ b/src/Discord/Parts/Channel/Message.php
@@ -668,11 +668,11 @@ class Message extends Part
      *
      * @param string|MessageBuilder $message Reply message to send after delay.
      * @param int                   $delay   Delay after text will be sent in milliseconds.
-     * @param ?TimerInterface       &$timer  Delay timer passed by reference.
+     * @param TimerInterface        &$timer  Delay timer passed by reference.
      *
      * @return ExtendedPromiseInterface<Message>
      */
-    public function delayedReply($message, int $delay, ?TimerInterface &$timer = null): ExtendedPromiseInterface
+    public function delayedReply($message, int $delay, TimerInterface &$timer = null): ExtendedPromiseInterface
     {
         $deferred = new Deferred();
 
@@ -688,12 +688,12 @@ class Message extends Part
      *
      * @see Message::deleteMessage()
      *
-     * @param int             $delay  Time to delay the delete by, in milliseconds.
-     * @param ?TimerInterface &$timer Delay timer passed by reference.
+     * @param int            $delay  Time to delay the delete by, in milliseconds.
+     * @param TimerInterface &$timer Delay timer passed by reference.
      *
      * @return ExtendedPromseInterface
      */
-    public function delayedDelete(int $delay, ?TimerInterface &$timer = null): ExtendedPromiseInterface
+    public function delayedDelete(int $delay, TimerInterface &$timer = null): ExtendedPromiseInterface
     {
         $deferred = new Deferred();
 


### PR DESCRIPTION
Add an optional `$timer` reference argument to allow timer being cancelled

Fixes #803

Example:
```php
$message->delayedReply('hi', 5000, $timer);
```

Cancel the reply before 5 seconds:
```php
$discord->getLoop()->cancelTimer($timer);
```

Tested