### PR TITLE
Deprecate Embed::setType and mark which fiels are read-only

### DIFF
--- a/src/Discord/Discord.php
+++ b/src/Discord/Discord.php
@@ -1499,7 +1499,7 @@ class Discord
         $this->logger->info('discord closed');
 
         if ($closeLoop) {
-            $this->stop();
+            $this->loop->stop();
         }
     }
 

--- a/src/Discord/Parts/Embed/Author.php
+++ b/src/Discord/Parts/Embed/Author.php
@@ -20,10 +20,10 @@ use Discord\Parts\Part;
  *
  * @since 4.0.3
  *
- * @property string      $name           The name of the author.
- * @property string|null $url            The URL to the author.
- * @property string|null $icon_url       The source of the author icon. Must be https.
- * @property string|null $proxy_icon_url A proxied version of the icon url.
+ * @property      string      $name           The name of the author.
+ * @property      string|null $url            The URL to the author.
+ * @property      string|null $icon_url       The source of the author icon. Must be https.
+ * @property-read string|null $proxy_icon_url A proxied version of the icon url.
  */
 class Author extends Part
 {

--- a/src/Discord/Parts/Embed/Embed.php
+++ b/src/Discord/Parts/Embed/Embed.php
@@ -24,19 +24,19 @@ use function Discord\poly_strlen;
  *
  * @since 4.0.3
  *
- * @property string|null        $title       The title of the embed.
- * @property string|null        $type        The type of the embed.
- * @property string|null        $description A description of the embed.
- * @property string|null        $url         The URL of the embed.
- * @property Carbon|null        $timestamp   A timestamp of the embed.
- * @property int|null           $color       The color of the embed.
- * @property Footer|null        $footer      The footer of the embed.
- * @property Image|null         $image       The image of the embed.
- * @property Image|null         $thumbnail   The thumbnail of the embed.
- * @property Video|null         $video       The video of the embed.
- * @property object|null        $provider    The provider of the embed.
- * @property Author|null        $author      The author of the embed.
- * @property Collection|Field[] $fields      A collection of embed fields.
+ * @property      string|null        $title       The title of the embed.
+ * @property-read string|null        $type        The type of the embed.
+ * @property      string|null        $description A description of the embed.
+ * @property      string|null        $url         The URL of the embed.
+ * @property      Carbon|null        $timestamp   A timestamp of the embed.
+ * @property      int|null           $color       The color of the embed.
+ * @property      Footer|null        $footer      The footer of the embed.
+ * @property      Image|null         $image       The image of the embed.
+ * @property      Image|null         $thumbnail   The thumbnail of the embed.
+ * @property-read Video|null         $video       The video of the embed.
+ * @property-read object|null        $provider    The provider of the embed.
+ * @property      Author|null        $author      The author of the embed.
+ * @property      Collection|Field[] $fields      A collection of embed fields.
  */
 class Embed extends Part
 {
@@ -202,6 +202,8 @@ class Embed extends Part
     /**
      * Sets the type of the embed.
      *
+     * @deprecated 10.0.0 Type `rich` will be always used in API.
+     *
      * @param string $type
      *
      * @throws \InvalidArgumentException Invalid embed type.
@@ -255,6 +257,8 @@ class Embed extends Part
 
     /**
      * Sets the type of the embed.
+     *
+     * @deprecated 10.0.0 Type `rich` will be always used in API.
      *
      * @param string $type
      *

--- a/src/Discord/Parts/Embed/Footer.php
+++ b/src/Discord/Parts/Embed/Footer.php
@@ -20,9 +20,9 @@ use Discord\Parts\Part;
  *
  * @since 4.0.3
  *
- * @property string      $text           Footer text.
- * @property string|null $icon_url       URL of an icon for the footer. Must be https.
- * @property string|null $proxy_icon_url Proxied version of the icon URL.
+ * @property      string      $text           Footer text.
+ * @property      string|null $icon_url       URL of an icon for the footer. Must be https.
+ * @property-read string|null $proxy_icon_url Proxied version of the icon URL.
  */
 class Footer extends Part
 {

--- a/src/Discord/Parts/Embed/Image.php
+++ b/src/Discord/Parts/Embed/Image.php
@@ -21,10 +21,10 @@ use Discord\Parts\Part;
  *
  * @since 4.0.3
  *
- * @property string      $url       The source of the image. Must be https.
- * @property string|null $proxy_url A proxied version of the image.
- * @property int|null    $height    The height of the image.
- * @property int|null    $width     The width of the image.
+ * @property      string      $url       The source of the image. Must be https.
+ * @property-read string|null $proxy_url A proxied version of the image.
+ * @property-read int|null    $height    The height of the image.
+ * @property-read int|null    $width     The width of the image.
  */
 class Image extends Part
 {

--- a/src/Discord/Parts/Embed/Video.php
+++ b/src/Discord/Parts/Embed/Video.php
@@ -20,10 +20,10 @@ use Discord\Parts\Part;
  *
  * @since 4.0.3
  *
- * @property string|null $url       The source of the video.
- * @property string|null $proxy_url A proxied url of the video.
- * @property int|null    $height    The height of the video.
- * @property int|null    $width     The width of the video.
+ * @property      string|null $url       The source of the video.
+ * @property-read string|null $proxy_url A proxied url of the video.
+ * @property-read int|null    $height    The height of the video.
+ * @property-read int|null    $width     The width of the video.
  */
 class Video extends Part
 {


### PR DESCRIPTION
Based on API docs: https://discord.com/developers/docs/resources/channel#create-message-limitations
> For the embed object, you can set every field except type (it will be rich regardless of if you try to set it), provider, video, and any height, width, or proxy_url values for images.

Same note can be found in webhooks.