### PR TITLE
Fix Event::MESSAGE_DELETE_BULK and add logger code for failed Cache::unserializer()

### DIFF
--- a/src/Discord/WebSockets/Events/MessageDeleteBulk.php
+++ b/src/Discord/WebSockets/Events/MessageDeleteBulk.php
@@ -11,6 +11,7 @@
 
 namespace Discord\WebSockets\Events;
 
+use Discord\Helpers\Collection;
 use Discord\WebSockets\Event;
 
 /**
@@ -25,13 +26,13 @@ class MessageDeleteBulk extends Event
      */
     public function handle($data)
     {
-        $resolves = [];
+        $resolved = new Collection();
 
         foreach ($data->ids as $id) {
             $event = new MessageDelete($this->discord);
-            $resolves[] = yield $event->handle((object) ['id' => $id, 'channel_id' => $data->channel_id, 'guild_id' => $data->guild_id]);
+            $resolved->pushItem(yield from $event->handle((object) ['id' => $id, 'channel_id' => $data->channel_id, 'guild_id' => $data->guild_id]));
         }
 
-        return $resolves;
+        return $resolved;
     }
 }


### PR DESCRIPTION
Adds a tracking/log code to identify error with:
```
Notice: unserialize(): Error at offset 0 of 925 bytes in X:\...\vendor\team-reflex\discord-php\src\Discord\Helpers\CacheWrapper.php on line 429 Warning: Attempt to read property "attributes" on bool in X:\...\vendor\team-reflex\discord-php\src\Discord\Helpers\CacheWrapper.php on line 432 Warning: Attempt to read property "created" on bool in X:\...\vendor\team-reflex\discord-php\src\Discord\Helpers
```

Also Fixed `BOT.ERROR: exception while trying to handle dispatch packet {"packet":"MESSAGE_DELETE_BULK","exception":"[object] (UnexpectedValueException(code: 0): Expected coroutine to yield React\\Promise\\PromiseInterface, but got Generator` in MessageDeleteBulk event handler