### PR TITLE
interaction ephemeral message can be deleted now

### DIFF
--- a/docs/src/pages/api/10_interactions.md
+++ b/docs/src/pages/api/10_interactions.md
@@ -51,4 +51,4 @@ otherwise throws a `RuntimeException` "Interaction has not been responded to."
 | `sendFollowUpMessage(MessageBuilder $builder, ?bool $ephemeral)`     | sends a follow up message to the interaction. ephemeral is defalt false                        | `Promise<Message>` |
 | `getFollowUpMessage(string $message_id)`                             | gets a non ephemeral follow up message from the interaction                                    | `Promise<Message>` |
 | `updateFollowUpMessage(string $message_id, MessageBuilder $builder)` | updates the follow up message of the interaction                                               | `Promise<Message>` |
-| `deleteFollowUpMessage(string $message_id)`                          | deletes a non ephemeral follow up message from the interaction                                 | `Promise<void>`    |
+| `deleteFollowUpMessage(string $message_id)`                          | deletes a follow up message from the interaction                                               | `Promise<void>`    |

--- a/guide/interactions.rst
+++ b/guide/interactions.rst
@@ -81,5 +81,5 @@ The following functions can be only used after interaction respond above, otherw
 +------------------------------------------------------------------------+------------------------------------------------------------------------------------------------+----------------------+
 | ``updateFollowUpMessage(string $message_id, MessageBuilder $builder)`` | updates the follow up message of the interaction                                               | ``Promise<Message>`` |
 +------------------------------------------------------------------------+------------------------------------------------------------------------------------------------+----------------------+
-| ``deleteFollowUpMessage(string $message_id)``                          | deletes a non ephemeral follow up message from the interaction                                 | ``Promise<void>``    |
+| ``deleteFollowUpMessage(string $message_id)``                          | deletes a follow up message from the interaction                                               | ``Promise<void>``    |
 +------------------------------------------------------------------------+------------------------------------------------------------------------------------------------+----------------------+

--- a/src/Discord/Parts/Interactions/Interaction.php
+++ b/src/Discord/Parts/Interactions/Interaction.php
@@ -512,7 +512,7 @@ class Interaction extends Part
     }
 
     /**
-     * Deletes a non ephemeral follow up message.
+     * Deletes a follow up message.
      *
      * @link https://discord.com/developers/docs/interactions/receiving-and-responding#delete-followup-message
      *


### PR DESCRIPTION
Cherry-picked from v7 branch 4dfe11f which is already applied.

Reference: https://github.com/discord/discord-api-docs/pull/5570
 
No code changed, can be merged right away.