### PR TITLE
Update event docs

### DIFF
--- a/docs/src/pages/api/03_events.md
+++ b/docs/src/pages/api/03_events.md
@@ -4,7 +4,7 @@ title: "Events"
 
 ### Application Command Permissions Update
 
-Called with a `Overwrite` object when an application command's permissions are updated.
+Called with an `Overwrite` object when an application command's permissions are updated.
 
 ```php
 $discord->on(Event::APPLICATION_COMMAND_PERMISSIONS_UPDATE, function (Overwrite $overwrite, Discord $discord, Overwrite $oldOverwrite) {
@@ -12,128 +12,52 @@ $discord->on(Event::APPLICATION_COMMAND_PERMISSIONS_UPDATE, function (Overwrite 
 });
 ```
 
-### Message Create
+### Auto Moderation Rule Create
 
-Called with a `Message` object when a message is sent in a guild or private channel.
+Called with a `Rule` object when an auto moderation rule is created.
 
-Requires the `Intents::GUILD_MESSAGES` intent.
+Requires the `Intents::AUTO_MODERATION_CONFIGURATION` intent.
 
 ```php
-$discord->on(Event::MESSAGE_CREATE, function (Message $message, Discord $discord) {
+$discord->on(Event::AUTO_MODERATION_RULE_CREATE, function (Rule $rule, Discord $discord) {
     // ...
 });
 ```
 
-### Message Update
+### Auto Moderation Rule Update
 
-Called with two `Message` objects when a message is updated in a guild or private channel.
-The old message may be null if `storeMessages` is not enabled _or_ the message was sent before the Bot was started.
-Discord does not provide a way to get message update history.
+Called with a `Rule` object when an auto moderation rule is updated.
 
-Requires the `Intents::GUILD_MESSAGES` intent.
+Requires the `Intents::AUTO_MODERATION_CONFIGURATION` intent.
 
 ```php
-$discord->on(Event::MESSAGE_UPDATE, function (Message $message, Discord $discord, ?Message $oldMessage) {
+$discord->on(Event::AUTO_MODERATION_RULE_UPDATE, function (Rule $rule, Discord $discord, Rule $oldRule) {
     // ...
 });
 ```
 
-### Message Delete
+### Auto Moderation Rule Delete
 
-Called with an old `Message` object _or_ the raw payload when a message is deleted.
-The `Message` object may be the raw payload if `storeMessages` is not enabled _or_ the message was sent before the Bot was started.
-Discord does not provide a way to get deleted messages.
+Called with a `Rule` object when an auto moderation rule is deleted.
 
-Requires the `Intents::GUILD_MESSAGES` intent.
+Requires the `Intents::AUTO_MODERATION_CONFIGURATION` intent.
 
 ```php
-$discord->on(Event::MESSAGE_DELETE, function ($message, Discord $discord) {
-    if ($message instanceof Message) {
-        // Message is present in cache
-    }
-    // If the message is not present in the cache:
-    else {
-        // {
-        //     "id": "", // deleted message ID,
-        //     "channel_id": "", // message channel ID,
-        //     "guild_id": "" // channel guild ID
-        // }
-    }
-});
-```
-
-### Message Delete Bulk
-
-Called with a `Collection` of old `Message` objects _or_ the raw payload when bulk messages are deleted.
-The `Message` object may be the raw payload if `storeMessages` is not enabled _or_ the message was sent before the Bot was started.
-Discord does not provide a way to get deleted messages.
-
-Requires the `Intents::GUILD_MESSAGES` intent.
-
-```php
-$discord->on(Event::MESSAGE_DELETE_BULK, function (Collection $messages, Discord $discord) {
-    foreach ($messages as $message) {
-        if ($message instanceof Message) {
-            // Message is present in cache
-        }
-        // If the message is not present in the cache:
-        else {
-            // {
-            //     "id": "", // deleted message ID,
-            //     "channel_id": "", // message channel ID,
-            //     "guild_id": "" // channel guild ID
-            // }
-        }
-    }
-});
-```
-
-### Message Reaction Add
-
-Called with a `MessageReaction` object when a user added a reaction to a message.
-
-Requires the `Intents::GUILD_MESSAGE_REACTIONS` intent.
-
-```php
-$discord->on(Event::MESSAGE_REACTION_ADD, function (MessageReaction $reaction, Discord $discord) {
+$discord->on(Event::AUTO_MODERATION_RULE_DELETE, function (Rule $rule, Discord $discord) {
     // ...
 });
 ```
 
-### Message Reaction Remove
+### Auto Moderation Action Execution
 
-Called with a `MessageReaction` object when a user removes a reaction from a message.
+Called with an `AutoModerationActionExecution` object when an auto moderation rule is triggered and an action is executed (e.g. when a message is blocked).
 
-Requires the `Intents::GUILD_MESSAGE_REACTIONS` intent.
-
-```php
-$discord->on(Event::MESSAGE_REACTION_REMOVE, function (MessageReaction $reaction, Discord $discord) {
-    // ...
-});
-```
-
-### Message Reaction Remove All
-
-Called with a `MessageReaction` object when all reactions are removed from a message.
-Note that only the fields relating to the message, channel and guild will be filled.
-
-Requires the `Intents::GUILD_MESSAGE_REACTIONS` intent.
+Requires the `Intents::AUTO_MODERATION_EXECUTION` intent.
 
 ```php
-$discord->on(Event::MESSAGE_REACTION_REMOVE_ALL, function (MessageReaction $reaction, Discord $discord) {
-    // ...
-});
-```
+// use `Discord\Parts\WebSockets\AutoModerationActionExecution`;
 
-### Message Reaction Remove Emoji
-
-Called with an object when all reactions of an emoji are removed from a message.
-Unlike Message Reaction Remove, this event contains no users or members.
-
-Requires the `Intents::GUILD_MESSAGE_REACTIONS` intent.
-
-```php
-$discord->on(Event::MESSAGE_REACTION_REMOVE_EMOJI, function (MessageReaction $reaction, Discord $discord) {
+$discord->on(Event::AUTO_MODERATION_ACTION_EXECUTION, function (AutoModerationActionExecution $actionExecution, Discord $discord) {
     // ...
 });
 ```
@@ -252,42 +176,6 @@ $discord->on(Event::THREAD_MEMBERS_UPDATE, function (Thread $thread, Discord $di
 });
 ```
 
-### Stage Instance Create
-
-Called with a `StageInstance` object when a stage instance is created (i.e. the Stage is now "live").
-
-Requires the `Intents::GUILDS` intent.
-
-```php
-$discord->on(Event::STAGE_INSTANCE_CREATE, function (StageInstance $stageInstance, Discord $discord) {
-    // ...
-});
-```
-
-### Stage Instance Update
-
-Called with `StageInstance` objects when a stage instance has been updated.
-
-Requires the `Intents::GUILDS` intent.
-
-```php
-$discord->on(Event::STAGE_INSTANCE_UPDATE, function (StageInstance $stageInstance, Discord $discord, ?StageInstance $oldStageInstance) {
-    // ...
-});
-```
-
-### Stage Instance Delete
-
-Called with a `StageInstance` object when a stage instance has been deleted (i.e. the Stage has been closed).
-
-Requires the `Intents::GUILDS` intent.
-
-```php
-$discord->on(Event::STAGE_INSTANCE_DELETE, function (StageInstance $stageInstance, Discord $discord) {
-    // ...
-});
-```
-
 ### Guild Create
 
 Called with a `Guild` object in one of the following situations:
@@ -336,42 +224,6 @@ $discord->on(Event::GUILD_DELETE, function (?Guild $guild, Discord $discord, boo
 });
 ```
 
-### Guild Member Add
-
-Called with a `Member` object when a new user joins a guild.
-
-Requires the `Intents::GUILD_MEMBERS` intent. This intent is a priviliged intent, it must be enabled in your Discord Bot developer settings.
-
-```php
-$discord->on(Event::GUILD_MEMBER_ADD, function (Member $member, Discord $discord) {
-    // ...
-});
-```
-
-### Guild Member Update
-
-Called with two `Member` objects when a member is updated in a guild. Note that the old member _may_ be `null` if `loadAllMembers` is disabled.
-
-Requires the `Intents::GUILD_MEMBERS` intent. This intent is a priviliged intent, it must be enabled in your Discord Bot developer settings.
-
-```php
-$discord->on(Event::GUILD_MEMBER_UPDATE, function (Member $member, Discord $discord, Member $oldMember) {
-    // ...
-});
-```
-
-### Guild Member Remove
-
-Called with a `Member` object when a member is removed from a guild (leave/kick/ban). Note that the member _may_ only have `User` data if `loadAllMembers` is disabled.
-
-Requires the `Intents::GUILD_MEMBERS` intent. This intent is a priviliged intent, it must be enabled in your Discord Bot developer settings.
-
-```php
-$discord->on(Event::GUILD_MEMBER_REMOVE, function (Member $member, Discord $discord) {
-    // ...
-});
-```
-
 ### Guild Ban Add
 
 Called with a `Ban` object when a member is banned from a guild.
@@ -392,6 +244,78 @@ Requires the `Intents::GUILD_BANS` intent.
 
 ```php
 $discord->on(Event::GUILD_BAN_REMOVE, function (Ban $ban, Discord $discord) {
+    // ...
+});
+```
+
+### Guild Emojis Update
+
+Called with two Collections of `Emoji` objects when a guild's emojis have been added/updated/deleted. `$oldEmojis` _may_ be empty if it was not cached or there were previously no emojis.
+
+Requires the `Intents::GUILD_EMOJIS_AND_STICKERS` intent.
+
+```php
+$discord->on(Event::GUILD_EMOJIS_UPDATE, function (Collection $emojis, Discord $discord, Collection $oldEmojis) {
+    // ...
+});
+```
+
+### Guild Stickers Update
+
+Called with two Collections of `Sticker` objects when a guild's stickers have been added/updated/deleted. `$oldStickers` _may_ be empty if it was not cached or there were previously no stickers.
+
+Requires the `Intents::GUILD_EMOJIS_AND_STICKERS` intent.
+
+```php
+$discord->on(Event::GUILD_STICKERS_UPDATE, function (Collection $stickers, Discord $discord, Collecetion $oldStickers) {
+    // ...
+});
+```
+
+### Guild Integrations Update
+
+Called with a cached `Guild` object when a guild integration is updated.
+
+Requires the `Intents::GUILD_INTEGRATIONS` intent.
+
+```php
+$discord->on(Event::GUILD_INTEGRATIONS_UPDATE, function (?Guild $guild, Discord $discord) {
+    // ...
+});
+```
+
+### Guild Member Add
+
+Called with a `Member` object when a new user joins a guild.
+
+Requires the `Intents::GUILD_MEMBERS` intent. This intent is a priviliged intent, it must be enabled in your Discord Bot developer settings.
+
+```php
+$discord->on(Event::GUILD_MEMBER_ADD, function (Member $member, Discord $discord) {
+    // ...
+});
+```
+
+### Guild Member Remove
+
+Called with a `Member` object when a member is removed from a guild (leave/kick/ban). Note that the member _may_ only have `User` data if `loadAllMembers` is disabled.
+
+Requires the `Intents::GUILD_MEMBERS` intent. This intent is a priviliged intent, it must be enabled in your Discord Bot developer settings.
+
+```php
+$discord->on(Event::GUILD_MEMBER_REMOVE, function (Member $member, Discord $discord) {
+    // ...
+});
+```
+
+### Guild Member Update
+
+Called with two `Member` objects when a member is updated in a guild. Note that the old member _may_ be `null` if `loadAllMembers` is disabled.
+
+Requires the `Intents::GUILD_MEMBERS` intent. This intent is a priviliged intent, it must be enabled in your Discord Bot developer settings.
+
+```php
+$discord->on(Event::GUILD_MEMBER_UPDATE, function (Member $member, Discord $discord, Member $oldMember) {
     // ...
 });
 ```
@@ -436,147 +360,6 @@ $discord->on(Event::GUILD_ROLE_DELETE, function ($role, Discord $discord) {
         // {
         //     "guild_id": "" // role guild ID
         //     "role_id": "", // role ID,
-        // }
-    }
-});
-```
-
-### Guild Emojis Update
-
-Called with two Collections of `Emoji` objects when a guild's emojis have been added/updated/deleted. `$oldEmojis` _may_ be empty if it was not cached or there were previously no emojis.
-
-Requires the `Intents::GUILD_EMOJIS_AND_STICKERS` intent.
-
-```php
-$discord->on(Event::GUILD_EMOJIS_UPDATE, function (Collection $emojis, Discord $discord, Collection $oldEmojis) {
-    // ...
-});
-```
-
-### Guild Stickers Update
-
-Called with two Collections of `Sticker` objects when a guild's stickers have been added/updated/deleted. `$oldStickers` _may_ be empty if it was not cached or there were previously no stickers.
-
-Requires the `Intents::GUILD_EMOJIS_AND_STICKERS` intent.
-
-```php
-$discord->on(Event::GUILD_STICKERS_UPDATE, function (Collection $stickers, Discord $discord, Collecetion $oldStickers) {
-    // ...
-});
-```
-
-### Guild Integrations Update
-
-Called with a cached `Guild` object when a guild integration is updated.
-
-Requires the `Intents::GUILD_INTEGRATIONS` intent.
-
-```php
-$discord->on(Event::GUILD_INTEGRATIONS_UPDATE, function (?Guild $guild, Discord $discord) {
-    // ...
-});
-```
-
-### Integration Create
-
-Called with an `Integration` object when an integration is created in a guild.
-
-Requires the `Intents::GUILD_INTEGRATIONS` intent.
-
-```php
-$discord->on(Event::INTEGRATION_CREATE, function (Integration $integration, Discord $discord) {
-    // ...
-});
-```
-
-### Integration Update
-
-Called with an `Integration` object when a integration is updated in a guild.
-
-Requires the `Intents::GUILD_INTEGRATIONS` intent.
-
-```php
-$discord->on(Event::INTEGRATION_UPDATE, function (Integration $integration, Discord $discord, ?Integration $oldIntegration) {
-    // ...
-});
-```
-
-### Integration Delete
-
-Called with an old `Integration` object when a integration is deleted from a guild.
-`$oldIntegration` _may_ be `null` if Integration is not cached.
-
-Requires the `Intents::GUILD_INTEGRATIONS` intent.
-
-```php
-$discord->on(Event::INTEGRATION_DELETE, function (?Integration $integration, Discord $discord) {
-    // ...
-});
-```
-
-### Webhooks Update
-
-Called with a `Guild` and `Channel` object when a guild channel's webhooks are is created, updated, or deleted.
-
-Requires the `Intents::GUILD_WEBHOOKS` intent.
-
-```php
-$discord->on(Event::WEBHOOKS_UPDATE, function (?Guild $guild, Discord $discord, ?Channel $channel) {
-    // ...
-});
-```
-
-### Voice Server Update
-
-Called with a `VoiceServerUpdate` object when a voice server is updated in a guild.
-
-```php
-$discord->on(Event::VOICE_SERVER_UPDATE, function (VoiceServerUpdate $guild, Discord $discord) {
-    // ...
-});
-```
-
-### Voice State Update
-
-Called with a `VoiceStateUpdate` object when a member joins, leaves or moves between voice channels.
-
-Requires the `Intents::GUILD_VOICE_STATES` intent.
-
-```php
-$discord->on(Event::VOICE_STATE_UPDATE, function (VoiceStateUpdate $state, Discord $discord, $oldstate) {
-    // ...
-});
-```
-
-### Invite Create
-
-Called with an `Invite` object when a new invite to a channel is created.
-
-Requires the `Intents::GUILD_INVITES` intent.
-
-```php
-$discord->on(Event::INVITE_CREATE, function (Invite $invite, Discord $discord) {
-    // ...
-});
-```
-
-### Invite Delete
-
-Called with an object when an invite is created.
-
-Requires the `Intents::GUILD_INVITES` intent.
-
-```php
-$discord->on(Event::INVITE_DELETE, function ($invite, Discord $discord) {
-    if ($invite instanceof Invite) {
-        // Invite is present in cache
-    }
-    // If the invite is not present in the cache:
-    else {
-        // {
-        //     "channel_id": "",
-        //     "guild_id": "",
-        //     "code": "" // the unique invite code
         // }
     }
 });
@@ -642,52 +425,39 @@ $discord->on(Event::GUILD_SCHEDULED_EVENT_USER_REMOVE, function ($data, Discord 
 });
 ```
 
-### Auto Moderation Rule Create
+### Integration Create
 
-Called with a `Rule` object when an auto moderation rule is created.
+Called with an `Integration` object when an integration is created in a guild.
 
-Requires the `Intents::AUTO_MODERATION_CONFIGURATION` intent.
+Requires the `Intents::GUILD_INTEGRATIONS` intent.
 
 ```php
-$discord->on(Event::AUTO_MODERATION_RULE_CREATE, function (Rule $rule, Discord $discord) {
+$discord->on(Event::INTEGRATION_CREATE, function (Integration $integration, Discord $discord) {
     // ...
 });
 ```
 
-### Auto Moderation Rule Update
+### Integration Update
 
-Called with a `Rule` object when an auto moderation rule is updated.
+Called with an `Integration` object when a integration is updated in a guild.
 
-Requires the `Intents::AUTO_MODERATION_CONFIGURATION` intent.
+Requires the `Intents::GUILD_INTEGRATIONS` intent.
 
 ```php
-$discord->on(Event::AUTO_MODERATION_RULE_UPDATE, function (Rule $rule, Discord $discord, Rule $oldRule) {
+$discord->on(Event::INTEGRATION_UPDATE, function (Integration $integration, Discord $discord, ?Integration $oldIntegration) {
     // ...
 });
 ```
 
-### Auto Moderation Rule Delete
+### Integration Delete
 
-Called with a `Rule` object when an auto moderation rule is deleted.
+Called with an old `Integration` object when a integration is deleted from a guild.
+`$oldIntegration` _may_ be `null` if Integration is not cached.
 
-Requires the `Intents::AUTO_MODERATION_CONFIGURATION` intent.
-
-```php
-$discord->on(Event::AUTO_MODERATION_RULE_DELETE, function (Rule $rule, Discord $discord) {
-    // ...
-});
-```
-
-### Auto Moderation Action Execution
-
-Called with an `AutoModerationActionExecution` object when an auto moderation rule is triggered and an action is executed (e.g. when a message is blocked).
-
-Requires the `Intents::AUTO_MODERATION_EXECUTION` intent.
+Requires the `Intents::GUILD_INTEGRATIONS` intent.
 
 ```php
-// use `Discord\Parts\WebSockets\AutoModerationActionExecution`;
-
-$discord->on(Event::AUTO_MODERATION_ACTION_EXECUTION, function (AutoModerationActionExecution $actionExecution, Discord $discord) {
+$discord->on(Event::INTEGRATION_DELETE, function (?Integration $integration, Discord $discord) {
     // ...
 });
 ```
@@ -704,14 +474,163 @@ $discord->on(Event::INTERACTION_CREATE, function (Interaction $interaction, Disc
 });
 ```
 
-### Typing Start
+### Invite Create
 
-Called with a `TypingStart` object when a user starts typing in a channel.
+Called with an `Invite` object when a new invite to a channel is created.
 
-Requires the `Intents::GUILD_MESSAGE_TYPING` intent.
+Requires the `Intents::GUILD_INVITES` intent.
 
 ```php
-$discord->on(Event::TYPING_START, function (TypingStart $typing, Discord $discord) {
+$discord->on(Event::INVITE_CREATE, function (Invite $invite, Discord $discord) {
+    // ...
+});
+```
+
+### Invite Delete
+
+Called with an object when an invite is created.
+
+Requires the `Intents::GUILD_INVITES` intent.
+
+```php
+$discord->on(Event::INVITE_DELETE, function ($invite, Discord $discord) {
+    if ($invite instanceof Invite) {
+        // Invite is present in cache
+    }
+    // If the invite is not present in the cache:
+    else {
+        // {
+        //     "channel_id": "",
+        //     "guild_id": "",
+        //     "code": "" // the unique invite code
+        // }
+    }
+});
+```
+
+### Message Create
+
+Called with a `Message` object when a message is sent in a guild or private channel.
+
+Requires the `Intents::GUILD_MESSAGES` intent.
+
+```php
+$discord->on(Event::MESSAGE_CREATE, function (Message $message, Discord $discord) {
+    // ...
+});
+```
+
+
+### Message Update
+
+Called with two `Message` objects when a message is updated in a guild or private channel.
+The old message may be null if `storeMessages` is not enabled _or_ the message was sent before the Bot was started.
+Discord does not provide a way to get message update history.
+
+Requires the `Intents::GUILD_MESSAGES` intent.
+
+```php
+$discord->on(Event::MESSAGE_UPDATE, function (Message $message, Discord $discord, ?Message $oldMessage) {
+    // ...
+});
+```
+
+### Message Delete
+
+Called with an old `Message` object _or_ the raw payload when a message is deleted.
+The `Message` object may be the raw payload if `storeMessages` is not enabled _or_ the message was sent before the Bot was started.
+Discord does not provide a way to get deleted messages.
+
+Requires the `Intents::GUILD_MESSAGES` intent.
+
+```php
+$discord->on(Event::MESSAGE_DELETE, function ($message, Discord $discord) {
+    if ($message instanceof Message) {
+        // Message is present in cache
+    }
+    // If the message is not present in the cache:
+    else {
+        // {
+        //     "id": "", // deleted message ID,
+        //     "channel_id": "", // message channel ID,
+        //     "guild_id": "" // channel guild ID
+        // }
+    }
+});
+```
+
+### Message Delete Bulk
+
+Called with a `Collection` of old `Message` objects _or_ the raw payload when bulk messages are deleted.
+The `Message` object may be the raw payload if `storeMessages` is not enabled _or_ the message was sent before the Bot was started.
+Discord does not provide a way to get deleted messages.
+
+Requires the `Intents::GUILD_MESSAGES` intent.
+
+```php
+$discord->on(Event::MESSAGE_DELETE_BULK, function (Collection $messages, Discord $discord) {
+    foreach ($messages as $message) {
+        if ($message instanceof Message) {
+            // Message is present in cache
+        }
+        // If the message is not present in the cache:
+        else {
+            // {
+            //     "id": "", // deleted message ID,
+            //     "channel_id": "", // message channel ID,
+            //     "guild_id": "" // channel guild ID
+            // }
+        }
+    }
+});
+```
+
+### Message Reaction Add
+
+Called with a `MessageReaction` object when a user added a reaction to a message.
+
+Requires the `Intents::GUILD_MESSAGE_REACTIONS` intent.
+
+```php
+$discord->on(Event::MESSAGE_REACTION_ADD, function (MessageReaction $reaction, Discord $discord) {
+    // ...
+});
+```
+
+### Message Reaction Remove
+
+Called with a `MessageReaction` object when a user removes a reaction from a message.
+
+Requires the `Intents::GUILD_MESSAGE_REACTIONS` intent.
+
+```php
+$discord->on(Event::MESSAGE_REACTION_REMOVE, function (MessageReaction $reaction, Discord $discord) {
+    // ...
+});
+```
+
+### Message Reaction Remove All
+
+Called with a `MessageReaction` object when all reactions are removed from a message.
+Note that only the fields relating to the message, channel and guild will be filled.
+
+Requires the `Intents::GUILD_MESSAGE_REACTIONS` intent.
+
+```php
+$discord->on(Event::MESSAGE_REACTION_REMOVE_ALL, function (MessageReaction $reaction, Discord $discord) {
+    // ...
+});
+```
+
+### Message Reaction Remove Emoji
+
+Called with an object when all reactions of an emoji are removed from a message.
+Unlike Message Reaction Remove, this event contains no users or members.
+
+Requires the `Intents::GUILD_MESSAGE_REACTIONS` intent.
+
+```php
+$discord->on(Event::MESSAGE_REACTION_REMOVE_EMOJI, function (MessageReaction $reaction, Discord $discord) {
     // ...
 });
 ```
@@ -728,12 +647,94 @@ $discord->on(Event::PRESENCE_UPDATE, function (PresenceUpdate $presence, Discord
 });
 ```
 
+### Stage Instance Create
+
+Called with a `StageInstance` object when a stage instance is created (i.e. the Stage is now "live").
+
+Requires the `Intents::GUILDS` intent.
+
+```php
+$discord->on(Event::STAGE_INSTANCE_CREATE, function (StageInstance $stageInstance, Discord $discord) {
+    // ...
+});
+```
+
+### Stage Instance Update
+
+Called with `StageInstance` objects when a stage instance has been updated.
+
+Requires the `Intents::GUILDS` intent.
+
+```php
+$discord->on(Event::STAGE_INSTANCE_UPDATE, function (StageInstance $stageInstance, Discord $discord, ?StageInstance $oldStageInstance) {
+    // ...
+});
+```
+
+### Stage Instance Delete
+
+Called with a `StageInstance` object when a stage instance has been deleted (i.e. the Stage has been closed).
+
+Requires the `Intents::GUILDS` intent.
+
+```php
+$discord->on(Event::STAGE_INSTANCE_DELETE, function (StageInstance $stageInstance, Discord $discord) {
+    // ...
+});
+```
+
+### Typing Start
+
+Called with a `TypingStart` object when a user starts typing in a channel.
+
+Requires the `Intents::GUILD_MESSAGE_TYPING` intent.
+
+```php
+$discord->on(Event::TYPING_START, function (TypingStart $typing, Discord $discord) {
+    // ...
+});
+```
+
 ### User Update
 
 Called with `User` object when the Bot's user properties change.
 
 ```php
 $discord->on(Event::USER_UPDATE, function (User $user, Discord $discord, ?User $oldUser) {
+    // ...
+});
+```
+
+### Voice State Update
+
+Called with a `VoiceStateUpdate` object when a member joins, leaves or moves between voice channels.
+
+Requires the `Intents::GUILD_VOICE_STATES` intent.
+
+```php
+$discord->on(Event::VOICE_STATE_UPDATE, function (VoiceStateUpdate $state, Discord $discord, $oldstate) {
+    // ...
+});
+```
+
+### Voice Server Update
+
+Called with a `VoiceServerUpdate` object when a voice server is updated in a guild.
+
+```php
+$discord->on(Event::VOICE_SERVER_UPDATE, function (VoiceServerUpdate $guild, Discord $discord) {
+    // ...
+});
+```
+
+### Webhooks Update
+
+Called with a `Guild` and `Channel` object when a guild channel's webhooks are is created, updated, or deleted.
+
+Requires the `Intents::GUILD_WEBHOOKS` intent.
+
+```php
+$discord->on(Event::WEBHOOKS_UPDATE, function (?Guild $guild, Discord $discord, ?Channel $channel) {
     // ...
 });
 ```

--- a/docs/src/pages/api/03_events.md
+++ b/docs/src/pages/api/03_events.md
@@ -2,9 +2,20 @@
 title: "Events"
 ---
 
+### Application Command Permissions Update
+
+Called with a `Overwrite` object when an application command's permissions are updated.
+
+```php
+$discord->on(Event::APPLICATION_COMMAND_PERMISSIONS_UPDATE, function (Overwrite $overwrite, Discord $discord, Overwrite $oldOverwrite) {
+    // ...
+});
+```
+
 ### Message Create
 
 Called with a `Message` object when a message is sent in a guild or private channel.
+
 Requires the `Intents::GUILD_MESSAGES` intent.
 
 ```php
@@ -16,21 +27,23 @@ $discord->on(Event::MESSAGE_CREATE, function (Message $message, Discord $discord
 ### Message Update
 
 Called with two `Message` objects when a message is updated in a guild or private channel.
-The old message may be null if `storeMessages` is not enabled _or_ the message was sent before the bot was started.
+The old message may be null if `storeMessages` is not enabled _or_ the message was sent before the Bot was started.
 Discord does not provide a way to get message update history.
+
 Requires the `Intents::GUILD_MESSAGES` intent.
 
 ```php
-$discord->on(Event::MESSAGE_UPDATE, function (Message $newMessage, Discord $discord, ?Message $oldMessage) {
+$discord->on(Event::MESSAGE_UPDATE, function (Message $message, Discord $discord, ?Message $oldMessage) {
     // ...
 });
 ```
 
 ### Message Delete
 
-Called with a `Message` object _or_ the raw payload when a message is deleted.
-The `Message` object may be the raw payload if `storeMessages` is not enabled _or_ the message was sent before the bot was started.
+Called with an old `Message` object _or_ the raw payload when a message is deleted.
+The `Message` object may be the raw payload if `storeMessages` is not enabled _or_ the message was sent before the Bot was started.
 Discord does not provide a way to get deleted messages.
+
 Requires the `Intents::GUILD_MESSAGES` intent.
 
 ```php
@@ -51,9 +64,10 @@ $discord->on(Event::MESSAGE_DELETE, function ($message, Discord $discord) {
 
 ### Message Delete Bulk
 
-Called with a `Collection` of `Message` objects _or_ the raw payload when bulk messages are deleted.
-The `Message` object may be the raw payload if `storeMessages` is not enabled _or_ the message was sent before the bot was started.
+Called with a `Collection` of old `Message` objects _or_ the raw payload when bulk messages are deleted.
+The `Message` object may be the raw payload if `storeMessages` is not enabled _or_ the message was sent before the Bot was started.
 Discord does not provide a way to get deleted messages.
+
 Requires the `Intents::GUILD_MESSAGES` intent.
 
 ```php
@@ -76,7 +90,8 @@ $discord->on(Event::MESSAGE_DELETE_BULK, function (Collection $messages, Discord
 
 ### Message Reaction Add
 
-Called with a `MessageReaction` object when a reaction is added to a message.
+Called with a `MessageReaction` object when a user added a reaction to a message.
+
 Requires the `Intents::GUILD_MESSAGE_REACTIONS` intent.
 
 ```php
@@ -87,7 +102,8 @@ $discord->on(Event::MESSAGE_REACTION_ADD, function (MessageReaction $reaction, D
 
 ### Message Reaction Remove
 
-Called with a `MessageReaction` object when a reaction is removed from a message.
+Called with a `MessageReaction` object when a user removes a reaction from a message.
+
 Requires the `Intents::GUILD_MESSAGE_REACTIONS` intent.
 
 ```php
@@ -100,6 +116,7 @@ $discord->on(Event::MESSAGE_REACTION_REMOVE, function (MessageReaction $reaction
 
 Called with a `MessageReaction` object when all reactions are removed from a message.
 Note that only the fields relating to the message, channel and guild will be filled.
+
 Requires the `Intents::GUILD_MESSAGE_REACTIONS` intent.
 
 ```php
@@ -112,6 +129,7 @@ $discord->on(Event::MESSAGE_REACTION_REMOVE_ALL, function (MessageReaction $reac
 
 Called with an object when all reactions of an emoji are removed from a message.
 Unlike Message Reaction Remove, this event contains no users or members.
+
 Requires the `Intents::GUILD_MESSAGE_REACTIONS` intent.
 
 ```php
@@ -122,7 +140,8 @@ $discord->on(Event::MESSAGE_REACTION_REMOVE_EMOJI, function (MessageReaction $re
 
 ### Channel Create
 
-Called with a `Channel` object when a channel is created.
+Called with a `Channel` object when a new channel is created, relevant to the Bot.
+
 Requires the `Intents::GUILDS` intent.
 
 ```php
@@ -134,17 +153,19 @@ $discord->on(Event::CHANNEL_CREATE, function (Channel $channel, Discord $discord
 ### Channel Update
 
 Called with two `Channel` objects when a channel is updated.
+
 Requires the `Intents::GUILDS` intent.
 
 ```php
-$discord->on(Event::CHANNEL_UPDATE, function (Channel $new, Discord $discord, ?Channel $old) {
+$discord->on(Event::CHANNEL_UPDATE, function (Channel $channel, Discord $discord, ?Channel $oldChannel) {
     // ...
 });
 ```
 
 ### Channel Delete
 
-Called with a `Channel` object when a channel is deleted.
+Called with a `Channel` object when a channel relevant to the Bot is deleted.
+
 Requires the `Intents::GUILDS` intent.
 
 ```php
@@ -155,7 +176,8 @@ $discord->on(Event::CHANNEL_DELETE, function (Channel $channel, Discord $discord
 
 ### Channel Pins Update
 
-Called with an object when the pinned messages in a channel are updated. This is not sent when a pinned message is deleted.
+Called with an object when a message is pinned or unpinned in a text channel. This is not sent when a pinned message is deleted.
+
 Requires the `Intents::GUILDS` intent.
 
 ```php
@@ -170,7 +192,7 @@ $discord->on(Event::CHANNEL_PINS_UPDATE, function ($pins, Discord $discord) {
 
 ### Thread Create
 
-Called with a `Thread` object when a thread is created.
+Called with a `Thread` object when a thread is created, relevant to the Bot.
 
 ```php
 $discord->on(Event::THREAD_CREATE, function (Thread $thread, Discord $discord) {
@@ -190,10 +212,10 @@ $discord->on(Event::THREAD_UPDATE, function (Thread $thread, Discord $discord, ?
 
 ### Thread Delete
 
-Called with an old `THREAD_DELETE` object when a thread deleted.
+Called with an old `Thread` object when a thread relevant to the Bot is deleted.
 
 ```php
-$discord->on(Event::THREAD_DELETE, function (?Thread $oldthread, Discord $discord) {
+$discord->on(Event::THREAD_DELETE, function (?Thread $thread, Discord $discord) {
     // ...
 });
 ```
@@ -210,19 +232,19 @@ $discord->on(Event::THREAD_LIST_SYNC, function (Collection $threads, Discord $di
 
 ### Thread Member Update
 
-Called when a thread member is updated.
+Called with a Thread `Member` object when the thread member for the current Bot is updated.
 
 ```php
 // use Discord\Parts\Thread\Member;
 
-$discord->on(Event::THREAD_MEMBER_UPDATE, function (Member $threadmember, Discord $discord) {
+$discord->on(Event::THREAD_MEMBER_UPDATE, function (Member $threadMember, Discord $discord) {
     // ...
 });
 ```
 
 ### Thread Members Update
 
-Called when a member is added to or removed from a thread.
+Called with a `Thread` object when anyone is added to or removed from a thread. If the Bot does not have the `Intents::GUILD_MEMBERS`, then this event will only be called if the Bot was added to or removed from the thread.
 
 ```php
 $discord->on(Event::THREAD_MEMBERS_UPDATE, function (Thread $thread, Discord $discord) {
@@ -232,7 +254,8 @@ $discord->on(Event::THREAD_MEMBERS_UPDATE, function (Thread $thread, Discord $di
 
 ### Stage Instance Create
 
-Called with a `StageInstance` object when a stage instance is created.
+Called with a `StageInstance` object when a stage instance is created (i.e. the Stage is now "live").
+
 Requires the `Intents::GUILDS` intent.
 
 ```php
@@ -243,7 +266,8 @@ $discord->on(Event::STAGE_INSTANCE_CREATE, function (StageInstance $stageInstanc
 
 ### Stage Instance Update
 
-Called with `StageInstance` objects when a stage instance is updated.
+Called with `StageInstance` objects when a stage instance has been updated.
+
 Requires the `Intents::GUILDS` intent.
 
 ```php
@@ -254,11 +278,12 @@ $discord->on(Event::STAGE_INSTANCE_UPDATE, function (StageInstance $stageInstanc
 
 ### Stage Instance Delete
 
-Called with an old `StageInstance` object when a stage instance is deleted.
+Called with a `StageInstance` object when a stage instance has been deleted (i.e. the Stage has been closed).
+
 Requires the `Intents::GUILDS` intent.
 
 ```php
-$discord->on(Event::STAGE_INSTANCE_DELETE, function (StageInstance $oldStageInstance, Discord $discord) {
+$discord->on(Event::STAGE_INSTANCE_DELETE, function (StageInstance $stageInstance, Discord $discord) {
     // ...
 });
 ```
@@ -267,9 +292,9 @@ $discord->on(Event::STAGE_INSTANCE_DELETE, function (StageInstance $oldStageInst
 
 Called with a `Guild` object in one of the following situations:
 
-1. When the bot is first starting and the guilds are becoming available.
+1. When the Bot is first starting and the guilds are becoming available.
 2. When a guild was unavailable and is now available due to an outage.
-3. When the bot joins a new guild.
+3. When the Bot joins a new guild.
 
 Requires the `Intents::GUILDS` intent.
 
@@ -281,11 +306,12 @@ $discord->on(Event::GUILD_CREATE, function (Guild $guild, Discord $discord) {
 
 ### Guild Update
 
-Called with two `Guild` object when a guild is updated.
+Called with two `Guild` objects when a guild is updated.
+
 Requires the `Intents::GUILDS` intent.
 
 ```php
-$discord->on(Event::GUILD_UPDATE, function (Guild $new, Discord $discord, ?Guild $old) {
+$discord->on(Event::GUILD_UPDATE, function (Guild $guild, Discord $discord, ?Guild $oldGuild) {
     // ...
 });
 ```
@@ -294,7 +320,7 @@ $discord->on(Event::GUILD_UPDATE, function (Guild $new, Discord $discord, ?Guild
 
 Called with a `Guild` object in one of the following situations:
 
-1. The bot was removed from a guild.
+1. The Bot was removed from a guild.
 2. The guild is unavailable due to an outage.
 
 Requires the `Intents::GUILDS` intent.
@@ -305,15 +331,16 @@ $discord->on(Event::GUILD_DELETE, function (?Guild $guild, Discord $discord, boo
     if ($unavailable) {
         // the guild is unavailabe due to an outage
     } else {
-        // the bot has been kicked from the guild
+        // the Bot has been kicked from the guild
     }
 });
 ```
 
 ### Guild Member Add
 
-Called with a `Member` object when a member joins a guild.
-Requires the `Intents::GUILD_MEMBERS` intent. This intent is a priviliged intent, it must be enabled in your Discord bot developer settings.
+Called with a `Member` object when a new user joins a guild.
+
+Requires the `Intents::GUILD_MEMBERS` intent. This intent is a priviliged intent, it must be enabled in your Discord Bot developer settings.
 
 ```php
 $discord->on(Event::GUILD_MEMBER_ADD, function (Member $member, Discord $discord) {
@@ -323,19 +350,21 @@ $discord->on(Event::GUILD_MEMBER_ADD, function (Member $member, Discord $discord
 
 ### Guild Member Update
 
-Called with two `Member` objects when a member is updated in a guild. Note that the old version of the member _may_ be `null` if `loadAllMembers` is disabled.
-Requires the `Intents::GUILD_MEMBERS` intent. This intent is a priviliged intent, it must be enabled in your Discord bot developer settings.
+Called with two `Member` objects when a member is updated in a guild. Note that the old member _may_ be `null` if `loadAllMembers` is disabled.
+
+Requires the `Intents::GUILD_MEMBERS` intent. This intent is a priviliged intent, it must be enabled in your Discord Bot developer settings.
 
 ```php
-$discord->on(Event::GUILD_MEMBER_UPDATE, function (Member $new, Discord $discord, Member $old) {
+$discord->on(Event::GUILD_MEMBER_UPDATE, function (Member $member, Discord $discord, Member $oldMember) {
     // ...
 });
 ```
 
 ### Guild Member Remove
 
-Called with a `Member` object when a member leaves a guild (leave/kick/ban). Note that the old version of the member _may_ only have `User` data if `loadAllMembers` is disabled.
-Requires the `Intents::GUILD_MEMBERS` intent. This intent is a priviliged intent, it must be enabled in your Discord bot developer settings.
+Called with a `Member` object when a member is removed from a guild (leave/kick/ban). Note that the member _may_ only have `User` data if `loadAllMembers` is disabled.
+
+Requires the `Intents::GUILD_MEMBERS` intent. This intent is a priviliged intent, it must be enabled in your Discord Bot developer settings.
 
 ```php
 $discord->on(Event::GUILD_MEMBER_REMOVE, function (Member $member, Discord $discord) {
@@ -346,6 +375,7 @@ $discord->on(Event::GUILD_MEMBER_REMOVE, function (Member $member, Discord $disc
 ### Guild Ban Add
 
 Called with a `Ban` object when a member is banned from a guild.
+
 Requires the `Intents::GUILD_BANS` intent.
 
 ```php
@@ -356,7 +386,8 @@ $discord->on(Event::GUILD_BAN_ADD, function (Ban $ban, Discord $discord) {
 
 ### Guild Ban Remove
 
-Called with a `Ban` object when a member is unbanned from a guild.
+Called with a `Ban` object when a user is unbanned from a guild.
+
 Requires the `Intents::GUILD_BANS` intent.
 
 ```php
@@ -368,6 +399,7 @@ $discord->on(Event::GUILD_BAN_REMOVE, function (Ban $ban, Discord $discord) {
 ### Guild Role Create
 
 Called with a `Role` object when a role is created in a guild.
+
 Requires the `Intents::GUILDS` intent.
 
 ```php
@@ -378,11 +410,12 @@ $discord->on(Event::GUILD_ROLE_CREATE, function (Role $role, Discord $discord) {
 
 ### Guild Role Update
 
-Called with two `Role` objects when a role is updated in a guild. 
+Called with two `Role` objects when a role is updated in a guild.
+
 Requires the `Intents::GUILDS` intent.
 
 ```php
-$discord->on(Event::GUILD_ROLE_UPDATE, function (Role $new, Discord $discord, ?Role $old) {
+$discord->on(Event::GUILD_ROLE_UPDATE, function (Role $role, Discord $discord, ?Role $oldRole) {
     // ...
 });
 ```
@@ -390,17 +423,28 @@ $discord->on(Event::GUILD_ROLE_UPDATE, function (Role $new, Discord $discord, ?R
 ### Guild Role Delete
 
 Called with a `Role` object when a role is deleted in a guild. `$role` may return `Role` object if it was cached.
+
 Requires the `Intents::GUILDS` intent.
 
 ```php
 $discord->on(Event::GUILD_ROLE_DELETE, function ($role, Discord $discord) {
-    // ...
+    if ($role instanceof Role) {
+        // Role is present in cache
+    }
+    // If the role is not present in the cache:
+    else {
+        // {
+        //     "guild_id": "" // role guild ID
+        //     "role_id": "", // role ID,
+        // }
+    }
 });
 ```
 
 ### Guild Emojis Update
 
-Called with Collections of `Emoji` object when a guild's emojis are added/updated/deleted. `$oldEmojis` _may_ be empty if it was not cached or there was previously no emojis.
+Called with two Collections of `Emoji` objects when a guild's emojis have been added/updated/deleted. `$oldEmojis` _may_ be empty if it was not cached or there were previously no emojis.
+
 Requires the `Intents::GUILD_EMOJIS_AND_STICKERS` intent.
 
 ```php
@@ -411,7 +455,8 @@ $discord->on(Event::GUILD_EMOJIS_UPDATE, function (Collection $emojis, Discord $
 
 ### Guild Stickers Update
 
-Called with Collections of `Sticker` object when a guild's stickers are added/updated/deleted. `$oldStickers` _may_ be empty if it was not cached or there was previously no stickers.
+Called with two Collections of `Sticker` objects when a guild's stickers have been added/updated/deleted. `$oldStickers` _may_ be empty if it was not cached or there were previously no stickers.
+
 Requires the `Intents::GUILD_EMOJIS_AND_STICKERS` intent.
 
 ```php
@@ -422,7 +467,8 @@ $discord->on(Event::GUILD_STICKERS_UPDATE, function (Collection $stickers, Disco
 
 ### Guild Integrations Update
 
-Called with a `Guild` object when a guild's integrations are updated.
+Called with a cached `Guild` object when a guild integration is updated.
+
 Requires the `Intents::GUILD_INTEGRATIONS` intent.
 
 ```php
@@ -433,7 +479,8 @@ $discord->on(Event::GUILD_INTEGRATIONS_UPDATE, function (?Guild $guild, Discord 
 
 ### Integration Create
 
-Called with an `Integration` object when a guild's integration is created.
+Called with an `Integration` object when an integration is created in a guild.
+
 Requires the `Intents::GUILD_INTEGRATIONS` intent.
 
 ```php
@@ -444,7 +491,8 @@ $discord->on(Event::INTEGRATION_CREATE, function (Integration $integration, Disc
 
 ### Integration Update
 
-Called with an `Integration` object when a guild's integration is updated.
+Called with an `Integration` object when a integration is updated in a guild.
+
 Requires the `Intents::GUILD_INTEGRATIONS` intent.
 
 ```php
@@ -455,19 +503,21 @@ $discord->on(Event::INTEGRATION_UPDATE, function (Integration $integration, Disc
 
 ### Integration Delete
 
-Called with an old `Integration` object when a guild's integration is deleted.
-`$oldIntegration` _may_ be `null` when Integration is not cached.
+Called with an old `Integration` object when a integration is deleted from a guild.
+`$oldIntegration` _may_ be `null` if Integration is not cached.
+
 Requires the `Intents::GUILD_INTEGRATIONS` intent.
 
 ```php
-$discord->on(Event::INTEGRATION_DELETE, function (?Integration $oldIntegration, Discord $discord) {
+$discord->on(Event::INTEGRATION_DELETE, function (?Integration $integration, Discord $discord) {
     // ...
 });
 ```
 
 ### Webhooks Update
 
-Called with a `Guild` and `Channel` object when a guild's webhooks are updated.
+Called with a `Guild` and `Channel` object when a guild channel's webhooks are is created, updated, or deleted.
+
 Requires the `Intents::GUILD_WEBHOOKS` intent.
 
 ```php
@@ -478,7 +528,7 @@ $discord->on(Event::WEBHOOKS_UPDATE, function (?Guild $guild, Discord $discord, 
 
 ### Voice Server Update
 
-Called with a `VoiceServerUpdate` object when a guild's voice server is updated.
+Called with a `VoiceServerUpdate` object when a voice server is updated in a guild.
 
 ```php
 $discord->on(Event::VOICE_SERVER_UPDATE, function (VoiceServerUpdate $guild, Discord $discord) {
@@ -489,6 +539,7 @@ $discord->on(Event::VOICE_SERVER_UPDATE, function (VoiceServerUpdate $guild, Dis
 ### Voice State Update
 
 Called with a `VoiceStateUpdate` object when a member joins, leaves or moves between voice channels.
+
 Requires the `Intents::GUILD_VOICE_STATES` intent.
 
 ```php
@@ -499,7 +550,8 @@ $discord->on(Event::VOICE_STATE_UPDATE, function (VoiceStateUpdate $state, Disco
 
 ### Invite Create
 
-Called with an `Invite` object when an invite is created.
+Called with an `Invite` object when a new invite to a channel is created.
+
 Requires the `Intents::GUILD_INVITES` intent.
 
 ```php
@@ -511,21 +563,29 @@ $discord->on(Event::INVITE_CREATE, function (Invite $invite, Discord $discord) {
 ### Invite Delete
 
 Called with an object when an invite is created.
+
 Requires the `Intents::GUILD_INVITES` intent.
 
 ```php
 $discord->on(Event::INVITE_DELETE, function ($invite, Discord $discord) {
-    // {
-    //     "channel_id": "",
-    //     "guild_id": "",
-    //     "code": "" // the unique invite code
-    // }
+    if ($invite instanceof Invite) {
+        // Invite is present in cache
+    }
+    // If the invite is not present in the cache:
+    else {
+        // {
+        //     "channel_id": "",
+        //     "guild_id": "",
+        //     "code": "" // the unique invite code
+        // }
+    }
 });
 ```
 
 ### Guild Scheduled Event Create
 
-Called with a `ScheduledEvent` object when a guild's scheduled event is created.
+Called with a `ScheduledEvent` object when a scheduled event is created in a guild.
+
 Requires the `Intents::GUILD_SCHEDULED_EVENTS` intent.
 
 ```php
@@ -536,7 +596,8 @@ $discord->on(Event::GUILD_SCHEDULED_EVENT_CREATE, function (ScheduledEvent $sche
 
 ### Guild Scheduled Event Update
 
-Called with a `ScheduledEvent` object when a guild's scheduled event is updated.
+Called with a `ScheduledEvent` object when a scheduled event is updated in a guild.
+
 Requires the `Intents::GUILD_SCHEDULED_EVENTS` intent.
 
 ```php
@@ -547,18 +608,20 @@ $discord->on(Event::GUILD_SCHEDULED_EVENT_UPDATE, function (ScheduledEvent $sche
 
 ### Guild Scheduled Event Delete
 
-Called with an old `ScheduledEvent` object when a guild's scheduled event is deleted.
+Called with a `ScheduledEvent` object when a scheduled event is deleted in a guild.
+
 Requires the `Intents::GUILD_SCHEDULED_EVENTS` intent.
 
 ```php
-$discord->on(Event::GUILD_SCHEDULED_EVENT_UPDATE, function (ScheduledEvent $scheduledEvent, Discord $discord) {
+$discord->on(Event::GUILD_SCHEDULED_EVENT_DELETE, function (ScheduledEvent $scheduledEvent, Discord $discord) {
     // ...
 });
 ```
 
 ### Guild Scheduled Event User Add
 
-Called when a member is added to a guild scheduled event.
+Called when a user has subscribed to a scheduled event in a guild.
+
 Requires the `Intents::GUILD_SCHEDULED_EVENTS` intent.
 
 ```php
@@ -569,7 +632,8 @@ $discord->on(Event::GUILD_SCHEDULED_EVENT_USER_ADD, function ($data, Discord $di
 
 ### Guild Scheduled Event User Remove
 
-Called when a member is removed to a guild scheduled event.
+Called when a user has unsubscribed from a scheduled event in a guild.
+
 Requires the `Intents::GUILD_SCHEDULED_EVENTS` intent.
 
 ```php
@@ -580,7 +644,8 @@ $discord->on(Event::GUILD_SCHEDULED_EVENT_USER_REMOVE, function ($data, Discord 
 
 ### Auto Moderation Rule Create
 
-Called with an `Rule` object when a guild's auto moderation rule is created.
+Called with a `Rule` object when an auto moderation rule is created.
+
 Requires the `Intents::AUTO_MODERATION_CONFIGURATION` intent.
 
 ```php
@@ -591,7 +656,8 @@ $discord->on(Event::AUTO_MODERATION_RULE_CREATE, function (Rule $rule, Discord $
 
 ### Auto Moderation Rule Update
 
-Called with an `Rule` object when a guild's auto moderation rule is updated.
+Called with a `Rule` object when an auto moderation rule is updated.
+
 Requires the `Intents::AUTO_MODERATION_CONFIGURATION` intent.
 
 ```php
@@ -602,22 +668,25 @@ $discord->on(Event::AUTO_MODERATION_RULE_UPDATE, function (Rule $rule, Discord $
 
 ### Auto Moderation Rule Delete
 
-Called with an old `Rule` object when a guild's auto moderation rule is deleted.
+Called with a `Rule` object when an auto moderation rule is deleted.
+
 Requires the `Intents::AUTO_MODERATION_CONFIGURATION` intent.
 
 ```php
-$discord->on(Event::AUTO_MODERATION_RULE_DELETE, function (Rule $oldRule, Discord $discord) {
+$discord->on(Event::AUTO_MODERATION_RULE_DELETE, function (Rule $rule, Discord $discord) {
     // ...
 });
 ```
 
 ### Auto Moderation Action Execution
 
-Called with an `AutoModerationActionExecution` object when a guild's auto moderation rule triggered and an action is executed (e.g. message is blocked).
+Called with an `AutoModerationActionExecution` object when an auto moderation rule is triggered and an action is executed (e.g. when a message is blocked).
+
 Requires the `Intents::AUTO_MODERATION_EXECUTION` intent.
-Note: Be sure to use the correct import `Discord\Parts\WebSockets\AutoModerationActionExecution`
 
 ```php
+// use `Discord\Parts\WebSockets\AutoModerationActionExecution`;
+
 $discord->on(Event::AUTO_MODERATION_ACTION_EXECUTION, function (AutoModerationActionExecution $actionExecution, Discord $discord) {
     // ...
 });
@@ -626,7 +695,7 @@ $discord->on(Event::AUTO_MODERATION_ACTION_EXECUTION, function (AutoModerationAc
 ### Interaction Create
 
 Called with an `Interaction` object when an interaction is created.
-Application Command & Message component listeners are processed prior to this event.
+Application Command & Message component listeners are processed before this event is called.
 Useful if you want to create a customized callback or have interaction response persists after Bot restart.
 
 ```php
@@ -637,7 +706,8 @@ $discord->on(Event::INTERACTION_CREATE, function (Interaction $interaction, Disc
 
 ### Typing Start
 
-Called with a `TypingStart` object when a member starts typing in a channel.
+Called with a `TypingStart` object when a user starts typing in a channel.
+
 Requires the `Intents::GUILD_MESSAGE_TYPING` intent.
 
 ```php
@@ -648,8 +718,9 @@ $discord->on(Event::TYPING_START, function (TypingStart $typing, Discord $discor
 
 ### Presence Update
 
-Called with a `PresenceUpdate` object when a members presence is updated.
-Requires the `Intents::GUILD_PRESENCES` intent. This intent is a priviliged intent, it must be enabled in your Discord bot developer settings.
+Called with a `PresenceUpdate` object when a member's presence is updated.
+
+Requires the `Intents::GUILD_PRESENCES` intent. This intent is a priviliged intent, it must be enabled in your Discord Bot developer settings.
 
 ```php
 $discord->on(Event::PRESENCE_UPDATE, function (PresenceUpdate $presence, Discord $discord) {
@@ -659,7 +730,7 @@ $discord->on(Event::PRESENCE_UPDATE, function (PresenceUpdate $presence, Discord
 
 ### User Update
 
-Called with `User` object when your Bot User data updates.
+Called with `User` object when the Bot's user properties change.
 
 ```php
 $discord->on(Event::USER_UPDATE, function (User $user, Discord $discord, ?User $oldUser) {

--- a/docs/src/pages/api/03_events.md
+++ b/docs/src/pages/api/03_events.md
@@ -7,6 +7,8 @@ title: "Events"
 Called with an `Overwrite` object when an application command's permissions are updated.
 
 ```php
+// use Discord\Parts\Interactions\Command\Overwrite;
+
 $discord->on(Event::APPLICATION_COMMAND_PERMISSIONS_UPDATE, function (Overwrite $overwrite, Discord $discord, Overwrite $oldOverwrite) {
     // ...
 });
@@ -469,6 +471,8 @@ Application Command & Message component listeners are processed before this even
 Useful if you want to create a customized callback or have interaction response persists after Bot restart.
 
 ```php
+// use Discord\Parts\Interactions\Interaction;
+
 $discord->on(Event::INTERACTION_CREATE, function (Interaction $interaction, Discord $discord) {
     // ...
 });
@@ -690,6 +694,8 @@ Called with a `TypingStart` object when a user starts typing in a channel.
 Requires the `Intents::GUILD_MESSAGE_TYPING` intent.
 
 ```php
+// use Discord\Parts\WebSockets\TypingStart;
+
 $discord->on(Event::TYPING_START, function (TypingStart $typing, Discord $discord) {
     // ...
 });
@@ -712,6 +718,8 @@ Called with a `VoiceStateUpdate` object when a member joins, leaves or moves bet
 Requires the `Intents::GUILD_VOICE_STATES` intent.
 
 ```php
+// use Discord\Parts\WebSockets\VoiceStateUpdate;
+
 $discord->on(Event::VOICE_STATE_UPDATE, function (VoiceStateUpdate $state, Discord $discord, $oldstate) {
     // ...
 });
@@ -722,6 +730,8 @@ $discord->on(Event::VOICE_STATE_UPDATE, function (VoiceStateUpdate $state, Disco
 Called with a `VoiceServerUpdate` object when a voice server is updated in a guild.
 
 ```php
+// use Discord\Parts\WebSockets\VoiceServerUpdate;
+
 $discord->on(Event::VOICE_SERVER_UPDATE, function (VoiceServerUpdate $guild, Discord $discord) {
     // ...
 });


### PR DESCRIPTION
Fixed some typos, wording, add a little more example, and re-order the events based on the list on discord api docs: https://discord.com/developers/docs/topics/gateway#commands-and-events-gateway-events

The second commit is the re-order, exclude that if you want to review the typos and corrections