### PR TITLE
Fix __serialize() and __unserialize() Also added back the original serialize() and unserialize() method

### DIFF
--- a/src/Discord/Parts/Part.php
+++ b/src/Discord/Parts/Part.php
@@ -18,7 +18,6 @@ use Discord\Factory\Factory;
 use Discord\Http\Http;
 use JsonSerializable;
 use React\Promise\ExtendedPromiseInterface;
-use Serializable;
 
 use function Discord\studly;
 
@@ -311,9 +310,14 @@ abstract class Part implements ArrayAccess, JsonSerializable
      *
      * @return string A string of serialized data.
      */
-    public function __serialize()
+    public function serialize()
     {
         return serialize($this->attributes);
+    }
+
+    public function __serialize(): array
+    {
+        return $this->attributes;
     }
 
     /**
@@ -323,10 +327,17 @@ abstract class Part implements ArrayAccess, JsonSerializable
      *
      * @see self::setAttribute() The unserialized data is stored with setAttribute.
      */
-    public function __unserialize($data)
+    public function unserialize($data)
     {
         $data = unserialize($data);
 
+        foreach ($data as $key => $value) {
+            $this->setAttribute($key, $value);
+        }
+    }
+    
+    public function __unserialize(array $data): void
+    {
         foreach ($data as $key => $value) {
             $this->setAttribute($key, $value);
         }

--- a/src/Discord/Parts/Part.php
+++ b/src/Discord/Parts/Part.php
@@ -25,7 +25,7 @@ use function Discord\studly;
  * This class is the base of all objects that are returned. All "Parts" extend off this
  * base class.
  */
-abstract class Part implements ArrayAccess, JsonSerializable, Serializable
+abstract class Part implements ArrayAccess, JsonSerializable
 {
     /**
      * The HTTP client.


### PR DESCRIPTION
There was a mistake in https://github.com/discord-php/DiscordPHP/pull/599 where @davidcole1340 asked to keep the methods but instead it was renamed to __serialize() and __unserialize() which does handle array instead of string (so it was throwing PHP fatal error). This PR fixes them.

Tested & can be merged (please squash)