### PR TITLE
remove libsodium polyfill

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,6 @@
         "trafficcophp/bytebuffer": "^0.3",
         "monolog/monolog": "^2.1 || ^3.0",
         "react/partial": "^3.0",
-        "mollie/polyfill-libsodium": "^1.1",
         "react/http": "^1.1",
         "ext-json": "*",
         "ext-zlib": "*",

--- a/src/Discord/Voice/VoiceClient.php
+++ b/src/Discord/Voice/VoiceClient.php
@@ -1262,7 +1262,7 @@ class VoiceClient extends EventEmitter
         $voicePacket = VoicePacket::make($message);
         $nonce = new Buffer(24);
         $nonce->write($voicePacket->getHeader(), 0);
-        $message = \Sodium\crypto_secretbox_open($voicePacket->getData(), (string) $nonce, $this->secret_key);
+        $message = \sodium_crypto_secretbox_open($voicePacket->getData(), (string) $nonce, $this->secret_key);
 
         if ($message === false) {
             // if we can't decode the message, drop it silently.
@@ -1402,7 +1402,7 @@ class VoiceClient extends EventEmitter
      */
     private function checkForLibsodium(): bool
     {
-        if (! function_exists('\Sodium\crypto_secretbox')) {
+        if (! function_exists('sodium_crypto_secretbox')) {
             $this->emit('error', [new LibSodiumNotFoundException('libsodium-php could not be found.')]);
 
             return false;

--- a/src/Discord/Voice/VoicePacket.php
+++ b/src/Discord/Voice/VoicePacket.php
@@ -11,8 +11,6 @@
 
 namespace Discord\Voice;
 
-use function Sodium\crypto_secretbox;
-
 /**
  * A voice packet received from Discord.
  */
@@ -118,7 +116,7 @@ class VoicePacket
         $nonce = new Buffer(24);
         $nonce->write((string) $header, 0);
 
-        $data = crypto_secretbox($data, (string) $nonce, $key);
+        $data = \sodium_crypto_secretbox($data, (string) $nonce, $key);
 
         $this->buffer = new Buffer(strlen((string) $header) + strlen($data));
         $this->buffer->write((string) $header, 0);


### PR DESCRIPTION
The polyfill was for migrating code prior to PHP 7.2

It is no longer needed as it comes with PHP now