### PR TITLE
Fix command builders and Promise error handling

### DIFF
--- a/src/Discord/Builders/CommandAttributes.php
+++ b/src/Discord/Builders/CommandAttributes.php
@@ -75,7 +75,7 @@ trait CommandAttributes
             throw new \LengthException('Command name can be only up to 32 characters long.');
         }
 
-        if (isset($this->type) && Command::CHAT_INPUT == Command::CHAT_INPUT && preg_match('/^[-_\p{L}\p{N}\p{Devanagari}\p{Thai}]{1,32}$/u', $name) === 0) {
+        if (isset($this->type) && $this->type == Command::CHAT_INPUT && preg_match('/^[-_\p{L}\p{N}\p{Devanagari}\p{Thai}]{1,32}$/u', $name) === 0) {
             throw new \DomainException('Slash command name contains invalid characters.');
         }
 

--- a/src/Discord/Builders/CommandAttributes.php
+++ b/src/Discord/Builders/CommandAttributes.php
@@ -75,7 +75,7 @@ trait CommandAttributes
             throw new \LengthException('Command name can be only up to 32 characters long.');
         }
 
-        if ($this->type == Command::CHAT_INPUT && preg_match('/^[-_\p{L}\p{N}\p{Devanagari}\p{Thai}]{1,32}$/u', $name) === 0) {
+        if (isset($this->type) && Command::CHAT_INPUT == Command::CHAT_INPUT && preg_match('/^[-_\p{L}\p{N}\p{Devanagari}\p{Thai}]{1,32}$/u', $name) === 0) {
             throw new \DomainException('Slash command name contains invalid characters.');
         }
 
@@ -109,6 +109,8 @@ trait CommandAttributes
                 throw new \DomainException('Slash command localized name contains invalid characters.');
             }
         }
+
+        $this->name_localizations ??= [];
 
         $this->name_localizations[$locale] = $name;
 
@@ -150,9 +152,11 @@ trait CommandAttributes
      */
     public function setDescriptionLocalization(string $locale, ?string $description): self
     {
-        if (isset($description) && $this->type == Command::CHAT_INPUT && poly_strlen($description) > 100) {
+        if (isset($description, $this->type) && $this->type == Command::CHAT_INPUT && poly_strlen($description) > 100) {
             throw new \LengthException('Command description must be less than or equal to 100 characters.');
         }
+
+        $this->description_localizations ??= [];
 
         $this->description_localizations[$locale] = $description;
 
@@ -215,13 +219,15 @@ trait CommandAttributes
      */
     public function addOption(Option $option): self
     {
-        if ($this->type != Command::CHAT_INPUT) {
+        if (isset($this->type) && $this->type != Command::CHAT_INPUT) {
             throw new \DomainException('Only CHAT_INPUT Command type can have option.');
         }
 
         if (isset($this->options) && count($this->options) >= 25) {
             throw new \OverflowException('Command can only have a maximum of 25 options.');
         }
+
+        $this->options ??= [];
 
         $this->options[] = $option;
 
@@ -239,7 +245,7 @@ trait CommandAttributes
      */
     public function removeOption(Option $option): self
     {
-        if ($this->type != Command::CHAT_INPUT) {
+        if (isset($this->type) && $this->type != Command::CHAT_INPUT) {
             throw new \DomainException('Only CHAT_INPUT Command type can have option.');
         }
 

--- a/src/Discord/Discord.php
+++ b/src/Discord/Discord.php
@@ -780,7 +780,13 @@ class Discord
                     $this->emit('mention', [$new, $this, $old]);
                 }
             }, function ($e) use ($data) {
-                $this->logger->warning('error while trying to handle dispatch packet', ['packet' => $data->t, 'error' => $e]);
+                if ($e instanceof \Error) {
+                    throw $e;
+                } elseif ($e instanceof \Exception) {
+                    $this->logger->error('exception while trying to handle dispatch packet', ['packet' => $data->t, 'exception' => $e]);
+                } else {
+                    $this->logger->warning('rejection while trying to handle dispatch packet', ['packet' => $data->t, 'rejection' => $e]);
+                }
             }, function ($d) use ($data) {
                 $this->logger->warning('notified from event', ['data' => $d, 'packet' => $data->t]);
             });

--- a/src/Discord/Discord.php
+++ b/src/Discord/Discord.php
@@ -787,8 +787,6 @@ class Discord
                 } else {
                     $this->logger->warning('rejection while trying to handle dispatch packet', ['packet' => $data->t, 'rejection' => $e]);
                 }
-            }, function ($d) use ($data) {
-                $this->logger->warning('notified from event', ['data' => $d, 'packet' => $data->t]);
             });
 
             $parse = [

--- a/src/Discord/Parts/Interactions/Command/Choice.php
+++ b/src/Discord/Parts/Interactions/Command/Choice.php
@@ -96,7 +96,7 @@ class Choice extends Part
             }
         }
 
-        $this->name_localizations[$locale] = $name;
+        $this->attributes['name_localizations'][$locale] = $name;
 
         return $this;
     }

--- a/src/Discord/Parts/Interactions/Command/Option.php
+++ b/src/Discord/Parts/Interactions/Command/Option.php
@@ -170,7 +170,7 @@ class Option extends Part
             throw new \LengthException('Name must be less than or equal to 32 characters.');
         }
 
-        $this->name_localizations[$locale] = $name;
+        $this->attributes['name_localizations'][$locale] = $name;
 
         return $this;
     }
@@ -211,7 +211,7 @@ class Option extends Part
             throw new \LengthException('Description must be less than or equal to 100 characters.');
         }
 
-        $this->description_localizations[$locale] = $description;
+        $this->attributes['description_localizations'][$locale] = $description;
 
         return $this;
     }


### PR DESCRIPTION
Cherry picked from v7 branch ff372aade73141e446f67f86226aef40873c55a3

This add checks for properties that are not set especially when used in trait, which was throwing PHP notice `Indirect modification of overloaded property Discord\Parts\Interactions\Command\Command::$options has no effect` when used in array read + append.
For the Part class, it is set from attributes array instead.

Thanks to mrWorst#0856 for reporting on Discord!