### PR TITLE
BC unavailable Event::GUILD_CREATE, component message non empty, mutable guild feature, deletable message, automod audit log

### DIFF
--- a/docs/src/pages/api/03_events/01_application_commands.md
+++ b/docs/src/pages/api/03_events/01_application_commands.md
@@ -4,12 +4,10 @@ title: "Application Commands"
 
 ### Application Command Permissions Update
 
-Called with an `Overwrite` object when an application command's permissions are updated.
+Called with an `CommandPermissions` object when an application command's permissions are updated.
 
 ```php
-// use Discord\Parts\Interactions\Command\Overwrite;
-
-$discord->on(Event::APPLICATION_COMMAND_PERMISSIONS_UPDATE, function (Overwrite $overwrite, Discord $discord, Overwrite $oldOverwrite) {
+$discord->on(Event::APPLICATION_COMMAND_PERMISSIONS_UPDATE, function (CommandPermissions $commandPermission, Discord $discord, ?CommandPermissions $oldCommandPermission) {
     // ...
 });
 ```

--- a/docs/src/pages/api/03_events/02_auto_moderations.md
+++ b/docs/src/pages/api/03_events/02_auto_moderations.md
@@ -21,7 +21,7 @@ Requires the `Intents::AUTO_MODERATION_CONFIGURATION` intent.
 Called with a `Rule` object when an auto moderation rule is updated.
 
 ```php
-$discord->on(Event::AUTO_MODERATION_RULE_UPDATE, function (Rule $rule, Discord $discord, Rule $oldRule) {
+$discord->on(Event::AUTO_MODERATION_RULE_UPDATE, function (Rule $rule, Discord $discord, ?Rule $oldRule) {
     // ...
 });
 ```

--- a/docs/src/pages/api/03_events/03_channels.md
+++ b/docs/src/pages/api/03_events/03_channels.md
@@ -79,7 +79,7 @@ $discord->on(Event::THREAD_UPDATE, function (Thread $thread, Discord $discord, ?
 Called with an old `Thread` object when a thread relevant to the Bot is deleted.
 
 ```php
-$discord->on(Event::THREAD_DELETE, function ($thread, Discord $discord) {
+$discord->on(Event::THREAD_DELETE, function (object $thread, Discord $discord) {
     // {
     //     "type": 0,
     //     "id": "",

--- a/docs/src/pages/api/03_events/03_channels.md
+++ b/docs/src/pages/api/03_events/03_channels.md
@@ -80,12 +80,18 @@ Called with an old `Thread` object when a thread relevant to the Bot is deleted.
 
 ```php
 $discord->on(Event::THREAD_DELETE, function (object $thread, Discord $discord) {
+    if ($thread instanceof Thread) {
+        // $thread was cached
+    }
+    // $thread was not in cache:
+    else {
     // {
     //     "type": 0,
     //     "id": "",
     //     "guild_id": "",
     //     "parent_id": ""
     // }
+    }
 });
 ```
 

--- a/docs/src/pages/api/03_events/04_guilds.md
+++ b/docs/src/pages/api/03_events/04_guilds.md
@@ -45,7 +45,7 @@ Called with a `Guild` object in one of the following situations:
 2. The guild is unavailable due to an outage.
 
 ```php
-$discord->on(Event::GUILD_DELETE, function ($guild, Discord $discord, bool $unavailable) {
+$discord->on(Event::GUILD_DELETE, function (object $guild, Discord $discord, bool $unavailable) {
     // ...
     if ($unavailable) {
         // the guild is unavailabe due to an outage, $guild is a stdClass
@@ -248,8 +248,11 @@ Requires the `Intents::GUILD_INTEGRATIONS` intent.
 Called with a cached `Guild` object when a guild integration is updated.
 
 ```php
-$discord->on(Event::GUILD_INTEGRATIONS_UPDATE, function (?Guild $guild, Discord $discord) {
+$discord->on(Event::GUILD_INTEGRATIONS_UPDATE, function (object $guild, Discord $discord) {
     // ...
+    if ($guild instanceof Guild) {
+        // Guild is present on cache
+    }
 });
 ```
 
@@ -278,7 +281,7 @@ $discord->on(Event::INTEGRATION_UPDATE, function (Integration $integration, Disc
 Called with an old `Integration` object when a integration is deleted from a guild.
 
 ```php
-$discord->on(Event::INTEGRATION_DELETE, function ($integration, Discord $discord) {
+$discord->on(Event::INTEGRATION_DELETE, function (object $integration, Discord $discord) {
     // if $integration is not cached,
     // {
     //     "id": "",

--- a/docs/src/pages/api/03_events/04_guilds.md
+++ b/docs/src/pages/api/03_events/04_guilds.md
@@ -8,12 +8,12 @@ Requires the `Intents::GUILDS` intent.
 
 Called with a `Guild` object in one of the following situations:
 
-1. When the Bot is first starting and the guilds are becoming available.
+1. When the Bot is first starting and the guilds are becoming available. (unless the listener is put inside after 'ready' event)
 2. When a guild was unavailable and is now available due to an outage.
 3. When the Bot joins a new guild.
 
 ```php
-$discord->on(Event::GUILD_CREATE, function ($guild, Discord $discord) {
+$discord->on(Event::GUILD_CREATE, function (object $guild, Discord $discord) {
     if (! ($guild instanceof Guild)) {
         // the guild is unavailable due to an outage, $guild is a stdClass
         // {
@@ -137,7 +137,7 @@ $discord->on(Event::GUILD_MEMBER_REMOVE, function (Member $member, Discord $disc
 Called with two `Member` objects when a member is updated in a guild. Note that the old member _may_ be `null` if `loadAllMembers` is disabled.
 
 ```php
-$discord->on(Event::GUILD_MEMBER_UPDATE, function (Member $member, Discord $discord, Member $oldMember) {
+$discord->on(Event::GUILD_MEMBER_UPDATE, function (Member $member, Discord $discord, ?Member $oldMember) {
     // ...
 });
 ```
@@ -171,7 +171,7 @@ $discord->on(Event::GUILD_ROLE_UPDATE, function (Role $role, Discord $discord, ?
 Called with a `Role` object when a role is deleted in a guild. `$role` may return `Role` object if it was cached.
 
 ```php
-$discord->on(Event::GUILD_ROLE_DELETE, function ($role, Discord $discord) {
+$discord->on(Event::GUILD_ROLE_DELETE, function (object $role, Discord $discord) {
     if ($role instanceof Role) {
         // Role is present in cache
     }

--- a/docs/src/pages/api/03_events/04_guilds.md
+++ b/docs/src/pages/api/03_events/04_guilds.md
@@ -13,8 +13,17 @@ Called with a `Guild` object in one of the following situations:
 3. When the Bot joins a new guild.
 
 ```php
-$discord->on(Event::GUILD_CREATE, function (Guild $guild, Discord $discord) {
-    // ...
+$discord->on(Event::GUILD_CREATE, function ($guild, Discord $discord) {
+    if (! ($guild instanceof Guild)) {
+        // the guild is unavailable due to an outage, $guild is a stdClass
+        // {
+        //     "id": "",
+        //     "unavailable": true,
+        // }
+        return;
+    }
+
+    // the Bot has joined the guild
 });
 ```
 

--- a/docs/src/pages/api/03_events/04_guilds.md
+++ b/docs/src/pages/api/03_events/04_guilds.md
@@ -173,9 +173,9 @@ Called with a `Role` object when a role is deleted in a guild. `$role` may retur
 ```php
 $discord->on(Event::GUILD_ROLE_DELETE, function (object $role, Discord $discord) {
     if ($role instanceof Role) {
-        // Role is present in cache
+        // $role was cached
     }
-    // If the role is not present in the cache:
+    // $role was not in cache:
     else {
         // {
         //     "guild_id": "" // role guild ID
@@ -249,9 +249,14 @@ Called with a cached `Guild` object when a guild integration is updated.
 
 ```php
 $discord->on(Event::GUILD_INTEGRATIONS_UPDATE, function (object $guild, Discord $discord) {
-    // ...
     if ($guild instanceof Guild) {
-        // Guild is present on cache
+        // $guild was cached
+    }
+    // $guild was not in cache:
+    else {
+        // {
+        //     "guild_id": "",
+        // }
     }
 });
 ```
@@ -282,11 +287,16 @@ Called with an old `Integration` object when a integration is deleted from a gui
 
 ```php
 $discord->on(Event::INTEGRATION_DELETE, function (object $integration, Discord $discord) {
-    // if $integration is not cached,
-    // {
-    //     "id": "",
-    //     "guild_id": "",
-    //     "application_id": ""
-    // }
+    if ($integration instanceof Integration) {
+        // $integration was cached
+    }
+    // $integration was not in cache:
+    else {
+        // {
+        //     "id": "",
+        //     "guild_id": "",
+        //     "application_id": ""
+        // }
+    }
 });
 ```

--- a/docs/src/pages/api/03_events/05_invites.md
+++ b/docs/src/pages/api/03_events/05_invites.md
@@ -21,9 +21,9 @@ Called with an object when an invite is created.
 ```php
 $discord->on(Event::INVITE_DELETE, function (object $invite, Discord $discord) {
     if ($invite instanceof Invite) {
-        // Invite is present in cache
+        // $invite was cached
     }
-    // If the invite is not present in the cache:
+    // If $invite was not in cache:
     else {
         // {
         //     "channel_id": "",

--- a/docs/src/pages/api/03_events/05_invites.md
+++ b/docs/src/pages/api/03_events/05_invites.md
@@ -19,7 +19,7 @@ $discord->on(Event::INVITE_CREATE, function (Invite $invite, Discord $discord) {
 Called with an object when an invite is created.
 
 ```php
-$discord->on(Event::INVITE_DELETE, function ($invite, Discord $discord) {
+$discord->on(Event::INVITE_DELETE, function (object $invite, Discord $discord) {
     if ($invite instanceof Invite) {
         // Invite is present in cache
     }

--- a/docs/src/pages/api/03_events/07_messages.md
+++ b/docs/src/pages/api/03_events/07_messages.md
@@ -37,9 +37,9 @@ Discord does not provide a way to get deleted messages.
 ```php
 $discord->on(Event::MESSAGE_DELETE, function (object $message, Discord $discord) {
     if ($message instanceof Message) {
-        // Message is present in cache
+        // $message was cached
     }
-    // If the message is not present in the cache:
+    // $message was not in cache:
     else {
         // {
         //     "id": "", // deleted message ID,
@@ -60,9 +60,9 @@ Discord does not provide a way to get deleted messages.
 $discord->on(Event::MESSAGE_DELETE_BULK, function (Collection $messages, Discord $discord) {
     foreach ($messages as $message) {
         if ($message instanceof Message) {
-            // Message is present in cache
+            // $message was cached
         }
-        // If the message is not present in the cache:
+        // $message was not in cache:
         else {
             // {
             //     "id": "", // deleted message ID,

--- a/docs/src/pages/api/03_events/07_messages.md
+++ b/docs/src/pages/api/03_events/07_messages.md
@@ -35,7 +35,7 @@ The `Message` object may be the raw payload if `storeMessages` is not enabled _o
 Discord does not provide a way to get deleted messages.
 
 ```php
-$discord->on(Event::MESSAGE_DELETE, function ($message, Discord $discord) {
+$discord->on(Event::MESSAGE_DELETE, function (object $message, Discord $discord) {
     if ($message instanceof Message) {
         // Message is present in cache
     }

--- a/docs/src/pages/api/03_events/11_webhooks.md
+++ b/docs/src/pages/api/03_events/11_webhooks.md
@@ -9,9 +9,9 @@ Called with a `Guild` and `Channel` object when a guild channel's webhooks are i
 ```php
 $discord->on(Event::WEBHOOKS_UPDATE, function (object $guild, Discord $discord, object $channel) {
     if ($guild instanceof Guild && $channel instanceof Channel) {
-        // Guild and Channel is present in cache
+        // $guild and $channel was cached
     }
-    // If not present in the cache:
+    // $guild and/or $channel was not in cache:
     else {
         // {
         //     "guild_id": "" // webhook guild ID

--- a/docs/src/pages/api/03_events/11_webhooks.md
+++ b/docs/src/pages/api/03_events/11_webhooks.md
@@ -7,7 +7,7 @@ title: "Webhooks"
 Called with a `Guild` and `Channel` object when a guild channel's webhooks are is created, updated, or deleted.
 
 ```php
-$discord->on(Event::WEBHOOKS_UPDATE, function ($guild, Discord $discord, $channel) {
+$discord->on(Event::WEBHOOKS_UPDATE, function (object $guild, Discord $discord, object $channel) {
     if ($guild instanceof Guild && $channel instanceof Channel) {
         // Guild and Channel is present in cache
     }

--- a/src/Discord/Builders/MessageBuilder.php
+++ b/src/Discord/Builders/MessageBuilder.php
@@ -662,6 +662,7 @@ class MessageBuilder implements JsonSerializable
 
         if (isset($this->components)) {
             $body['components'] = $this->components;
+            $empty = false;
         }
 
         if ($this->sticker_ids) {

--- a/src/Discord/Parts/Channel/Channel.php
+++ b/src/Discord/Parts/Channel/Channel.php
@@ -261,6 +261,8 @@ class Channel extends Part
      * Gets the last pinned message timestamp.
      *
      * @return Carbon|null
+     *
+     * @throws \Exception
      */
     protected function getLastPinTimestampAttribute(): ?Carbon
     {

--- a/src/Discord/Parts/Channel/Invite.php
+++ b/src/Discord/Parts/Channel/Invite.php
@@ -178,8 +178,6 @@ class Invite extends Part
     /**
      * Returns the inviter attribute.
      *
-     * @throws \Exception
-     *
      * @return User|null The User that invited you.
      */
     protected function getInviterAttribute(): ?User
@@ -230,9 +228,9 @@ class Invite extends Part
     /**
      * Returns the expires at attribute.
      *
-     * @throws \Exception
-     *
      * @return Carbon|null The time that the invite was created.
+     *
+     * @throws \Exception
      */
     protected function getExpiresAtAttribute(): ?Carbon
     {
@@ -267,6 +265,8 @@ class Invite extends Part
      * Returns the created at attribute.
      *
      * @return Carbon|null The time that the invite was created.
+     *
+     * @throws \Exception
      */
     protected function getCreatedAtAttribute(): ?Carbon
     {

--- a/src/Discord/Parts/Channel/Message.php
+++ b/src/Discord/Parts/Channel/Message.php
@@ -804,7 +804,7 @@ class Message extends Part
         $deferred = new Deferred();
 
         $timer = $this->discord->getLoop()->addTimer($delay / 1000, function () use ($deferred) {
-            $this->delete([$deferred, 'resolve'], [$deferred, 'reject']);
+            $this->delete()->done([$deferred, 'resolve'], [$deferred, 'reject']);
         });
 
         return $deferred->promise();
@@ -905,9 +905,15 @@ class Message extends Part
      * @link https://discord.com/developers/docs/resources/channel#delete-message
      *
      * @return ExtendedPromiseInterface
+     *
+     * @throws \RuntimeException This type of message cannot be deleted.
      */
     public function delete(): ExtendedPromiseInterface
     {
+        if (! $this->isDeletable()) {
+            return reject(new \RuntimeException("Cannot delete this type of message: {$this->type}", 50021));
+        }
+
         return $this->http->delete(Endpoint::bind(Endpoint::CHANNEL_MESSAGE, $this->channel_id, $this->id));
     }
 
@@ -975,6 +981,22 @@ class Message extends Part
     {
         return $this->edit(MessageBuilder::new()
             ->addEmbed($embed));
+    }
+
+    public function isDeletable(): bool
+    {
+        return ! in_array($this->type, [
+            self::TYPE_RECIPIENT_ADD,
+            self::TYPE_RECIPIENT_REMOVE,
+            self::TYPE_CALL,
+            self::TYPE_CHANNEL_NAME_CHANGE,
+            self::TYPE_CHANNEL_ICON_CHANGE,
+            self::TYPE_GUILD_DISCOVERY_DISQUALIFIED,
+            self::TYPE_GUILD_DISCOVERY_REQUALIFIED,
+            self::TYPE_GUILD_DISCOVERY_GRACE_PERIOD_INITIAL_WARNING,
+            self::TYPE_GUILD_DISCOVERY_GRACE_PERIOD_FINAL_WARNING,
+            self::TYPE_THREAD_STARTER_MESSAGE,
+        ]);
     }
 
     /**

--- a/src/Discord/Parts/Channel/Message.php
+++ b/src/Discord/Parts/Channel/Message.php
@@ -603,6 +603,8 @@ class Message extends Part
      * Returns the timestamp attribute.
      *
      * @return Carbon|null The time that the message was sent.
+     *
+     * @throws \Exception
      */
     protected function getTimestampAttribute(): ?Carbon
     {
@@ -617,6 +619,8 @@ class Message extends Part
      * Returns the edited_timestamp attribute.
      *
      * @return Carbon|null The time that the message was edited.
+     *
+     * @throws \Exception
      */
     protected function getEditedTimestampAttribute(): ?Carbon
     {

--- a/src/Discord/Parts/Channel/Overwrite.php
+++ b/src/Discord/Parts/Channel/Overwrite.php
@@ -50,7 +50,6 @@ class Overwrite extends Part
      * Sets the allow attribute of the role.
      *
      * @param  ChannelPermission|int $allow
-     * @throws \Exception
      */
     protected function setAllowAttribute($allow): void
     {
@@ -65,7 +64,6 @@ class Overwrite extends Part
      * Sets the deny attribute of the role.
      *
      * @param  ChannelPermission|int $deny
-     * @throws \Exception
      */
     protected function setDenyAttribute($deny): void
     {

--- a/src/Discord/Parts/Embed/Embed.php
+++ b/src/Discord/Parts/Embed/Embed.php
@@ -70,6 +70,8 @@ class Embed extends Part
      * Gets the timestamp attribute.
      *
      * @return Carbon|null The timestamp attribute.
+     *
+     * @throws \Exception
      */
     protected function getTimestampAttribute(): ?Carbon
     {

--- a/src/Discord/Parts/Guild/AuditLog/Entry.php
+++ b/src/Discord/Parts/Guild/AuditLog/Entry.php
@@ -86,6 +86,8 @@ class Entry extends Part
     public const AUTO_MODERATION_RULE_UPDATE = 141;
     public const AUTO_MODERATION_RULE_DELETE = 142;
     public const AUTO_MODERATION_BLOCK_MESSAGE = 143;
+    public const AUTO_MODERATION_FLAG_TO_CHANNEL = 144;
+    public const AUTO_MODERATION_USER_COMMUNICATION_DISABLED = 145;
 
     // AUDIT LOG ENTRY TYPES
 

--- a/src/Discord/Parts/Guild/AuditLog/Options.php
+++ b/src/Discord/Parts/Guild/AuditLog/Options.php
@@ -21,15 +21,17 @@ use Discord\Parts\Part;
  *
  * @since 5.1.0
  *
- * @property string $application_id     ID of the app whose permissions were targeted.
- * @property string $channel_id         Channel in which the entities were targeted.
- * @property string $count              Number of entities that were targeted.
- * @property string $delete_member_days Number of days after which inactive members were kicked.
- * @property string $id                 Id of the overwritten entity.
- * @property string $members_removed    Number of members removed by the prune.
- * @property string $message_id         Id of the message that was targeted.
- * @property string $role_name          Name of the role if type is "0" (not present if type is "1").
- * @property string $type               Type of overwritten entity - "0" for "role" or "1" for "member".
+ * @property string $application_id                    ID of the app whose permissions were targeted.
+ * @property string $auto_moderation_rule_name         Name of the Auto Moderation rule that was triggered.
+ * @property string $auto_moderation_rule_trigger_type Trigger type of the Auto Moderation rule that was triggered.
+ * @property string $channel_id                        Channel in which the entities were targeted.
+ * @property string $count                             Number of entities that were targeted.
+ * @property string $delete_member_days                Number of days after which inactive members were kicked.
+ * @property string $id                                Id of the overwritten entity.
+ * @property string $members_removed                   Number of members removed by the prune.
+ * @property string $message_id                        Id of the message that was targeted.
+ * @property string $role_name                         Name of the role if type is "0" (not present if type is "1").
+ * @property string $type                              Type of overwritten entity - "0" for "role" or "1" for "member".
  */
 class Options extends Part
 {
@@ -38,6 +40,8 @@ class Options extends Part
      */
     protected $fillable = [
         'application_id',
+        'auto_moderation_rule_name',
+        'auto_moderation_rule_trigger_type',
         'channel_id',
         'count',
         'delete_member_days',

--- a/src/Discord/Parts/Guild/Guild.php
+++ b/src/Discord/Parts/Guild/Guild.php
@@ -1248,8 +1248,8 @@ class Guild extends Part
      *
      * @link https://discord.com/developers/docs/resources/guild#modify-guild-mfa-level
      *
-     * @param int    $level  The new MFA level `Guild::MFA_NONE` or `Guild::MFA_ELEVATED`.
-     * @param string $reason Reason for Audit Log.
+     * @param int         $level  The new MFA level `Guild::MFA_NONE` or `Guild::MFA_ELEVATED`.
+     * @param string|null $reason Reason for Audit Log.
      *
      * @return ExtendedPromiseInterface<Guild> This guild.
      */
@@ -1272,7 +1272,8 @@ class Guild extends Part
      *
      * @link https://discord.com/developers/docs/resources/guild#modify-guild
      *
-     * @param bool[] $features Array of features to set/unset, e.g. `['COMMUNITY' => true, 'INVITES_DISABLED' => false]`.
+     * @param bool[]      $features Array of features to set/unset, e.g. `['COMMUNITY' => true, 'INVITES_DISABLED' => false]`.
+     * @param string|null $reason   Reason for Audit Log.
      *
      * @return ExtendedPromiseInterface<Guild> This guild.
      *

--- a/src/Discord/Parts/Guild/Guild.php
+++ b/src/Discord/Parts/Guild/Guild.php
@@ -65,7 +65,7 @@ use function React\Promise\resolve;
  * @property-read User|null          $owner                                    The owner of the guild.
  * @property      ?string|null       $region                                   The region the guild's voice channels are hosted in.
  * @property      string             $afk_channel_id                           The unique identifier of the AFK channel ID.
- * @property      int                $afk_timeout                              How long you will remain in the voice channel until you are moved into the AFK channel.
+ * @property      int                $afk_timeout                              How long in seconds you will remain in the voice channel until you are moved into the AFK channel. Can be set to: 60, 300, 900, 1800, 3600.
  * @property      bool|null          $widget_enabled                           Is server widget enabled.
  * @property      ?string|null       $widget_channel_id                        Channel that the widget will create an invite to.
  * @property      int                $verification_level                       The verification level used for the guild.

--- a/src/Discord/Parts/Guild/Guild.php
+++ b/src/Discord/Parts/Guild/Guild.php
@@ -371,9 +371,9 @@ class Guild extends Part
     /**
      * Returns the joined_at attribute.
      *
-     * @throws \Exception
-     *
      * @return Carbon|null The joined_at attribute.
+     *
+     * @throws \Exception
      */
     protected function getJoinedAtAttribute(): ?Carbon
     {

--- a/src/Discord/Parts/Guild/Integration.php
+++ b/src/Discord/Parts/Guild/Integration.php
@@ -92,9 +92,9 @@ class Integration extends Part
     /**
      * Returns the synced_at attribute.
      *
-     * @throws \Exception
-     *
      * @return Carbon|null The synced_at attribute.
+     *
+     * @throws \Exception
      */
     protected function getSyncedAtAttribute(): ?Carbon
     {

--- a/src/Discord/Parts/Guild/Role.php
+++ b/src/Discord/Parts/Guild/Role.php
@@ -63,8 +63,6 @@ class Role extends Part
      * Sets the permissions attribute.
      *
      * @param RolePermission|int $permission The permissions to set.
-     *
-     * @throws \Exception
      */
     protected function setPermissionsAttribute($permission): void
     {

--- a/src/Discord/Parts/Guild/ScheduledEvent.php
+++ b/src/Discord/Parts/Guild/ScheduledEvent.php
@@ -202,9 +202,9 @@ class ScheduledEvent extends Part
     /**
      * Returns the created at attribute.
      *
-     * @throws \Exception
-     *
      * @return Carbon The time the scheduled event will start.
+     *
+     * @throws \Exception
      */
     protected function getScheduledStartTimeAttribute(): Carbon
     {
@@ -214,9 +214,9 @@ class ScheduledEvent extends Part
     /**
      * Returns the created at attribute.
      *
-     * @throws \Exception
-     *
      * @return Carbon|null The time the scheduled event will end, required if entity_type is EXTERNAL.
+     *
+     * @throws \Exception
      */
     protected function getScheduledEndTimeAttribute(): ?Carbon
     {

--- a/src/Discord/Parts/Interactions/Interaction.php
+++ b/src/Discord/Parts/Interactions/Interaction.php
@@ -153,9 +153,7 @@ class Interaction extends Part
             if ($guild = $this->guild) {
                 if ($member = $guild->members->get('id', $this->attributes['member']->user->id)) {
                     // @todo Temporary workaround until member is cached from INTERACTION_CREATE event
-                    if (! $member->permissions) {
-                        $member->permissions = $this->attributes['member']->permissions;
-                    }
+                    $member->permissions = $this->attributes['member']->permissions;
                     return $member;
                 }
             }

--- a/src/Discord/Parts/Interactions/Interaction.php
+++ b/src/Discord/Parts/Interactions/Interaction.php
@@ -133,8 +133,10 @@ class Interaction extends Part
      */
     protected function getChannelAttribute(): ?Channel
     {
-        if ($this->guild && $channel = $this->guild->channels->get('id', $this->channel_id)) {
-            return $channel;
+        if ($guild = $this->guild) {
+            if ($channel = $guild->channels->get('id', $this->channel_id)) {
+                return $channel;
+            }
         }
 
         return $this->discord->getChannel($this->channel_id);
@@ -148,8 +150,14 @@ class Interaction extends Part
     protected function getMemberAttribute(): ?Member
     {
         if (isset($this->attributes['member'])) {
-            if ($this->guild && $member = $this->guild->members->get('id', $this->attributes['member']->user->id)) {
-                return $member;
+            if ($guild = $this->guild) {
+                if ($member = $guild->members->get('id', $this->attributes['member']->user->id)) {
+                    // @todo Temporary workaround until member is cached from INTERACTION_CREATE event
+                    if (! $member->permissions) {
+                        $member->permissions = $this->attributes['member']->permissions;
+                    }
+                    return $member;
+                }
             }
 
             return $this->factory->part(Member::class, (array) $this->attributes['member'] + ['guild_id' => $this->guild_id], true);

--- a/src/Discord/Parts/Thread/Member.php
+++ b/src/Discord/Parts/Thread/Member.php
@@ -55,9 +55,9 @@ class Member extends Part
     /**
      * Returns the time that the member joined the thread.
      *
-     * @throws \Exception
-     *
      * @return Carbon
+     *
+     * @throws \Exception
      */
     protected function getJoinTimestampAttribute(): Carbon
     {

--- a/src/Discord/Parts/Thread/Thread.php
+++ b/src/Discord/Parts/Thread/Thread.php
@@ -175,6 +175,8 @@ class Thread extends Part
      * Returns the timestamp when the last message was pinned in the thread.
      *
      * @return Carbon|null
+     *
+     * @throws \Exception
      */
     protected function getLastPinTimestampAttribute(): ?Carbon
     {
@@ -263,6 +265,8 @@ class Thread extends Part
      * also mean the time when the thread was created, archived, unarchived etc.
      *
      * @return Carbon
+     *
+     * @throws \Exception
      */
     protected function getArchiveTimestampAttribute(): Carbon
     {
@@ -273,6 +277,8 @@ class Thread extends Part
      * Returns the timestamp when the thread was created; only populated for threads created after 2022-01-09.
      *
      * @return Carbon|null
+     *
+     * @throws \Exception
      */
     protected function getCreateTimestampAttribute(): ?Carbon
     {

--- a/src/Discord/Parts/User/Activity.php
+++ b/src/Discord/Parts/User/Activity.php
@@ -91,6 +91,8 @@ class Activity extends Part
      * Gets the created at timestamp.
      *
      * @return Carbon|null
+     *
+     * @throws \Exception
      */
     protected function getCreatedAtAttribute(): ?Carbon
     {

--- a/src/Discord/Parts/User/Member.php
+++ b/src/Discord/Parts/User/Member.php
@@ -588,9 +588,9 @@ class Member extends Part
     /**
      * Returns the joined at attribute.
      *
-     * @throws \Exception
-     *
      * @return Carbon|null The timestamp from when the member joined.
+     *
+     * @throws \Exception
      */
     protected function getJoinedAtAttribute(): ?Carbon
     {
@@ -644,6 +644,8 @@ class Member extends Part
      * Returns the premium since attribute.
      *
      * @return Carbon|null
+     *
+     * @throws \Exception
      */
     protected function getPremiumSinceAttribute(): ?Carbon
     {
@@ -675,6 +677,8 @@ class Member extends Part
      * Returns the communication disabled until attribute.
      *
      * @return Carbon|null
+     *
+     * @throws \Exception
      */
     protected function getCommunicationDisabledUntilAttribute(): ?Carbon
     {

--- a/src/Discord/Parts/User/User.php
+++ b/src/Discord/Parts/User/User.php
@@ -140,7 +140,7 @@ class User extends Part
      *
      * @link https://discord.com/developers/docs/resources/channel#trigger-typing-indicator
      *
-     * @throws \Exception
+     * @throws \RuntimeException
      *
      * @return ExtendedPromiseInterface
      */

--- a/src/Discord/Parts/WebSockets/TypingStart.php
+++ b/src/Discord/Parts/WebSockets/TypingStart.php
@@ -106,9 +106,9 @@ class TypingStart extends Part
     /**
      * Gets the timestamp attribute.
      *
-     * @throws \Exception
-     *
      * @return Carbon The time that the user started typing.
+     *
+     * @throws \Exception
      */
     protected function getTimestampAttribute(): Carbon
     {

--- a/src/Discord/Parts/WebSockets/VoiceStateUpdate.php
+++ b/src/Discord/Parts/WebSockets/VoiceStateUpdate.php
@@ -133,6 +133,8 @@ class VoiceStateUpdate extends Part
      * Gets the request_to_speak_timestamp attribute.
      *
      * @return Carbon|null
+     *
+     * @throws \Exception
      */
     protected function getRequestToSpeakTimestampAttribute(): ?Carbon
     {

--- a/src/Discord/WebSockets/Events/GuildCreate.php
+++ b/src/Discord/WebSockets/Events/GuildCreate.php
@@ -25,7 +25,6 @@ use Discord\Parts\Guild\ScheduledEvent;
 use Discord\Parts\Thread\Thread;
 
 use function React\Promise\all;
-use function React\Promise\reject;
 
 /**
  * @link https://discord.com/developers/docs/topics/gateway#guild-create
@@ -39,8 +38,8 @@ class GuildCreate extends Event
      */
     public function handle($data)
     {
-        if (isset($data->unavailable) && $data->unavailable) {
-            return reject(['unavailable', $data->id]);
+        if (! empty($data->unavailable)) {
+            return $data;
         }
 
         /** @var Guild */


### PR DESCRIPTION
Everything tested.

### Added
- Message::`isDeletable()` https://github.com/discord/discord-api-docs/pull/5148
- Some extra notes in the phpdoc for the Guild::`$afk_timeout` attribute https://github.com/discord/discord-api-docs/pull/5336
- More auto moderation Audit Log stuff https://github.com/discord/discord-api-docs/pull/5334
  - `Entry::AUTO_MODERATION_FLAG_TO_CHANNEL`
  - `Entry::AUTO_MODERATION_USER_COMMUNICATION_DISABLED`
  - `Options::$auto_moderation_rule_name`
  - `Options::$auto_moderation_rule_trigger_type`
- Guild::`setFeatures()` to update mutable guild features https://github.com/discord/discord-api-docs/pull/5270


### Changed
- MessageBuilder to count `component` as non empty https://github.com/discord/discord-api-docs/pull/5435
- Breaking Change Event::GUILD_CREATE event to allow event listeners on unavailable guilds. Put the event listener inside ready to not conflict with the library lazy loading logic. https://github.com/discord/discord-api-docs/pull/5122

### Fixed
- Some inconsistent Exceptions phpdoc
- (temporary workaround) `$interaction->member->permissions` [(from v7)](https://github.com/discord-php/DiscordPHP/commit/8480a4d73f35766557d8b222ff9c9e03329a4af9)