### PR TITLE
Attempt to fix executable finder

### DIFF
--- a/src/Discord/Voice/VoiceClient.php
+++ b/src/Discord/Voice/VoiceClient.php
@@ -1437,7 +1437,7 @@ class VoiceClient extends EventEmitter
     private static function checkForExecutable(string $executable): ?string
     {
         $which = strtoupper(substr(PHP_OS, 0, 3)) === 'WIN' ? 'where' : 'command -v';
-        $executable = rtrim((string) shell_exec("{$which} {$executable}"));
+        $executable = rtrim((string) explode(PHP_EOL, shell_exec("{$which} {$executable}"))[0]);
 
         return is_executable($executable) ? $executable : null;
     }


### PR DESCRIPTION
People reported that voiceclient would not work because dphp doesn't detect ffmpeg in it's path. One example output showed several copies being installed. This small change assures only the first line is being accepted.