### PR TITLE
fix autocomplete no subcommand

### DIFF
--- a/src/Discord/WebSockets/Events/InteractionCreate.php
+++ b/src/Discord/WebSockets/Events/InteractionCreate.php
@@ -67,6 +67,8 @@ class InteractionCreate extends Event
                             if (! empty($option->options)) {
                                 return $checkCommand($subCommand, $option->options);
                             }
+                        } elseif (! empty($option->focused)) {
+                            return $command->suggest($interaction);
                         }
                     }
                     return false;


### PR DESCRIPTION
Follow up to #894 which is already patched to [7.2.6](https://github.com/discord-php/DiscordPHP/releases/tag/v7.2.6)

Please merge immediately.