### PR TITLE
Consistency: Use root namespace for SPL exceptions

### DIFF
--- a/src/Discord/Helpers/Buffer.php
+++ b/src/Discord/Helpers/Buffer.php
@@ -12,11 +12,9 @@
 namespace Discord\Helpers;
 
 use Evenement\EventEmitter;
-use Exception;
 use React\EventLoop\LoopInterface;
 use React\Promise\ExtendedPromiseInterface;
 use React\Stream\WritableStreamInterface;
-use RuntimeException;
 
 class Buffer extends EventEmitter implements WritableStreamInterface
 {
@@ -118,9 +116,9 @@ class Buffer extends EventEmitter implements WritableStreamInterface
      * @param null|string $format  Format to read the bytes in. See `pack()`.
      * @param int         $timeout Time in milliseconds before the read times out.
      *
-     * @return ExtendedPromiseInterface<mixed, RuntimeException>
+     * @return ExtendedPromiseInterface<mixed, \RuntimeException>
      *
-     * @throws RuntimeException When there is an error unpacking the read bytes.
+     * @throws \RuntimeException When there is an error unpacking the read bytes.
      */
     public function read(int $length, ?string $format = null, ?int $timeout = -1): ExtendedPromiseInterface
     {
@@ -133,7 +131,7 @@ class Buffer extends EventEmitter implements WritableStreamInterface
 
             if ($timeout >= 0 && $this->loop !== null) {
                 $timer = $this->loop->addTimer($timeout / 1000, function () use ($deferred) {
-                    $deferred->reject(new Exception('Timed out.'));
+                    $deferred->reject(new \Exception('Timed out.'));
                 });
 
                 $deferred->promise()->then(function () use ($timer) {
@@ -147,7 +145,7 @@ class Buffer extends EventEmitter implements WritableStreamInterface
                 $unpacked = unpack($format, $d);
                 
                 if ($unpacked === false) {
-                    throw new RuntimeException('Error unpacking buffer.');
+                    throw new \RuntimeException('Error unpacking buffer.');
                 }
                 
                 return reset($unpacked);
@@ -162,9 +160,9 @@ class Buffer extends EventEmitter implements WritableStreamInterface
      *
      * @param int $timeout Time in milliseconds before the read times out.
      *
-     * @return ExtendedPromiseInterface<int, RuntimeException>
+     * @return ExtendedPromiseInterface<int, \RuntimeException>
      *
-     * @throws RuntimeException When there is an error unpacking the read bytes.
+     * @throws \RuntimeException When there is an error unpacking the read bytes.
      */
     public function readInt32(int $timeout = -1): ExtendedPromiseInterface
     {
@@ -176,9 +174,9 @@ class Buffer extends EventEmitter implements WritableStreamInterface
      *
      * @param int $timeout Time in milliseconds before the read times out.
      *
-     * @return ExtendedPromiseInterface<int, RuntimeException>
+     * @return ExtendedPromiseInterface<int, \RuntimeException>
      *
-     * @throws RuntimeException When there is an error unpacking the read bytes.
+     * @throws \RuntimeException When there is an error unpacking the read bytes.
      */
     public function readInt16(int $timeout = -1): ExtendedPromiseInterface
     {

--- a/src/Discord/Parts/Part.php
+++ b/src/Discord/Parts/Part.php
@@ -18,7 +18,6 @@ use Discord\Factory\Factory;
 use Discord\Http\Http;
 use JsonSerializable;
 use React\Promise\ExtendedPromiseInterface;
-use RuntimeException;
 use Serializable;
 
 use function Discord\studly;
@@ -163,13 +162,13 @@ abstract class Part implements ArrayAccess, JsonSerializable
      * Fetches any missing information about
      * the part from Discord's servers.
      *
-     * @throws RuntimeException The part is not fetchable.
+     * @throws \RuntimeException The part is not fetchable.
      *
      * @return ExtendedPromiseInterface<static>
      */
     public function fetch(): ExtendedPromiseInterface
     {
-        throw new RuntimeException('This part is not fetchable.');
+        throw new \RuntimeException('This part is not fetchable.');
     }
 
     /**

--- a/src/Discord/Repository/Channel/ThreadRepository.php
+++ b/src/Discord/Repository/Channel/ThreadRepository.php
@@ -16,7 +16,6 @@ use Discord\Http\Endpoint;
 use Discord\Parts\Thread\Member;
 use Discord\Parts\Thread\Thread;
 use Discord\Repository\AbstractRepository;
-use InvalidArgumentException;
 use React\Promise\ExtendedPromiseInterface;
 
 /**
@@ -72,13 +71,15 @@ class ThreadRepository extends AbstractRepository
      * @param int|null           $limit   The number of threads to return, null to return all.
      * @param Thread|string|null $before  Retrieve threads before this thread. Takes a thread object or a thread ID.
      *
+     * @throws \InvalidArgumentException
+     * 
      * @return ExtendedPromiseInterface<Collection<Thread>>
      */
     public function archived(bool $private = false, bool $joined = false, ?int $limit = null, $before = null): ExtendedPromiseInterface
     {
         if ($joined) {
             if (! $private) {
-                throw new InvalidArgumentException('You cannot fetch threads that the bot has joined but are not private.');
+                throw new \InvalidArgumentException('You cannot fetch threads that the bot has joined but are not private.');
             }
 
             $endpoint = Endpoint::CHANNEL_THREADS_ARCHIVED_PRIVATE_ME;

--- a/src/Discord/Voice/VoiceClient.php
+++ b/src/Discord/Voice/VoiceClient.php
@@ -28,7 +28,6 @@ use React\Datagram\Socket;
 use React\Dns\Resolver\Factory as DNSFactory;
 use React\EventLoop\LoopInterface;
 use Discord\Helpers\Deferred;
-use Exception;
 use Psr\Log\LoggerInterface;
 use React\ChildProcess\Process;
 use React\Promise\ExtendedPromiseInterface;
@@ -36,7 +35,6 @@ use React\Stream\ReadableResourceStream as Stream;
 use React\EventLoop\TimerInterface;
 use React\Stream\ReadableResourceStream;
 use React\Stream\ReadableStreamInterface;
-use RuntimeException;
 
 /**
  * The Discord voice client.
@@ -766,7 +764,7 @@ class VoiceClient extends EventEmitter
         $deferred = new Deferred();
 
         if (! $this->isReady()) {
-            $deferred->reject(new Exception('Voice client is not ready yet.'));
+            $deferred->reject(new \Exception('Voice client is not ready yet.'));
 
             return $deferred->promise();
         }
@@ -794,7 +792,7 @@ class VoiceClient extends EventEmitter
         }
 
         if (! ($stream instanceof ReadableStreamInterface)) {
-            $deferred->reject(new Exception('The stream passed to playDCAStream was not an instance of resource, ReactPHP Process, ReactPHP Readable Stream'));
+            $deferred->reject(new \Exception('The stream passed to playDCAStream was not an instance of resource, ReactPHP Process, ReactPHP Readable Stream'));
 
             return $deferred->promise();
         }
@@ -1416,11 +1414,11 @@ class VoiceClient extends EventEmitter
     private function checkPHPVersion(): bool
     {
         if (substr(strtolower(PHP_OS), 0, 3) === 'win' && PHP_VERSION_ID < 80000) {
-            $this->emit('error', [new RuntimeException('PHP 8.0.0 or later is required to run the voice client on Windows.')]);
+            $this->emit('error', [new \RuntimeException('PHP 8.0.0 or later is required to run the voice client on Windows.')]);
 
             return false;
         } elseif (PHP_VERSION_ID < 70400) {
-            $this->emit('error', [new RuntimeException('PHP 7.4.0 or later is required to run the voice client.')]);
+            $this->emit('error', [new \RuntimeException('PHP 7.4.0 or later is required to run the voice client.')]);
 
             return false;
         }


### PR DESCRIPTION
There are apparently still some exceptions left using `use`, this PR fixes that incosistency

It helps pointing to the right exception for LSP & documentation