### PR TITLE
Fix variable name mistaken when resolving PR conflict

### DIFF
--- a/src/Discord/Repository/Guild/BanRepository.php
+++ b/src/Discord/Repository/Guild/BanRepository.php
@@ -103,7 +103,7 @@ class BanRepository extends AbstractRepository
      *
      * @return ExtendedPromiseInterface
      */
-    public function unban($member, ?string $reason = null): ExtendedPromiseInterface
+    public function unban($user, ?string $reason = null): ExtendedPromiseInterface
     {
         if ($user instanceof User || $user instanceof Member) {
             $user = $user->id;
@@ -111,6 +111,6 @@ class BanRepository extends AbstractRepository
             $user = $user->user_id;
         }
 
-        return $this->delete($member, $reason);
+        return $this->delete($user, $reason);
     }
 }


### PR DESCRIPTION
Was a mistake when resolving conflict from https://github.com/discord-php/DiscordPHP/pull/840/commits/ad14bc3827753bc8299973dd5927c6b6811580c3

Fixes #851 