### PR TITLE
Skip creating part when already cached by event

### DIFF
--- a/src/Discord/Parts/Channel/Channel.php
+++ b/src/Discord/Parts/Channel/Channel.php
@@ -1010,7 +1010,7 @@ class Channel extends Part
             return $this->http->post(Endpoint::bind(Endpoint::CHANNEL_THREADS, $this->id), $options, $headers);
         })()->then(function ($response) {
             /** @var ?Thread */
-            if ($threadPart = $this->threads->offsetGet('id', $response->id)) {
+            if ($threadPart = $this->threads->offsetGet($response->id)) {
                 $threadPart->fill((array) $response);
             } else {
                 /** @var Thread */

--- a/src/Discord/Parts/Channel/Channel.php
+++ b/src/Discord/Parts/Channel/Channel.php
@@ -1010,10 +1010,13 @@ class Channel extends Part
             return $this->http->post(Endpoint::bind(Endpoint::CHANNEL_THREADS, $this->id), $options, $headers);
         })()->then(function ($response) {
             /** @var ?Thread */
-            if (! $threadPart = $this->threads->get('id', $response->id)) {
+            if ($threadPart = $this->threads->offsetGet('id', $response->id)) {
+                $threadPart->fill((array) $response);
+            } else {
                 /** @var Thread */
                 $threadPart = $this->factory->part(Thread::class, (array) $response, true);
             }
+            $this->threads->pushItem($threadPart);
             if ($messageId = ($response->message->id ?? null)) {
                 /** @var ?Message */
                 if (! $threadPart->messages->offsetExists($messageId)) {

--- a/src/Discord/Parts/Channel/Message.php
+++ b/src/Discord/Parts/Channel/Message.php
@@ -985,6 +985,11 @@ class Message extends Part
             ->addEmbed($embed));
     }
 
+    /**
+     * Whether this type of message can be deleted (not due to permission).
+     *
+     * @return bool true if this message can be deleted.
+     */
     public function isDeletable(): bool
     {
         return ! in_array($this->type, [

--- a/src/Discord/Parts/Channel/Message.php
+++ b/src/Discord/Parts/Channel/Message.php
@@ -688,7 +688,7 @@ class Message extends Part
     /**
      * Starts a public thread from the message.
      *
-     * @link https://discord.com/developers/docs/resources/channel#start-thread-with-message
+     * @link https://discord.com/developers/docs/resources/channel#start-thread-from-message
      *
      * @param string      $name                  The name of the thread.
      * @param int         $auto_archive_duration Number of minutes of inactivity until the thread is auto-archived. One of 60, 1440, 4320, 10080.
@@ -698,6 +698,8 @@ class Message extends Part
      * @throws \UnexpectedValueException `$auto_archive_duration` is not one of 60, 1440, 4320, 10080.
      *
      * @return ExtendedPromiseInterface<Thread>
+     *
+     * @todo use OptionResolver
      */
     public function startThread(string $name, int $auto_archive_duration = 1440, ?string $reason = null): ExtendedPromiseInterface
     {

--- a/src/Discord/Parts/Guild/Guild.php
+++ b/src/Discord/Parts/Guild/Guild.php
@@ -698,10 +698,12 @@ class Guild extends Part
 
         return $this->http->post(Endpoint::bind(Endpoint::GUILD_EMOJIS, $this->id), $options, $headers)
             ->then(function ($response) {
-                $emoji = $this->factory->part(Emoji::class, (array) $response, true);
-                $this->emojis->pushItem($emoji);
+                if (! $emojiPart = $this->emojis->get('id', $response->id)) {
+                    $emojiPart = $this->factory->part(Emoji::class, (array) $response, true);
+                    $this->emojis->pushItem($emojiPart);
+                }
 
-                return $emoji;
+                return $emojiPart;
             });
     }
 
@@ -798,10 +800,12 @@ class Guild extends Part
 
         return $this->http->post(Endpoint::bind(Endpoint::GUILD_STICKERS, $this->id), (string) $multipart, $headers)
             ->then(function ($response) {
-                $sticker = $this->factory->part(Sticker::class, (array) $response, true);
-                $this->stickers->pushItem($sticker);
+                if (! $stickerPart = $this->stickers->get('id', $response->id)) {
+                    $stickerPart = $this->factory->part(Sticker::class, (array) $response, true);
+                    $this->stickers->pushItem($stickerPart);
+                }
 
-                return $sticker;
+                return $stickerPart;
             });
     }
 

--- a/src/Discord/Parts/Guild/GuildTemplate.php
+++ b/src/Discord/Parts/Guild/GuildTemplate.php
@@ -152,18 +152,19 @@ class GuildTemplate extends Part
 
         return $this->http->post(Endpoint::bind(Endpoint::GUILDS_TEMPLATE, $this->code), $options)
             ->then(function ($response) use ($roles, $channels) {
-                if (! $guild = $this->discord->guilds->get('id', $response->id)) {
+                /** @var ?Guild */
+                if (! $guildPart = $this->discord->guilds->get('id', $response->id)) {
                     /** @var Guild */
-                    $guild = $this->factory->part(Guild::class, (array) $response + ['roles' => $roles], true);
+                    $guildPart = $this->factory->part(Guild::class, (array) $response + ['roles' => $roles], true);
 
                     foreach ($channels as $channel) {
-                        $guild->channels->pushItem($guild->channels->create($channel, true));
+                        $guildPart->channels->pushItem($guildPart->channels->create($channel, true));
                     }
 
-                    $this->discord->guilds->pushItem($guild);
+                    $this->discord->guilds->pushItem($guildPart);
                 }
 
-                return $guild;
+                return $guildPart;
             });
     }
 

--- a/src/Discord/Parts/Thread/Thread.php
+++ b/src/Discord/Parts/Thread/Thread.php
@@ -710,7 +710,7 @@ class Thread extends Part
 
             return $this->http->post(Endpoint::bind(Endpoint::CHANNEL_MESSAGES, $this->id), $message);
         })()->then(function ($response) {
-            return $this->factory->part(Message::class, (array) $response, true);
+            return $this->messages->get('id', $response->id) ?? $this->factory->part(Message::class, (array) $response, true);
         });
     }
 

--- a/src/Discord/WebSockets/Events/MessageCreate.php
+++ b/src/Discord/WebSockets/Events/MessageCreate.php
@@ -55,6 +55,8 @@ class MessageCreate extends Event
                     if ($channel instanceof Thread && $parent = $channel->parent) {
                         if ($parent->type == Channel::TYPE_GUILD_FORUM) {
                             $parent->last_message_id = $data->id;
+                            $channel->message_count++;
+                            $channel->total_message_sent++;
                         }
                     }
                 }

--- a/src/Discord/WebSockets/Events/ThreadCreate.php
+++ b/src/Discord/WebSockets/Events/ThreadCreate.php
@@ -37,6 +37,7 @@ class ThreadCreate extends Event
             if ($parent = yield $guild->channels->cacheGet($data->parent_id)) {
                 if ($parent->type == Channel::TYPE_GUILD_FORUM) {
                     $parent->last_message_id = $data->id;
+                    $threadPart->last_message_id = $data->id;
                 }
                 $parent->threads->set($data->id, $threadPart);
             }


### PR DESCRIPTION
This PR changes the behavior with "create" endpoint call methods, where at most of time gets handled first by events and the part is being cached already, this change skips creating another Part when the it is already cached.

Untested, will look for more methods with similar code.