### PR TITLE
Fix Events

### DIFF
--- a/src/Discord/WebSockets/Events/GuildBanRemove.php
+++ b/src/Discord/WebSockets/Events/GuildBanRemove.php
@@ -25,14 +25,18 @@ class GuildBanRemove extends Event
      */
     public function handle(Deferred &$deferred, $data): void
     {
-        /** @var Ban */
-        $banPart = $this->factory->create(Ban::class, $data);
+        $banPart = null;
 
-        if ($guild = $banPart->guild) {
+        if ($guild = $this->discord->guilds->get('id', $data->guild_id)) {
             if ($banPart = $guild->bans->pull($data->user->id)) {
                 $banPart->fill((array) $data);
                 $banPart->created = false;
             }
+        }
+
+        if (! $banPart) {
+            /** @var Ban */
+            $banPart = $this->factory->create(Ban::class, $data);
         }
 
         $this->cacheUser($data->user);

--- a/src/Discord/WebSockets/Events/GuildDelete.php
+++ b/src/Discord/WebSockets/Events/GuildDelete.php
@@ -25,11 +25,6 @@ class GuildDelete extends Event
      */
     public function handle(Deferred &$deferred, $data): void
     {
-        if (! $guildPart = $this->discord->guilds->pull($data->id)) {
-            /** @var Guild */
-            $guildPart = $this->factory->create(Guild::class, $data);
-        }
-
-        $deferred->resolve([$guildPart, $data->unavailable ?? false]);
+        $deferred->resolve([$this->discord->guilds->pull($data->id), $data->unavailable ?? false]);
     }
 }


### PR DESCRIPTION
The `GUILD_DELETE` event does not send a `Guild` object in `$data` even if it was just unavailable (reference: https://github.com/discord-payloads/discord-payloads/blob/master/events/guild/guild_delete-unavailable.json) so the Part should be left null for uncached Guild (this is already noted in our docs)

Reference: https://discord.com/developers/docs/topics/gateway#guild-delete

This partially reverts https://github.com/discord-php/DiscordPHP/commit/59283c443bc078bd088ac3f59aa5899c17694fb2