### PR TITLE
Remove typecasting on delayedDelete/delayedReply

### DIFF
--- a/src/Discord/Parts/Channel/Message.php
+++ b/src/Discord/Parts/Channel/Message.php
@@ -29,7 +29,6 @@ use Discord\Parts\Guild\Sticker;
 use Discord\Parts\Interactions\Request\Component;
 use Discord\Parts\Thread\Thread;
 use Discord\Repository\Channel\ReactionRepository;
-use React\EventLoop\TimerInterface;
 use React\Promise\ExtendedPromiseInterface;
 
 use function React\Promise\reject;
@@ -672,7 +671,7 @@ class Message extends Part
      *
      * @return ExtendedPromiseInterface<Message>
      */
-    public function delayedReply($message, int $delay, TimerInterface &$timer = null): ExtendedPromiseInterface
+    public function delayedReply($message, int $delay, &$timer = null): ExtendedPromiseInterface
     {
         $deferred = new Deferred();
 
@@ -693,7 +692,7 @@ class Message extends Part
      *
      * @return ExtendedPromseInterface
      */
-    public function delayedDelete(int $delay, TimerInterface &$timer = null): ExtendedPromiseInterface
+    public function delayedDelete(int $delay, &$timer = null): ExtendedPromiseInterface
     {
         $deferred = new Deferred();
 

--- a/src/Discord/Parts/Channel/Message.php
+++ b/src/Discord/Parts/Channel/Message.php
@@ -29,6 +29,7 @@ use Discord\Parts\Guild\Sticker;
 use Discord\Parts\Interactions\Request\Component;
 use Discord\Parts\Thread\Thread;
 use Discord\Repository\Channel\ReactionRepository;
+use React\EventLoop\TimerInterface;
 use React\Promise\ExtendedPromiseInterface;
 
 use function React\Promise\reject;


### PR DESCRIPTION
There is no need to require a variable that is going to be overwritten anyways to be of a certain type since once the code is executed, its value will be of type TimerInterface