### PR TITLE
Simplify Carbon objects creation

### DIFF
--- a/src/Discord/Parts/Embed/Embed.php
+++ b/src/Discord/Parts/Embed/Embed.php
@@ -424,7 +424,7 @@ class Embed extends Part
      */
     public function setTimestamp(?int $timestamp = null): self
     {
-        $this->timestamp = (new Carbon($timestamp ?? 'now'))->format('c');
+        $this->timestamp = Carbon::parse($timestamp)->format('c');
 
         return $this;
     }

--- a/src/Discord/Parts/Embed/Embed.php
+++ b/src/Discord/Parts/Embed/Embed.php
@@ -55,13 +55,11 @@ class Embed extends Part
      */
     protected function getTimestampAttribute(): Carbon
     {
-        if (! array_key_exists('timestamp', $this->attributes)) {
+        if (empty($this->attributes['timestamp'])) {
             return Carbon::now();
         }
 
-        if (! empty($this->attributes['timestamp'])) {
-            return Carbon::parse($this->attributes['timestamp']);
-        }
+        return Carbon::parse($this->attributes['timestamp']);
     }
 
     /**
@@ -426,7 +424,7 @@ class Embed extends Part
      */
     public function setTimestamp(?int $timestamp = null): self
     {
-        $this->timestamp = (new Carbon(($timestamp !== null ? '@'.$timestamp : 'now')))->format('c');
+        $this->timestamp = (new Carbon($timestamp ?? 'now'))->format('c');
 
         return $this;
     }

--- a/src/Discord/Parts/Embed/Embed.php
+++ b/src/Discord/Parts/Embed/Embed.php
@@ -24,7 +24,7 @@ use function Discord\poly_strlen;
  * @property string|null        $type        The type of the embed.
  * @property string|null        $description A description of the embed.
  * @property string|null        $url         The URL of the embed.
- * @property Carbon|string|null $timestamp   A timestamp of the embed.
+ * @property Carbon|null        $timestamp   A timestamp of the embed.
  * @property int|null           $color       The color of the embed.
  * @property Footer|null        $footer      The footer of the embed.
  * @property Image|null         $image       The image of the embed.
@@ -51,12 +51,12 @@ class Embed extends Part
     /**
      * Gets the timestamp attribute.
      *
-     * @return Carbon The timestamp attribute.
+     * @return Carbon|null The timestamp attribute.
      */
-    protected function getTimestampAttribute(): Carbon
+    protected function getTimestampAttribute(): ?Carbon
     {
-        if (empty($this->attributes['timestamp'])) {
-            return Carbon::now();
+        if (! isset($this->attributes['timestamp'])) {
+            return null;
         }
 
         return Carbon::parse($this->attributes['timestamp']);

--- a/src/Discord/Parts/WebSockets/TypingStart.php
+++ b/src/Discord/Parts/WebSockets/TypingStart.php
@@ -109,7 +109,7 @@ class TypingStart extends Part
      */
     protected function getTimestampAttribute(): Carbon
     {
-        return new Carbon(gmdate('r', $this->attributes['timestamp']));
+        return new Carbon($this->attributes['timestamp']);
     }
 
     /**


### PR DESCRIPTION
- `getTimestampAttribute` return type is not nullable, so the method can be simplified to always return "now" when "timestamp" is empty.
- `gmdate` call is not needed as `Carbon` constructor understand integer as a timestamp already, if `$this->attributes['timestamp']` can be a numeric string, an `(int)` cast need to be added but I assumed it can't as other similar methods (in Message.php for instance) use a simple construction
- `new Carbon($timestamp !== null ? '@'.$timestamp : 'now')` is equivalent to `new Carbon($timestamp ?? 'now')` as here `$timestamp` is guaranteed to be `int|null`