### PR TITLE
Add audit log reason for save() and delete(), add queryparams for fresh()

### DIFF
--- a/src/Discord/Parts/Guild/Guild.php
+++ b/src/Discord/Parts/Guild/Guild.php
@@ -556,13 +556,14 @@ class Guild extends Part
      *
      * @see https://discord.com/developers/docs/resources/guild#create-guild-role
      *
-     * @param array $data The data to fill the role with.
+     * @param array       $data The data to fill the role with.
+     * @param string|null $reason Reason for Audit Log.
      *
      * @throws NoPermissionsException
      *
      * @return ExtendedPromiseInterface<Role>
      */
-    public function createRole(array $data = []): ExtendedPromiseInterface
+    public function createRole(array $data = [], ?string $reason = null): ExtendedPromiseInterface
     {
         $botperms = $this->members->offsetGet($this->discord->id)->getPermissions();
 
@@ -570,7 +571,7 @@ class Guild extends Part
             return reject(new NoPermissionsException('You do not have permission to manage roles in the specified guild.'));
         }
 
-        return $this->roles->save($this->factory->create(Role::class, $data));
+        return $this->roles->save($this->factory->create(Role::class, $data), $reason);
     }
 
     /**
@@ -780,7 +781,7 @@ class Guild extends Part
      *
      * @return ExtendedPromiseInterface
      *
-     * @see self::REGION_DEFAULT The default region.
+     * @see Guild::REGION_DEFAULT The default region.
      */
     public function validateRegion(): ExtendedPromiseInterface
     {

--- a/src/Discord/Repository/AbstractRepository.php
+++ b/src/Discord/Repository/AbstractRepository.php
@@ -207,6 +207,10 @@ abstract class AbstractRepository extends Collection
         }
 
         return $this->http->delete($endpoint, null, $headers)->then(function ($response) use (&$part) {
+            if ($response) {
+                $part->fill((array) $response);
+            }
+
             $part->created = false;
 
             return $part;

--- a/src/Discord/Repository/Guild/BanRepository.php
+++ b/src/Discord/Repository/Guild/BanRepository.php
@@ -98,10 +98,11 @@ class BanRepository extends AbstractRepository
      * @see https://discord.com/developers/docs/resources/guild#remove-guild-ban
      *
      * @param Member|Ban|string $member
+     * @param string|null       $reason Reason for Audit Log.
      *
      * @return ExtendedPromiseInterface
      */
-    public function unban($member): ExtendedPromiseInterface
+    public function unban($member, ?string $reason = null): ExtendedPromiseInterface
     {
         if ($member instanceof Member) {
             $member = $member->id;
@@ -109,6 +110,6 @@ class BanRepository extends AbstractRepository
             $member = $member->user_id;
         }
 
-        return $this->delete($member);
+        return $this->delete($member, $reason);
     }
 }

--- a/src/Discord/Repository/Guild/MemberRepository.php
+++ b/src/Discord/Repository/Guild/MemberRepository.php
@@ -47,19 +47,18 @@ class MemberRepository extends AbstractRepository
     protected $class = Member::class;
 
     /**
-     * Alias for delete.
+     * Alias for `$member->delete()`.
      *
      * @see https://discord.com/developers/docs/resources/guild#remove-guild-member
      *
-     * @param Member $member The member to kick.
+     * @param Member      $member The member to kick.
+     * @param string|null $reason Reason for Audit Log.
      *
      * @return PromiseInterface
-     *
-     * @see self::delete()
      */
-    public function kick(Member $member): PromiseInterface
+    public function kick(Member $member, ?string $reason = null): PromiseInterface
     {
-        return $this->delete($member);
+        return $this->delete($member, $reason);
     }
 
     /**


### PR DESCRIPTION
Add optional Audit log `$reason` argument for Repository `save()` & `delete()`, does not validate for non supported endpoints (developers should consult the docs first), and Discord keep adding more endpoints to support audit log reason headers, Closes #653 

This also adds reason to `Guild::createRole()` and `BanRepository::ban()` & `MemberRepository::kick()`

Add query parameters argument for Repository `fresh()`, did not add it for `fetch()` since it doesn't always create http request instead return one from cache.