### PR TITLE
Fix message reactions not stored in repository cache

### DIFF
--- a/src/Discord/Parts/Channel/Channel.php
+++ b/src/Discord/Parts/Channel/Channel.php
@@ -857,11 +857,12 @@ class Channel extends Part
         $this->attributes['permission_overwrites'] = $overwrites;
 
         foreach ($overwrites as $overwrite) {
-            $overwrite = (array) $overwrite + ['channel_id' => $this->id];
+            $overwrite = (array) $overwrite;
+            /** @var Overwrite */
             if ($overwritePart = $this->overwrites->offsetGet($overwrite['id'])) {
                 $overwritePart->fill($overwrite);
             }
-            $this->overwrites->pushItem($this->factory->part(Overwrite::class, $overwrite, true));
+            $this->overwrites->pushItem($overwritePart ?: $this->overwrites->create($overwrite, true));
         }
     }
 

--- a/src/Discord/Parts/Channel/Message.php
+++ b/src/Discord/Parts/Channel/Message.php
@@ -351,14 +351,20 @@ class Message extends Part
     /**
      * Sets the reactions attriubte.
      *
-     * @param iterable $reactions
+     * @param array $reactions
      */
-    protected function setReactionsAttribute(iterable $reactions)
+    protected function setReactionsAttribute(array $reactions)
     {
-        $this->reactions->clear();
+        $this->attributes['reactions'] = $reactions;
 
         foreach ($reactions as $reaction) {
-            $this->reactions->pushItem($this->reactions->create((array) $reaction, true));
+            $reaction = (array) $reaction;
+            /** @var Reaction */
+            if ($reactionPart = $this->reactions->offsetGet($reaction['emoji']->id ?? $reaction['emoji']->name)) {
+                $reactionPart->fill($reaction);
+                $reactionPart->created = $this->created;
+            }
+            $this->reactions->pushItem($reactionPart ?: $this->reactions->create($reaction, $this->created));
         }
     }
 

--- a/src/Discord/Parts/Channel/Reaction.php
+++ b/src/Discord/Parts/Channel/Reaction.php
@@ -24,7 +24,7 @@ use function Discord\normalizePartId;
 use function React\Promise\resolve;
 
 /**
- * Represents a reaction to a message by members(s).
+ * Represents a reaction emoji to a message by members(s).
  *
  * @link https://discord.com/developers/docs/resources/channel#reaction-object
  *
@@ -237,5 +237,15 @@ class Reaction extends Part
         }
 
         return $this->discord->guilds->get('id', $this->guild_id);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getRepositoryAttributes(): array
+    {
+        return [
+            'emoji' => urlencode($this->emoji->id === null ? $this->emoji->name : "{$this->emoji->name}:{$this->emoji->id}")
+        ];
     }
 }

--- a/src/Discord/Parts/Channel/Reaction.php
+++ b/src/Discord/Parts/Channel/Reaction.php
@@ -97,9 +97,11 @@ class Reaction extends Part
     /**
      * Gets the users that have used the reaction.
      *
+     * @param array       $options          An array of options. All fields are optional.
+     * @param string|null $options['after'] Get users after this user ID.
+     * @param int|null    $options['limit'] Max number of users to return (1-100).
+     *
      * @link https://discord.com/developers/docs/resources/channel#get-reactions
-
-     * @param array $options See https://discord.com/developers/docs/resources/channel#get-reactions
      *
      * @return ExtendedPromiseInterface<Collection|Users[]>
      */

--- a/src/Discord/Parts/Channel/Reaction.php
+++ b/src/Discord/Parts/Channel/Reaction.php
@@ -245,7 +245,7 @@ class Reaction extends Part
     public function getRepositoryAttributes(): array
     {
         return [
-            'emoji' => urlencode($this->emoji->id === null ? $this->emoji->name : "{$this->emoji->name}:{$this->emoji->id}")
+            'emoji' => isset($this->attributes['emoji']->id) ? $this->attributes['emoji']->name.':'.$this->attributes['emoji']->id : urlencode($this->attributes['emoji']->name)
         ];
     }
 }

--- a/src/Discord/Parts/Channel/Reaction.php
+++ b/src/Discord/Parts/Channel/Reaction.php
@@ -81,17 +81,15 @@ class Reaction extends Part
     }
 
     /**
-     * Gets the emoji identifier, combination of `id` and `name`.
+     * Gets the emoji identifier.
      *
      * @return string
+     *
+     * @since 10.0.0 Changed to only return custom emoji id or unicode emoji name.
      */
     protected function getIdAttribute(): string
     {
-        if ($this->emoji->id === null) {
-            return $this->emoji->name;
-        }
-
-        return ":{$this->emoji->name}:{$this->emoji->id}";
+        return $this->emoji->id ?? $this->emoji->name;
     }
 
     /**
@@ -107,7 +105,7 @@ class Reaction extends Part
      */
     public function getUsers(array $options = []): ExtendedPromiseInterface
     {
-        $query = Endpoint::bind(Endpoint::MESSAGE_REACTION_EMOJI, $this->channel_id, $this->message_id, urlencode($this->id));
+        $query = Endpoint::bind(Endpoint::MESSAGE_REACTION_EMOJI, $this->channel_id, $this->message_id, urlencode($this->emoji->id === null ? $this->emoji->name : "{$this->emoji->name}:{$this->emoji->id}"));
 
         $resolver = new OptionsResolver();
         $resolver

--- a/src/Discord/Parts/Guild/Emoji.php
+++ b/src/Discord/Parts/Guild/Emoji.php
@@ -127,7 +127,7 @@ class Emoji extends Part
     public function __toString(): string
     {
         if ($this->id) {
-            return '<'.($this->animated ? 'a' : '').$this->toReactionString().'>';
+            return '<'.($this->animated ? 'a:' : '')."{$this->name}:{$this->id}>";
         }
 
         return $this->name;

--- a/src/Discord/Parts/Guild/Guild.php
+++ b/src/Discord/Parts/Guild/Guild.php
@@ -287,41 +287,47 @@ class Guild extends Part
 
     /**
      * @inheritDoc
+     *
+     * @todo move each repository fill to the set<Attribute>Attributes methods
      */
     public function fill(array $attributes): void
     {
         parent::fill($attributes);
 
         foreach ($attributes['roles'] ?? [] as $role) {
-            $role = (array) $role + ['guild_id' => $this->id];
+            $role = (array) $role;
+            /** @var Role */
             if ($rolePart = $this->roles->offsetGet($role['id'])) {
                 $rolePart->fill($role);
             }
-            $this->roles->pushItem($rolePart ?? $this->factory->part(Role::class, $role, $this->created));
+            $this->roles->pushItem($rolePart ?: $this->roles->create($role, $this->created));
         }
 
         foreach ($attributes['emojis'] ?? [] as $emoji) {
-            $emoji = (array) $emoji + ['guild_id' => $this->id];
+            $emoji = (array) $emoji;
+            /** @var Emoji */
             if ($emojiPart = $this->emojis->offsetGet($emoji['id'])) {
                 $emojiPart->fill($emoji);
             }
-            $this->emojis->pushItem($emojiPart ?? $this->factory->part(Emoji::class, $emoji, $this->created));
+            $this->emojis->pushItem($emojiPart ?: $this->emojis->create($emoji, $this->created));
         }
 
         foreach ($attributes['stickers'] ?? [] as $sticker) {
-            $sticker = (array) $sticker + ['guild_id' => $this->id];
+            $sticker = (array) $sticker;
+            /** @var Sticker */
             if ($stickerPart = $this->stickers->offsetGet($sticker['id'])) {
                 $stickerPart->fill($sticker);
             }
-            $this->stickers->pushItem($stickerPart ?? $this->factory->part(Sticker::class, $sticker, $this->created));
+            $this->stickers->pushItem($stickerPart ?: $this->stickers->create($sticker, $this->created));
         }
 
         foreach ($attributes['channels'] ?? [] as $channel) {
-            $channel = (array) $channel + ['guild_id' => $this->id];
+            $channel = (array) $channel;
+            /** @var Channel */
             if ($channelPart = $this->channels->offsetGet($channel['id'])) {
                 $channelPart->fill($channel);
             }
-            $this->channels->pushItem($channelPart ?? $this->factory->part(Channel::class, $channel, true));
+            $this->channels->pushItem($channelPart ?: $this->channels->create($channel, true));
         }
     }
 

--- a/src/Discord/Parts/WebSockets/MessageReaction.php
+++ b/src/Discord/Parts/WebSockets/MessageReaction.php
@@ -28,8 +28,6 @@ use function React\Promise\resolve;
  * Represents a specific reaction to a message by a specific user.
  * Different from `Reaction` in the fact that `Reaction` represents a specific reaction to a message by _multiple_ members.
  *
- * @todo Fix caching.
- *
  * @since 5.0.0
  *
  * @property      string|null    $user_id    ID of the user that performed the reaction.
@@ -246,24 +244,24 @@ class MessageReaction extends Part
             }
         }
 
-        $reaction = $this->emoji->toReactionString();
+        $emoji = urlencode($this->emoji->id === null ? $this->emoji->name : "{$this->emoji->name}:{$this->emoji->id}");
 
         switch ($type) {
             case Message::REACT_DELETE_ALL:
                 $url = Endpoint::bind(Endpoint::MESSAGE_REACTION_ALL, $this->channel_id, $this->message_id);
                 break;
             case Message::REACT_DELETE_ME:
-                $url = Endpoint::bind(Endpoint::OWN_MESSAGE_REACTION, $this->channel_id, $this->message_id, $reaction);
+                $url = Endpoint::bind(Endpoint::OWN_MESSAGE_REACTION, $this->channel_id, $this->message_id, $emoji);
                 break;
             case Message::REACT_DELETE_EMOJI:
-                $url = Endpoint::bind(Endpoint::MESSAGE_REACTION_EMOJI, $this->channel_id, $this->message_id, $reaction);
+                $url = Endpoint::bind(Endpoint::MESSAGE_REACTION_EMOJI, $this->channel_id, $this->message_id, $emoji);
                 break;
             case Message::REACT_DELETE_ID:
             default:
                 if (! $userid = $this->user_id ?? $this->user->id) {
                     return reject(new \RuntimeException('This reaction has no user id'));
                 }
-                $url = Endpoint::bind(Endpoint::USER_MESSAGE_REACTION, $this->channel_id, $this->message_id, $reaction, $userid);
+                $url = Endpoint::bind(Endpoint::USER_MESSAGE_REACTION, $this->channel_id, $this->message_id, $emoji, $userid);
                 break;
         }
 

--- a/src/Discord/Parts/WebSockets/MessageReaction.php
+++ b/src/Discord/Parts/WebSockets/MessageReaction.php
@@ -105,10 +105,12 @@ class MessageReaction extends Part
      * Gets the ID of the reaction.
      *
      * @return string
+     * 
+     * @since 10.0.0 Changed to only return custom emoji id or unicode emoji name.
      */
     protected function getReactionIdAttribute(): string
     {
-        return ":{$this->emoji->name}:{$this->emoji->id}";
+        return $this->emoji->id ?? $this->emoji->name;
     }
 
     /**

--- a/src/Discord/Parts/WebSockets/MessageReaction.php
+++ b/src/Discord/Parts/WebSockets/MessageReaction.php
@@ -223,13 +223,16 @@ class MessageReaction extends Part
     /**
      * Delete this reaction.
      *
-     * @see Message::deleteReaction()
-     *
      * @param int|null $type The type of deletion to perform.
      *
      * @throws \RuntimeException Reaction has no user id.
      *
      * @return ExtendedPromiseInterface
+     *
+     * @see Message::deleteReaction()
+     *
+     * @link https://discord.com/developers/docs/resources/channel#delete-own-reaction
+     * @link https://discord.com/developers/docs/resources/channel#delete-user-reaction
      */
     public function delete(?int $type = null): ExtendedPromiseInterface
     {

--- a/src/Discord/Repository/Channel/ReactionRepository.php
+++ b/src/Discord/Repository/Channel/ReactionRepository.php
@@ -52,6 +52,8 @@ class ReactionRepository extends AbstractRepository
      * @param Part|string $part   The Reaction part or unicode emoji to delete.
      *
      * @return ExtendedPromiseInterface<Reaction>
+     *
+     * @since 10.0.0
      */
     public function delete($part, ?string $reason = null): ExtendedPromiseInterface
     {

--- a/src/Discord/Repository/Channel/ReactionRepository.php
+++ b/src/Discord/Repository/Channel/ReactionRepository.php
@@ -11,8 +11,10 @@
 
 namespace Discord\Repository\Channel;
 
+use Discord\Http\Endpoint;
 use Discord\Parts\Channel\Reaction;
 use Discord\Repository\AbstractRepository;
+use React\Promise\ExtendedPromiseInterface;
 
 /**
  * Contains reactions on a message.
@@ -22,18 +24,21 @@ use Discord\Repository\AbstractRepository;
  *
  * @since 5.1.0
  *
- * @method Reaction|null get(string $discrim, $key)
- * @method Reaction|null pull(string|int $key, $default = null)
- * @method Reaction|null first()
- * @method Reaction|null last()
- * @method Reaction|null find()
+ * @method Reaction|null                  get(string $discrim, $key)
+ * @method Reaction|null                  pull(string|int $key, $default = null)
+ * @method Reaction|null                  first()
+ * @method Reaction|null                  last()
+ * @method Reaction|null                  find()
+ * @method ExtendedPromiseInterface<Part> delete(Part|string $part, ?string $reason = null) Delete all reactions for emoji
  */
 class ReactionRepository extends AbstractRepository
 {
     /**
      * @inheritDoc
      */
-    protected $endpoints = [];
+    protected $endpoints = [
+        'delete' => Endpoint::MESSAGE_REACTION_EMOJI,
+    ];
 
     /**
      * @inheritDoc

--- a/src/Discord/Repository/Channel/ReactionRepository.php
+++ b/src/Discord/Repository/Channel/ReactionRepository.php
@@ -24,12 +24,11 @@ use React\Promise\ExtendedPromiseInterface;
  *
  * @since 5.1.0
  *
- * @method Reaction|null                  get(string $discrim, $key)
- * @method Reaction|null                  pull(string|int $key, $default = null)
- * @method Reaction|null                  first()
- * @method Reaction|null                  last()
- * @method Reaction|null                  find()
- * @method ExtendedPromiseInterface<Part> delete(Part|string $part, ?string $reason = null) Delete all reactions for emoji
+ * @method Reaction|null get(string $discrim, $key)
+ * @method Reaction|null pull(string|int $key, $default = null)
+ * @method Reaction|null first()
+ * @method Reaction|null last()
+ * @method Reaction|null find()
  */
 class ReactionRepository extends AbstractRepository
 {
@@ -44,4 +43,23 @@ class ReactionRepository extends AbstractRepository
      * @inheritDoc
      */
     protected $class = Reaction::class;
+
+    /**
+     * Delete all reactions for emoji
+     *
+     * {@inheritDoc}
+     *
+     * @param Part|string $part   The Reaction part or unicode emoji to delete.
+     *
+     * @return ExtendedPromiseInterface<Reaction>
+     */
+    public function delete($part, ?string $reason = null): ExtendedPromiseInterface
+    {
+        // Deal with unicode emoji
+        if (! ($part instanceof Reaction) && ! is_numeric($part)) {
+            $part = $this->create([$this->discrim => $part, 'emoji' => (object) ['id' => null, 'name' => $part]], true);
+        }
+
+        return parent::delete($part, $reason);
+    }
 }

--- a/src/Discord/WebSockets/Events/MessageDelete.php
+++ b/src/Discord/WebSockets/Events/MessageDelete.php
@@ -54,6 +54,10 @@ class MessageDelete extends Event
             }
         }
 
+        if ($messagePart) {
+            $messagePart->reactions->cache->clear();
+        }
+
         return $messagePart ?? $data;
     }
 }

--- a/src/Discord/WebSockets/Events/MessageReactionAdd.php
+++ b/src/Discord/WebSockets/Events/MessageReactionAdd.php
@@ -65,18 +65,24 @@ class MessageReactionAdd extends Event
                     }
 
                     $addedReaction = true;
-                    $reaction = $react;
                     break;
                 }
             }
 
             // New reaction added
             if (! $addedReaction) {
-                $reaction->count = 1;
-                $reaction->me = $data->user_id == $this->discord->id;
+                /** @var Reaction */
+                $react = $message->reactions->create([
+                    'count' => 1,
+                    'me' => $reaction->user_id == $this->discord->id,
+                    'emoji' => $reaction->emoji->getRawAttributes(),
+                    'channel_id' => $data->channel_id,
+                    'message_id' => $data->message_id,
+                    'guild_id' => $data->guild_id ?? null,
+                ], true);
             }
 
-            $message->reactions->set($reaction->reaction_id, $reaction);
+            $message->reactions->pushItem($react);
         }
 
         if (isset($data->member->user)) {

--- a/src/Discord/WebSockets/Events/MessageReactionRemoveAll.php
+++ b/src/Discord/WebSockets/Events/MessageReactionRemoveAll.php
@@ -52,7 +52,7 @@ class MessageReactionRemoveAll extends Event
 
         /** @var ?Message */
         if (isset($channel) && $message = yield $channel->messages->cacheGet($data->message_id)) {
-            $message->reactions->clear();
+            yield $message->reactions->cache->clear();
         }
 
         return $reaction;

--- a/src/Discord/WebSockets/Events/MessageReactionRemoveEmoji.php
+++ b/src/Discord/WebSockets/Events/MessageReactionRemoveEmoji.php
@@ -52,7 +52,7 @@ class MessageReactionRemoveEmoji extends Event
 
         /** @var ?Message */
         if (isset($channel) && $message = yield $channel->messages->cacheGet($data->message_id)) {
-            yield $message->reactions->cache->delete($reaction->emoji->toReactionString());
+            yield $message->reactions->cache->delete($reaction->reaction_id);
         }
 
         return $reaction;


### PR DESCRIPTION
BC replace ID formatting,

Reaction ID (for repository discriminator & cache offset) now uses the unicode emoji character (👍) or if it's a custom emoji just use the id (1032994718054891521).
Affected class: Reaction & MessageReaction

also fixed emoji cast to string (already applied in v7)