### PR TITLE
Add AuditLog::application_commands and Integration::scopes

### DIFF
--- a/src/Discord/Parts/Guild/AuditLog/AuditLog.php
+++ b/src/Discord/Parts/Guild/AuditLog/AuditLog.php
@@ -68,7 +68,7 @@ class AuditLog extends Part
     }
 
     /**
-     * Returns a collection of webhooks found in the audit log.
+     * Returns a collection of application commands found in the audit log.
      *
      * @return Collection|Command[]
      */
@@ -77,7 +77,7 @@ class AuditLog extends Part
         $collection = Collection::for(Command::class);
 
         foreach ($this->attributes['application_commands'] ?? [] as $application_commands) {
-            $collection->pushItem($this->factory->create(Webhook::class, $application_commands, true));
+            $collection->pushItem($this->factory->create(Command::class, $application_commands, true));
         }
 
         return $collection;

--- a/src/Discord/Parts/Guild/AuditLog/AuditLog.php
+++ b/src/Discord/Parts/Guild/AuditLog/AuditLog.php
@@ -16,6 +16,7 @@ use Discord\Parts\Channel\Webhook;
 use Discord\Parts\Guild\AutoModeration\Rule;
 use Discord\Parts\Guild\Guild;
 use Discord\Parts\Guild\ScheduledEvent;
+use Discord\Parts\Interactions\Command\Command;
 use Discord\Parts\Part;
 use Discord\Parts\Thread\Thread;
 use Discord\Parts\User\User;
@@ -26,6 +27,7 @@ use ReflectionClass;
  *
  * @see https://discord.com/developers/docs/resources/audit-log#audit-log-object
  *
+ * @property Collection|Command               $application_commands   List of application commands referenced in the audit log.
  * @property Collection|Entry[]               $audit_log_entries      List of audit log entries.
  * @property Collection|Rule[]                $auto_moderation_rules  List of auto moderation rules referenced in the audit log.
  * @property Collection|GuildScheduledEvent[] $guild_scheduled_events List of guild scheduled events referenced in the audit log.
@@ -42,6 +44,7 @@ class AuditLog extends Part
      * @inheritdoc
      */
     protected $fillable = [
+        'application_commands',
         'webhooks',
         'auto_moderation_rules',
         'guild_scheduled_events',
@@ -62,6 +65,22 @@ class AuditLog extends Part
     protected function getGuildAttribute(): ?Guild
     {
         return $this->discord->guilds->get('id', $this->guild_id);
+    }
+
+    /**
+     * Returns a collection of webhooks found in the audit log.
+     *
+     * @return Collection|Command[]
+     */
+    protected function getApplicationCommandsAttribute(): Collection
+    {
+        $collection = Collection::for(Command::class);
+
+        foreach ($this->attributes['application_commands'] ?? [] as $application_commands) {
+            $collection->pushItem($this->factory->create(Webhook::class, $application_commands, true));
+        }
+
+        return $collection;
     }
 
     /**

--- a/src/Discord/Parts/Guild/Integration.php
+++ b/src/Discord/Parts/Guild/Integration.php
@@ -37,6 +37,7 @@ use Discord\Parts\User\User;
  * @property int|null         $subscriber_count    How many subscribers this integration has.
  * @property bool|null        $revoked             Has this integration been revoked.
  * @property Application|null $application         The bot/OAuth2 application for discord integrations.
+ * @property array|null       $scopes              The scopes the application has been authorized for.
  * @property Guild|null       $guild
  */
 class Integration extends Part
@@ -60,6 +61,7 @@ class Integration extends Part
         'subscriber_count',
         'revoked',
         'application',
+        'scopes',
         'guild_id',
     ];
 

--- a/src/Discord/WebSockets/Intents.php
+++ b/src/Discord/WebSockets/Intents.php
@@ -152,6 +152,7 @@ class Intents
     public const DIRECT_MESSAGE_TYPING = (1 << 14);
 
     public const MESSAGE_CONTENT = (1 << 15);
+
     /**
      * Guild scheduled events events:.
      *


### PR DESCRIPTION
This is a cherry-pick from [v7.3.0](https://github.com/discord-php/DiscordPHP/releases/tag/v7.3.0). Can be merged immediately.

Reference:
- https://github.com/discord/discord-api-docs/pull/5311
- https://github.com/discord/discord-api-docs/pull/5252