### PR TITLE
Remove 'get' endpoint from RoleRepository

### DIFF
--- a/src/Discord/Repository/Guild/RoleRepository.php
+++ b/src/Discord/Repository/Guild/RoleRepository.php
@@ -33,7 +33,6 @@ class RoleRepository extends AbstractRepository
      */
     protected $endpoints = [
         'all' => Endpoint::GUILD_ROLES,
-        'get' => Endpoint::GUILD_ROLE,
         'create' => Endpoint::GUILD_ROLES,
         'update' => Endpoint::GUILD_ROLE,
         'delete' => Endpoint::GUILD_ROLE,


### PR DESCRIPTION
The endpoint to fetch a single role doesn't actually exist in the API, so `$guild->roles->fetch('role id here', true)` will not work.

`[2022-07-24T05:11:51.061076+00:00] DiscordPHP.WARNING: REQ GET guilds/872531095621615646/roles/894836570832666695 failed: Discord\Http\Exceptions\RequestFailedException: Method Not Allowed - {     "message": "405: Method Not Allowed",     "code": 0 }`