### PR TITLE
Remove custom ID (not working) and re-arrange code block

### DIFF
--- a/docs/src/pages/api/03_events/02_auto_moderations.md
+++ b/docs/src/pages/api/03_events/02_auto_moderations.md
@@ -8,19 +8,17 @@ All auto moderation related events are currently only sent to bot users which ha
 
 Called with a `Rule` object when an auto moderation rule is created.
 
-Requires the `Intents::AUTO_MODERATION_CONFIGURATION` intent.
-
 ```php
 $discord->on(Event::AUTO_MODERATION_RULE_CREATE, function (Rule $rule, Discord $discord) {
     // ...
 });
 ```
 
+Requires the `Intents::AUTO_MODERATION_CONFIGURATION` intent.
+
 ### Auto Moderation Rule Update
 
 Called with a `Rule` object when an auto moderation rule is updated.
-
-Requires the `Intents::AUTO_MODERATION_CONFIGURATION` intent.
 
 ```php
 $discord->on(Event::AUTO_MODERATION_RULE_UPDATE, function (Rule $rule, Discord $discord, Rule $oldRule) {
@@ -32,19 +30,17 @@ $discord->on(Event::AUTO_MODERATION_RULE_UPDATE, function (Rule $rule, Discord $
 
 Called with a `Rule` object when an auto moderation rule is deleted.
 
-Requires the `Intents::AUTO_MODERATION_CONFIGURATION` intent.
-
 ```php
 $discord->on(Event::AUTO_MODERATION_RULE_DELETE, function (Rule $rule, Discord $discord) {
     // ...
 });
 ```
 
+Requires the `Intents::AUTO_MODERATION_CONFIGURATION` intent.
+
 ### Auto Moderation Action Execution
 
 Called with an `AutoModerationActionExecution` object when an auto moderation rule is triggered and an action is executed (e.g. when a message is blocked).
-
-Requires the `Intents::AUTO_MODERATION_EXECUTION` intent.
 
 ```php
 // use `Discord\Parts\WebSockets\AutoModerationActionExecution`;
@@ -53,3 +49,5 @@ $discord->on(Event::AUTO_MODERATION_ACTION_EXECUTION, function (AutoModerationAc
     // ...
 });
 ```
+
+Requires the `Intents::AUTO_MODERATION_EXECUTION` intent.

--- a/docs/src/pages/api/03_events/03_channels.md
+++ b/docs/src/pages/api/03_events/03_channels.md
@@ -38,8 +38,6 @@ $discord->on(Event::CHANNEL_DELETE, function (Channel $channel, Discord $discord
 
 Called with an object when a message is pinned or unpinned in a text channel. This is not sent when a pinned message is deleted.
 
-> For direct messages, it only requires the `Intents::DIRECT_MESSAGES` intent.
-
 ```php
 $discord->on(Event::CHANNEL_PINS_UPDATE, function ($pins, Discord $discord) {
     // {
@@ -49,6 +47,8 @@ $discord->on(Event::CHANNEL_PINS_UPDATE, function ($pins, Discord $discord) {
     // }
 });
 ```
+
+> For direct messages, it only requires the `Intents::DIRECT_MESSAGES` intent.
 
 ## Threads
 

--- a/docs/src/pages/api/03_events/04_guilds.md
+++ b/docs/src/pages/api/03_events/04_guilds.md
@@ -46,7 +46,7 @@ $discord->on(Event::GUILD_DELETE, function (?Guild $guild, Discord $discord, boo
 });
 ```
 
-## Guild Bans {#guild_bans}
+## Guild Bans
 
 Requires the `Intents::GUILD_BANS` intent and `ban_members` permission.
 
@@ -70,7 +70,7 @@ $discord->on(Event::GUILD_BAN_REMOVE, function (Ban $ban, Discord $discord) {
 });
 ```
 
-## Guild Emojis and Stickers {#guild_emojis_and_stickers}
+## Guild Emojis and Stickers
 
 Requires the `Intents::GUILD_EMOJIS_AND_STICKERS` intent.
 
@@ -95,7 +95,7 @@ $discord->on(Event::GUILD_STICKERS_UPDATE, function (Collection $stickers, Disco
 });
 ```
 
-## Guild Members {#guild_members}
+## Guild Members
 
 Requires the `Intents::GUILD_MEMBERS` intent. This intent is a priviliged intent, it must be enabled in your Discord Bot developer settings.
 
@@ -129,7 +129,7 @@ $discord->on(Event::GUILD_MEMBER_UPDATE, function (Member $member, Discord $disc
 });
 ```
 
-## Guild Roles {#guild_roles}
+## Guild Roles
 
 Requires the `Intents::GUILDS` intent.
 
@@ -172,7 +172,7 @@ $discord->on(Event::GUILD_ROLE_DELETE, function ($role, Discord $discord) {
 });
 ```
 
-## Guild Scheduled Events {#guild_scheduled_events}
+## Guild Scheduled Events
 
 Requires the `Intents::GUILD_SCHEDULED_EVENTS` intent.
 

--- a/docs/src/pages/api/03_events/06_interactions.md
+++ b/docs/src/pages/api/03_events/06_interactions.md
@@ -5,8 +5,6 @@ title: "Interactions"
 ### Interaction Create
 
 Called with an `Interaction` object when an interaction is created.
-Application Command & Message component listeners are processed before this event is called.
-Useful if you want to create a customized callback or have interaction response persists after Bot restart.
 
 ```php
 // use Discord\Parts\Interactions\Interaction;
@@ -15,3 +13,6 @@ $discord->on(Event::INTERACTION_CREATE, function (Interaction $interaction, Disc
     // ...
 });
 ```
+
+Application Command & Message component listeners are processed before this event is called.
+Useful if you want to create a customized callback or have interaction response persists after Bot restart.

--- a/docs/src/pages/api/03_events/07_messages.md
+++ b/docs/src/pages/api/03_events/07_messages.md
@@ -74,7 +74,7 @@ $discord->on(Event::MESSAGE_DELETE_BULK, function (Collection $messages, Discord
 });
 ```
 
-## Message Reactions {#message_reactions}
+## Message Reactions
 
 Requires the `Intents::GUILD_MESSAGE_REACTIONS` intent for guild or `Intents::DIRECT_MESSAGE_REACTIONS` for direct messages.
 

--- a/docs/src/pages/api/03_events/08_presences.md
+++ b/docs/src/pages/api/03_events/08_presences.md
@@ -6,19 +6,17 @@ title: "Presences"
 
 Called with a `PresenceUpdate` object when a member's presence is updated.
 
-Requires the `Intents::GUILD_PRESENCES` intent. This intent is a priviliged intent, it must be enabled in your Discord Bot developer settings.
-
 ```php
 $discord->on(Event::PRESENCE_UPDATE, function (PresenceUpdate $presence, Discord $discord) {
     // ...
 });
 ```
 
+Requires the `Intents::GUILD_PRESENCES` intent. This intent is a priviliged intent, it must be enabled in your Discord Bot developer settings.
+
 ### Typing Start
 
 Called with a `TypingStart` object when a user starts typing in a channel.
-
-Requires the `Intents::GUILD_MESSAGE_TYPING` intent.
 
 ```php
 // use Discord\Parts\WebSockets\TypingStart;
@@ -27,6 +25,8 @@ $discord->on(Event::TYPING_START, function (TypingStart $typing, Discord $discor
     // ...
 });
 ```
+
+Requires the `Intents::GUILD_MESSAGE_TYPING` intent.
 
 ### User Update
 

--- a/docs/src/pages/api/03_events/10_voices.md
+++ b/docs/src/pages/api/03_events/10_voices.md
@@ -6,8 +6,6 @@ title: "Voices"
 
 Called with a `VoiceStateUpdate` object when a member joins, leaves or moves between voice channels.
 
-Requires the `Intents::GUILD_VOICE_STATES` intent.
-
 ```php
 // use Discord\Parts\WebSockets\VoiceStateUpdate;
 
@@ -15,6 +13,8 @@ $discord->on(Event::VOICE_STATE_UPDATE, function (VoiceStateUpdate $state, Disco
     // ...
 });
 ```
+
+Requires the `Intents::GUILD_VOICE_STATES` intent.
 
 ### Voice Server Update
 

--- a/docs/src/pages/api/03_events/11_webhooks.md
+++ b/docs/src/pages/api/03_events/11_webhooks.md
@@ -6,10 +6,10 @@ title: "Webhooks"
 
 Called with a `Guild` and `Channel` object when a guild channel's webhooks are is created, updated, or deleted.
 
-Requires the `Intents::GUILD_WEBHOOKS` intent.
-
 ```php
 $discord->on(Event::WEBHOOKS_UPDATE, function (?Guild $guild, Discord $discord, ?Channel $channel) {
     // ...
 });
 ```
+
+Requires the `Intents::GUILD_WEBHOOKS` intent.


### PR DESCRIPTION
Follow up to #876, since the custom id {#custom id} does not work and also re-arrange the code block on the side.

Can be merged any time.