### PR TITLE
Fix an error when closing the client with no websocket connection

### DIFF
--- a/src/Discord/Discord.php
+++ b/src/Discord/Discord.php
@@ -1431,7 +1431,7 @@ class Discord
     public function close(bool $closeLoop = true): void
     {
         $this->closing = true;
-        if (!is_null($this->ws)) {
+        if ($this->ws !== null) {
             $this->ws->close($closeLoop ? Op::CLOSE_UNKNOWN_ERROR : Op::CLOSE_NORMAL, 'discordphp closing...');
         }
         $this->emit('closed', [$this]);

--- a/src/Discord/Discord.php
+++ b/src/Discord/Discord.php
@@ -1431,7 +1431,7 @@ class Discord
     public function close(bool $closeLoop = true): void
     {
         $this->closing = true;
-        if ($this->ws !== null) {
+        if ($this->ws) {
             $this->ws->close($closeLoop ? Op::CLOSE_UNKNOWN_ERROR : Op::CLOSE_NORMAL, 'discordphp closing...');
         }
         $this->emit('closed', [$this]);

--- a/src/Discord/Discord.php
+++ b/src/Discord/Discord.php
@@ -1431,7 +1431,9 @@ class Discord
     public function close(bool $closeLoop = true): void
     {
         $this->closing = true;
-        $this->ws->close($closeLoop ? Op::CLOSE_UNKNOWN_ERROR : Op::CLOSE_NORMAL, 'discordphp closing...');
+        if (!is_null($this->ws)) {
+            $this->ws->close($closeLoop ? Op::CLOSE_UNKNOWN_ERROR : Op::CLOSE_NORMAL, 'discordphp closing...');
+        }
         $this->emit('closed', [$this]);
         $this->logger->info('discord closed');
 


### PR DESCRIPTION
If for websocket cannot connect for some reason, calling `Discord::close()` function will cause a `Call to a member function close()` error.