### PR TITLE
test: remove allowText assertion on voice channel

### DIFF
--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -1,5 +1,6 @@
 name: Unit Tests
-on: [ push ]
+on:
+  workflow_dispatch:
 
 env:
   DISCORD_TOKEN: ${{ secrets.DISCORD_TOKEN }}
@@ -15,6 +16,7 @@ jobs:
     strategy:
       matrix:
         php:
+          - '8.1'
           - '8.0'
           - '7.4'
     steps:

--- a/tests/Parts/Channel/ChannelTest.php
+++ b/tests/Parts/Channel/ChannelTest.php
@@ -266,7 +266,7 @@ final class ChannelTest extends DiscordTestCase
     /**
      * @covers \Discord\Parts\Channel\Channel::allowVoice
      */
-    public function testVoiceChannelDoesNotAllowText()
+    public function testVoiceChannelAllowVoice()
     {
         /**
          * @var Channel
@@ -275,7 +275,6 @@ final class ChannelTest extends DiscordTestCase
             return $channel->type == Channel::TYPE_VOICE;
         })->first();
 
-        $this->assertFalse($vc->allowText());
         $this->assertTrue($vc->allowVoice());
     }
 }


### PR DESCRIPTION
Text In Voice has been possible so this test has been changed to just test the `allowVoice()` method