### PR TITLE
Remove rule from PHPCS, exclude examples

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -50,7 +50,6 @@ $fixers = [
     'phpdoc_no_package',
     'phpdoc_scalar',
     'phpdoc_summary',
-    'phpdoc_to_comment',
     'phpdoc_trim',
     'phpdoc_var_without_name',
     'no_leading_import_slash',
@@ -98,5 +97,6 @@ return $config
     ->setRules($rules)
     ->setFinder(
         PhpCsFixer\Finder::create()
+            ->exclude('examples')
             ->in(__DIR__)
     );

--- a/src/Discord/Helpers/CacheWrapper.php
+++ b/src/Discord/Helpers/CacheWrapper.php
@@ -422,6 +422,7 @@ final class CacheWrapper
             $tmp = unserialize($value);
             if ($tmp === false) {
                 $this->discord->getLogger()->error('Malformed cache serialization', ['class' => $this->class, 'interface' => get_class($this->interface), 'serialized' => $value]);
+
                 return null;
             }
             $value = $tmp;

--- a/src/Discord/Parts/Channel/Overwrite.php
+++ b/src/Discord/Parts/Channel/Overwrite.php
@@ -49,7 +49,7 @@ class Overwrite extends Part
     /**
      * Sets the allow attribute of the role.
      *
-     * @param  ChannelPermission|int $allow
+     * @param ChannelPermission|int $allow
      */
     protected function setAllowAttribute($allow): void
     {
@@ -63,7 +63,7 @@ class Overwrite extends Part
     /**
      * Sets the deny attribute of the role.
      *
-     * @param  ChannelPermission|int $deny
+     * @param ChannelPermission|int $deny
      */
     protected function setDenyAttribute($deny): void
     {
@@ -100,7 +100,7 @@ class Overwrite extends Part
     }
 
     /**
-     * {@inheritDoc}
+     * @inheritDoc
      */
     public function getRawAttributes(): array
     {

--- a/src/Discord/Parts/Guild/Role.php
+++ b/src/Discord/Parts/Guild/Role.php
@@ -193,7 +193,7 @@ class Role extends Part
     }
 
     /**
-     * {@inheritDoc}
+     * @inheritDoc
      */
     public function getRawAttributes(): array
     {

--- a/src/Discord/Parts/Interactions/Interaction.php
+++ b/src/Discord/Parts/Interactions/Interaction.php
@@ -154,6 +154,7 @@ class Interaction extends Part
                 if ($member = $guild->members->get('id', $this->attributes['member']->user->id)) {
                     // @todo Temporary workaround until member is cached from INTERACTION_CREATE event
                     $member->permissions = $this->attributes['member']->permissions;
+
                     return $member;
                 }
             }

--- a/src/Discord/Parts/Thread/Thread.php
+++ b/src/Discord/Parts/Thread/Thread.php
@@ -29,7 +29,6 @@ use Discord\Repository\Thread\MemberRepository;
 use Discord\WebSockets\Event;
 use React\Promise\ExtendedPromiseInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
-use Traversable;
 
 use function React\Promise\all;
 use function React\Promise\reject;
@@ -447,7 +446,7 @@ class Thread extends Part
      * @link https://discord.com/developers/docs/resources/channel#get-pinned-messages
      *
      * @return ExtendedPromiseInterface<Collection<Message>>
-     * 
+     *
      * @todo Make it in a trait along with Channel
      */
     public function getPinnedMessages(): ExtendedPromiseInterface
@@ -477,7 +476,7 @@ class Thread extends Part
      * @param string|null $reason   Reason for Audit Log (only for bulk messages).
      *
      * @return ExtendedPromiseInterface
-     * 
+     *
      * @todo Make it in a trait along with Channel
      */
     public function deleteMessages($messages, ?string $reason = null): ExtendedPromiseInterface
@@ -532,7 +531,7 @@ class Thread extends Part
      * @param array $options
      *
      * @return ExtendedPromiseInterface<Collection<Message>>
-     * 
+     *
      * @todo Make it in a trait along with Channel
      */
     public function getMessageHistory(array $options): ExtendedPromiseInterface
@@ -596,7 +595,7 @@ class Thread extends Part
      * @throws \RuntimeException
      *
      * @return ExtendedPromiseInterface<Message>
-     * 
+     *
      * @todo Make it in a trait along with Channel
      */
     public function pinMessage(Message $message, ?string $reason = null): ExtendedPromiseInterface
@@ -632,7 +631,7 @@ class Thread extends Part
      * @throws \RuntimeException
      *
      * @return ExtendedPromiseInterface<Message>
-     * 
+     *
      * @todo Make it in a trait along with Channel
      */
     public function unpinMessage(Message $message, ?string $reason = null): ExtendedPromiseInterface
@@ -672,7 +671,7 @@ class Thread extends Part
      * @param Message|null          $replyTo          Sends the message as a reply to the given message instance.
      *
      * @return ExtendedPromiseInterface<Message>
-     * 
+     *
      * @todo Make it in a trait along with Channel
      */
     public function sendMessage($message, bool $tts = false, $embed = null, $allowed_mentions = null, ?Message $replyTo = null): ExtendedPromiseInterface
@@ -740,7 +739,7 @@ class Thread extends Part
      * @param int      $options ['limit'] The amount of messages allowed or false.
      *
      * @return ExtendedPromiseInterface<Collection<Message>>
-     * 
+     *
      * @todo Make it in a trait along with Channel
      */
     public function createMessageCollector(callable $filter, array $options = []): ExtendedPromiseInterface

--- a/src/Discord/Repository/AbstractRepository.php
+++ b/src/Discord/Repository/AbstractRepository.php
@@ -683,7 +683,7 @@ abstract class AbstractRepository extends Collection
     }
 
     /**
-     * {@inheritDoc}
+     * @inheritDoc
      */
     public function jsonSerialize(): array
     {

--- a/src/Discord/Repository/Guild/MemberRepository.php
+++ b/src/Discord/Repository/Guild/MemberRepository.php
@@ -16,7 +16,6 @@ use Discord\Http\Endpoint;
 use Discord\Parts\User\Member;
 use Discord\Repository\AbstractRepository;
 use React\Promise\ExtendedPromiseInterface;
-use React\Promise\PromiseInterface;
 
 /**
  * Contains members of a guild.

--- a/tests/DiscordSingleton.php
+++ b/tests/DiscordSingleton.php
@@ -57,7 +57,7 @@ class DiscordSingleton
             'token' => getenv('DISCORD_TOKEN'),
             'loop' => $loop,
             'logger' => $logger,
-            'cacheInterface' => $cache
+            'cacheInterface' => $cache,
         ]);
 
         $e = null;
@@ -78,7 +78,6 @@ class DiscordSingleton
         if ($e !== null) {
             throw $e;
         }
-
     }
 
     private static function new()


### PR DESCRIPTION
Stop `composer run-script cs` from changing PHPDoc comments to code comments.

Exclude `examples` dir from phpcs fixer