### PR TITLE
Fix game activity, Update channel name type constants, fix return type and internal phpdoc, and more

### DIFF
--- a/src/Discord/Builders/MessageBuilder.php
+++ b/src/Discord/Builders/MessageBuilder.php
@@ -261,7 +261,7 @@ class MessageBuilder implements JsonSerializable
     /**
      * Sets the embeds for the message. Clears the existing embeds in the process.
      *
-     * @param array $embeds
+     * @param Embed[]|array $embeds
      *
      * @return self
      */
@@ -274,6 +274,8 @@ class MessageBuilder implements JsonSerializable
 
     /**
      * Sets the allowed mentions object of the message.
+     *
+     * @link https://discord.com/developers/docs/resources/channel#allowed-mentions-object
      *
      * @param array $allowed_mentions
      *

--- a/src/Discord/Builders/MessageBuilder.php
+++ b/src/Discord/Builders/MessageBuilder.php
@@ -549,8 +549,9 @@ class MessageBuilder implements JsonSerializable
 
     /**
      * Sets the flags of the message.
+     * You cannot set flags except for when sending webhooks or interaction. Use the APIs given.
      *
-     * @internal You cannot set flags except for when sending webhooks or interaction. Use the APIs given.
+     * @internal
      *
      * @param int $flags
      *

--- a/src/Discord/Helpers/BigInt.php
+++ b/src/Discord/Helpers/BigInt.php
@@ -23,8 +23,9 @@ final class BigInt
 
     /**
      * Run a single check whether the GMP extension is loaded.
+     * Internally used during Discord class construct.
      *
-     * @internal internally used during Discord class construct.
+     * @internal
      *
      * @return bool true if GMP extension is loaded
      */

--- a/src/Discord/Parts/Channel/Channel.php
+++ b/src/Discord/Parts/Channel/Channel.php
@@ -91,18 +91,37 @@ use function React\Promise\resolve;
  */
 class Channel extends Part
 {
-    public const TYPE_TEXT = 0;
+    public const TYPE_GUILD_TEXT = 0;
     public const TYPE_DM = 1;
-    public const TYPE_VOICE = 2;
-    public const TYPE_GROUP = 3;
-    public const TYPE_CATEGORY = 4;
-    public const TYPE_NEWS = 5;
-    public const TYPE_NEWS_THREAD = 10;
+    public const TYPE_GUILD_VOICE = 2;
+    public const TYPE_GROUP_DM = 3;
+    public const TYPE_GUILD_CATEGORY = 4;
+    public const TYPE_GUILD_ANNOUNCEMENT = 5;
+    public const TYPE_ANNOUNCEMENT_THREAD = 10;
     public const TYPE_PUBLIC_THREAD = 11;
     public const TYPE_PRIVATE_THREAD = 12;
-    public const TYPE_STAGE_CHANNEL = 13;
-    public const TYPE_DIRECTORY = 14;
-    public const TYPE_FORUM = 15;
+    public const TYPE_GUILD_STAGE_VOICE = 13;
+    public const TYPE_GUILD_DIRECTORY = 14;
+    public const TYPE_GUILD_FORUM = 15;
+
+    /** @deprecated 10.0.0 Use `Channel::TYPE_GUILD_TEXT` */
+    public const TYPE_TEXT = self::TYPE_GUILD_TEXT;
+    /** @deprecated 10.0.0 Use `Channel::TYPE_GUILD_VOICE` */
+    public const TYPE_VOICE = self::TYPE_GUILD_VOICE;
+    /** @deprecated 10.0.0 Use `Channel::TYPE_GROUP_DM` */
+    public const TYPE_GROUP = self::TYPE_GROUP_DM;
+    /** @deprecated 10.0.0 Use `Channel::TYPE_GUILD_CATEGORY` */
+    public const TYPE_CATEGORY = self::TYPE_GUILD_CATEGORY;
+    /** @deprecated 10.0.0 Use `Channel::TYPE_GUILD_ANNOUNCEMENT` */
+    public const TYPE_NEWS = self::TYPE_GUILD_ANNOUNCEMENT;
+    /** @deprecated 10.0.0 Use `Channel::TYPE_ANNOUNCEMENT_THREAD` */
+    public const TYPE_NEWS_THREAD = self::TYPE_ANNOUNCEMENT_THREAD;
+    /** @deprecated 10.0.0 Use `Channel::TYPE_GUILD_STAGE_VOICE` */
+    public const TYPE_STAGE_CHANNEL = self::TYPE_GUILD_STAGE_VOICE;
+    /** @deprecated 10.0.0 Use `Channel::TYPE_GUILD_DIRECTORY` */
+    public const TYPE_DIRECTORY = self::TYPE_GUILD_DIRECTORY;
+    /** @deprecated 10.0.0 Use `Channel::TYPE_GUILD_FORUM` */
+    public const TYPE_FORUM = self::TYPE_GUILD_FORUM;
 
     public const VIDEO_QUALITY_AUTO = 1;
     public const VIDEO_QUALITY_FULL = 2;

--- a/src/Discord/Parts/Channel/Channel.php
+++ b/src/Discord/Parts/Channel/Channel.php
@@ -189,7 +189,7 @@ class Channel extends Part
      */
     protected function afterConstruct(): void
     {
-        if (! array_key_exists('bitrate', $this->attributes) && $this->type != self::TYPE_TEXT) {
+        if (! array_key_exists('bitrate', $this->attributes) && $this->type != self::TYPE_GUILD_TEXT) {
             $this->bitrate = 64000;
         }
     }
@@ -201,7 +201,7 @@ class Channel extends Part
      */
     protected function getIsPrivateAttribute(): bool
     {
-        return in_array($this->type, [self::TYPE_DM, self::TYPE_GROUP]);
+        return in_array($this->type, [self::TYPE_DM, self::TYPE_GROUP_DM]);
     }
 
     /**
@@ -803,14 +803,14 @@ class Channel extends Part
             return reject(new \RuntimeException('Guild does not have access to private threads.'));
         }
 
-        if ($this->type == Channel::TYPE_NEWS) {
+        if ($this->type == self::TYPE_GUILD_ANNOUNCEMENT) {
             if ($private) {
                 return reject(new \RuntimeException('You cannot start a private thread within a news channel.'));
             }
 
-            $type = Channel::TYPE_NEWS_THREAD;
-        } elseif ($this->type == Channel::TYPE_TEXT) {
-            $type = $private ? Channel::TYPE_PRIVATE_THREAD : Channel::TYPE_PUBLIC_THREAD;
+            $type = self::TYPE_ANNOUNCEMENT_THREAD;
+        } elseif ($this->type == self::TYPE_GUILD_TEXT) {
+            $type = $private ? self::TYPE_PRIVATE_THREAD : self::TYPE_PUBLIC_THREAD;
         } else {
             return reject(new \RuntimeException('You cannot start a thread in this type of channel.'));
         }
@@ -1028,7 +1028,7 @@ class Channel extends Part
      */
     public function allowText()
     {
-        return in_array($this->type, [self::TYPE_TEXT, self::TYPE_DM, self::TYPE_VOICE, self::TYPE_GROUP, self::TYPE_NEWS]);
+        return in_array($this->type, [self::TYPE_GUILD_TEXT, self::TYPE_DM, self::TYPE_GUILD_VOICE, self::TYPE_GROUP_DM, self::TYPE_GUILD_ANNOUNCEMENT]);
     }
 
     /**
@@ -1038,7 +1038,7 @@ class Channel extends Part
      */
     public function allowVoice()
     {
-        return in_array($this->type, [self::TYPE_VOICE, self::TYPE_STAGE_CHANNEL]);
+        return in_array($this->type, [self::TYPE_GUILD_VOICE, self::TYPE_GUILD_STAGE_VOICE]);
     }
 
     /**
@@ -1048,7 +1048,7 @@ class Channel extends Part
      */
     public function allowInvite()
     {
-        return in_array($this->type, [self::TYPE_TEXT, self::TYPE_VOICE, self::TYPE_NEWS, self::TYPE_STAGE_CHANNEL, self::TYPE_FORUM]);
+        return in_array($this->type, [self::TYPE_GUILD_TEXT, self::TYPE_GUILD_VOICE, self::TYPE_GUILD_ANNOUNCEMENT, self::TYPE_GUILD_STAGE_VOICE, self::TYPE_GUILD_FORUM]);
     }
 
     /**

--- a/src/Discord/Parts/Channel/Channel.php
+++ b/src/Discord/Parts/Channel/Channel.php
@@ -910,6 +910,8 @@ class Channel extends Part
     /**
      * Sends an embed to the channel.
      *
+     * @deprecated 10.0.0 Use `Channel::sendMessage` with `MessageBuilder::addEmbed()`
+     *
      * @see Channel::sendMessage()
      *
      * @param Embed $embed Embed to send.
@@ -925,14 +927,14 @@ class Channel extends Part
     /**
      * Sends a file to the channel.
      *
+     * @deprecated 7.0.0 Use `Channel::sendMessage` to send files.
+     *
      * @see Channel::sendMessage()
      *
      * @param string      $filepath The path to the file to be sent.
      * @param string|null $filename The name to send the file as.
      * @param string|null $content  Message content to send with the file.
      * @param bool        $tts      Whether to send the message with TTS.
-     *
-     * @deprecated 7.0.0 Use `Channel::sendMessage` to send files.
      *
      * @return ExtendedPromiseInterface<Message>
      */

--- a/src/Discord/Parts/Channel/Message.php
+++ b/src/Discord/Parts/Channel/Message.php
@@ -691,7 +691,7 @@ class Message extends Part
     public function startThread(string $name, int $auto_archive_duration = 1440, ?string $reason = null): ExtendedPromiseInterface
     {
         $channel = $this->channel;
-        if ($channel && ! in_array($channel->type, [Channel::TYPE_TEXT, Channel::TYPE_NEWS, null])) {
+        if ($channel && ! in_array($channel->type, [Channel::TYPE_GUILD_TEXT, Channel::TYPE_GUILD_ANNOUNCEMENT, null])) {
             return reject(new \RuntimeException('You can only start threads on guild text channels or news channels.'));
         }
 

--- a/src/Discord/Parts/Embed/Embed.php
+++ b/src/Discord/Parts/Embed/Embed.php
@@ -20,6 +20,8 @@ use function Discord\poly_strlen;
 /**
  * An embed object to be sent with a message.
  *
+ * @link https://discord.com/developers/docs/resources/channel#embed-object
+ *
  * @since 4.0.3
  *
  * @property string|null        $title       The title of the embed.

--- a/src/Discord/Parts/Guild/GuildTemplate.php
+++ b/src/Discord/Parts/Guild/GuildTemplate.php
@@ -86,7 +86,7 @@ class GuildTemplate extends Part
      *
      * @return User
      */
-    protected function getCreatorAttribute(): Part
+    protected function getCreatorAttribute(): User
     {
         if ($creator = $this->discord->users->get('id', $this->creator_id)) {
             return $creator;

--- a/src/Discord/Parts/Guild/Sticker.php
+++ b/src/Discord/Parts/Guild/Sticker.php
@@ -12,6 +12,7 @@
 namespace Discord\Parts\Guild;
 
 use Discord\Parts\Part;
+use Discord\Parts\User\User;
 
 /**
  * A sticker that can be sent in a Discord message.
@@ -94,7 +95,7 @@ class Sticker extends Part
      *
      * @return User|null
      */
-    protected function getUserAttribute(): ?Part
+    protected function getUserAttribute(): ?User
     {
         if (! isset($this->attributes['user'])) {
             return null;

--- a/src/Discord/Parts/Interactions/Request/Resolved.php
+++ b/src/Discord/Parts/Interactions/Request/Resolved.php
@@ -163,7 +163,7 @@ class Resolved extends Part
             }
 
             if (! $channelPart) {
-                if (in_array($channel->type, [Channel::TYPE_NEWS_THREAD, Channel::TYPE_PRIVATE_THREAD, Channel::TYPE_PUBLIC_THREAD])) {
+                if (in_array($channel->type, [Channel::TYPE_ANNOUNCEMENT_THREAD, Channel::TYPE_PRIVATE_THREAD, Channel::TYPE_PUBLIC_THREAD])) {
                     $channelPart = $this->factory->part(Thread::class, (array) $channel + ['guild_id' => $this->guild_id], true);
                 } else {
                     $channelPart = $this->factory->part(Channel::class, (array) $channel + ['guild_id' => $this->guild_id], true);

--- a/src/Discord/Parts/Thread/Thread.php
+++ b/src/Discord/Parts/Thread/Thread.php
@@ -709,12 +709,14 @@ class Thread extends Part
     /**
      * Sends an embed to the thread.
      *
+     * @deprecated 10.0.0 Use `Channel::sendMessage` with `MessageBuilder::addEmbed()`
+     *
      * @see Thread::sendMessage()
      *
      * @param Embed $embed Embed to send.
      *
      * @return ExtendedPromiseInterface<Message>
-     * 
+     *
      * @todo Make it in a trait along with Channel
      */
     public function sendEmbed(Embed $embed): ExtendedPromiseInterface

--- a/src/Discord/Parts/User/Activity.php
+++ b/src/Discord/Parts/User/Activity.php
@@ -41,12 +41,15 @@ use Discord\Parts\Part;
  */
 class Activity extends Part
 {
-    public const TYPE_PLAYING = 0; // Playing {$this->name}
+    public const TYPE_GAME = 0; // Playing {$this->name}
     public const TYPE_STREAMING = 1; // Streaming {$this->details}
     public const TYPE_LISTENING = 2; // Listening to {$this->name}
     public const TYPE_WATCHING = 3; // Watching {$this->name}
     public const TYPE_CUSTOM = 4; // {$this->emoji} {$this->name}
     public const TYPE_COMPETING = 5; // Competing in {$this->name}
+
+    /** @deprecated 10.0.0 Use `Activity::TYPE_GAME` */
+    public const TYPE_PLAYING = self::TYPE_GAME;
 
     public const FLAG_INSTANCE = (1 << 0);
     public const FLAG_JOIN = (1 << 1);

--- a/src/Discord/Parts/User/Member.php
+++ b/src/Discord/Parts/User/Member.php
@@ -479,7 +479,7 @@ class Member extends Part
      */
     protected function getGameAttribute(): ?Activity
     {
-        return $this->activities->first();
+        return $this->activities->get('type', Activity::TYPE_GAME);
     }
 
     /**

--- a/src/Discord/Parts/User/Member.php
+++ b/src/Discord/Parts/User/Member.php
@@ -102,7 +102,7 @@ class Member extends Part
      *
      * @return PresenceUpdate Old presence.
      */
-    public function updateFromPresence(PresenceUpdate $presence): Part
+    public function updateFromPresence(PresenceUpdate $presence): PresenceUpdate
     {
         $rawPresence = $presence->getRawAttributes();
         $oldPresence = $this->factory->part(PresenceUpdate::class, (array) $this->attributes, true);

--- a/src/Discord/Parts/User/Member.php
+++ b/src/Discord/Parts/User/Member.php
@@ -20,6 +20,7 @@ use Discord\Http\Exceptions\NoPermissionsException;
 use Discord\Parts\Channel\Channel;
 use Discord\Parts\Channel\Message;
 use Discord\Parts\Channel\Overwrite;
+use Discord\Parts\Guild\Ban;
 use Discord\Parts\Guild\Guild;
 use Discord\Parts\Guild\Role;
 use Discord\Parts\Part;
@@ -120,15 +121,17 @@ class Member extends Part
      * @param int|null    $daysToDeleteMessages The amount of days to delete messages from.
      * @param string|null $reason               Reason of the Ban.
      *
-     * @throws \Exception
+     * @throws \RuntimeException Member has no `$guild`
      *
-     * @return ExtendedPromiseInterface
+     * @return ExtendedPromiseInterface<Ban>
      */
     public function ban(?int $daysToDeleteMessages = null, ?string $reason = null): ExtendedPromiseInterface
     {
-        $guild = $this->guild;
+        if (! $guild = $this->guild) {
+            return reject(new \RuntimeException('Member has no Guild Part'));
+        }
 
-        return $guild->bans->ban($this, $daysToDeleteMessages, $reason);
+        return $guild->bans->ban($this, ['delete_message_days' => $daysToDeleteMessages], $reason);
     }
 
     /**

--- a/src/Discord/Parts/WebSockets/PresenceUpdate.php
+++ b/src/Discord/Parts/WebSockets/PresenceUpdate.php
@@ -110,9 +110,9 @@ class PresenceUpdate extends Part
      *
      * @return Activity|null The game attribute.
      */
-    protected function getGameAttribute(): ?Part
+    protected function getGameAttribute(): ?Activity
     {
-        return $this->activities->first();
+        return $this->activities->get('type', Activity::TYPE_GAME);
     }
 
     /**

--- a/src/Discord/Repository/Guild/BanRepository.php
+++ b/src/Discord/Repository/Guild/BanRepository.php
@@ -122,7 +122,7 @@ class BanRepository extends AbstractRepository
      * @param User|Ban|string $ban    User or Ban Part, or User ID
      * @param string|null     $reason Reason for Audit Log.
      *
-     * @return ExtendedPromiseInterface<Part>
+     * @return ExtendedPromiseInterface
      */
     public function unban($ban, ?string $reason = null): ExtendedPromiseInterface
     {

--- a/src/Discord/Repository/Guild/BanRepository.php
+++ b/src/Discord/Repository/Guild/BanRepository.php
@@ -63,7 +63,7 @@ class BanRepository extends AbstractRepository
      * @param array              $options Array of Ban options 'delete_message_seconds' or 'delete_message_days' (deprecated).
      * @param string|null        $reason  Reason for Audit Log.
      *
-     * @return ExtendedPromiseInterface
+     * @return ExtendedPromiseInterface<Ban>
      */
     public function ban($user, array $options = [], ?string $reason = null): ExtendedPromiseInterface
     {
@@ -101,6 +101,7 @@ class BanRepository extends AbstractRepository
             empty($content) ? null : $content,
             $headers
         )->then(function () use ($user, $reason) {
+            /** @var Ban */
             $ban = $this->factory->part(Ban::class, [
                 'user' => (object) $user->getRawAttributes(),
                 'reason' => $reason,
@@ -121,7 +122,7 @@ class BanRepository extends AbstractRepository
      * @param User|Ban|string $ban    User or Ban Part, or User ID
      * @param string|null     $reason Reason for Audit Log.
      *
-     * @return ExtendedPromiseInterface
+     * @return ExtendedPromiseInterface<Part>
      */
     public function unban($ban, ?string $reason = null): ExtendedPromiseInterface
     {

--- a/src/Discord/Repository/Guild/MemberRepository.php
+++ b/src/Discord/Repository/Guild/MemberRepository.php
@@ -57,9 +57,9 @@ class MemberRepository extends AbstractRepository
      * @param Member      $member The member to kick.
      * @param string|null $reason Reason for Audit Log.
      *
-     * @return PromiseInterface
+     * @return ExtendedPromiseInterface
      */
-    public function kick(Member $member, ?string $reason = null): PromiseInterface
+    public function kick(Member $member, ?string $reason = null): ExtendedPromiseInterface
     {
         return $this->delete($member, $reason);
     }

--- a/src/Discord/Repository/Guild/ScheduledEventRepository.php
+++ b/src/Discord/Repository/Guild/ScheduledEventRepository.php
@@ -54,6 +54,8 @@ class ScheduledEventRepository extends AbstractRepository
      * @inheritDoc
      *
      * @param bool $with_user_count Whether to include number of users subscribed to each event
+     *
+     * @return ExtendedPromiseInterface<ScheduledEvent>
      */
     public function fetch(string $id, bool $fresh = false, bool $with_user_count = false): ExtendedPromiseInterface
     {


### PR DESCRIPTION
The fix game activity commit [already applied in v7 branch](https://github.com/discord-php/DiscordPHP/commit/c05cd51d9ea267eecff93a48a54840d0e5a1aa9c) and tested.

Like message type constants update in the [#916](https://github.com/discord-php/DiscordPHP/pull/916/commits/18d169fdca4beba4fa41f268072fe7f7483c1a6e), Update channel name constants according to https://discord.com/developers/docs/resources/channel#channel-object-channel-types, deprecated the old and inconsistent consts

Updated return type to the specific child Part class instead of using parent "Part" class

Fix wrong use of @ internal phpdoc, moved the description to comment instead.

Deprecated sendEmbed since v10 requires 'embeds' and dropped 'embed' support

Can be merged right away after review.