### PR TITLE
Rename Channel allowX methods, add Guild createSticker & createEmoji exceptions, fix ReactionRepository delete, etc

### DIFF
--- a/src/Discord/Discord.php
+++ b/src/Discord/Discord.php
@@ -1212,7 +1212,7 @@ class Discord
     {
         $deferred = new Deferred();
 
-        if (! $channel->allowVoice()) {
+        if (! $channel->isVoiceBased()) {
             $deferred->reject(new \RuntimeException('Channel must allow voice.'));
 
             return $deferred->promise();

--- a/src/Discord/Parts/Channel/Channel.php
+++ b/src/Discord/Parts/Channel/Channel.php
@@ -619,8 +619,8 @@ class Channel extends Part
             ->setAllowedTypes('target_type', 'int')
             ->setAllowedTypes('target_user_id', ['string', 'int'])
             ->setAllowedTypes('target_application_id', ['string', 'int'])
-            ->setAllowedValues('max_age', range(0, 604800))
-            ->setAllowedValues('max_uses', range(0, 100));
+            ->setAllowedValues('max_age', fn ($value) => ($value >= 0 && $value <= 604800))
+            ->setAllowedValues('max_uses', fn ($value) => ($value >= 0 && $value <= 100));
 
         $options = $resolver->resolve($options);
 
@@ -729,7 +729,7 @@ class Channel extends Part
         $resolver->setAllowedTypes('before', [Message::class, 'string']);
         $resolver->setAllowedTypes('after', [Message::class, 'string']);
         $resolver->setAllowedTypes('around', [Message::class, 'string']);
-        $resolver->setAllowedValues('limit', range(1, 100));
+        $resolver->setAllowedValues('limit', fn ($value) => ($value >= 1 && $value <= 100));
 
         $options = $resolver->resolve($options);
         if (isset($options['before'], $options['after']) ||

--- a/src/Discord/Parts/Channel/Channel.php
+++ b/src/Discord/Parts/Channel/Channel.php
@@ -479,7 +479,7 @@ class Channel extends Part
      */
     public function moveMember($member, ?string $reason = null): ExtendedPromiseInterface
     {
-        if (! $this->allowVoice()) {
+        if (! $this->isVoiceBased()) {
             return reject(new \RuntimeException('You cannot move a member in a text channel.'));
         }
 
@@ -514,7 +514,7 @@ class Channel extends Part
      */
     public function muteMember($member, ?string $reason = null): ExtendedPromiseInterface
     {
-        if (! $this->allowVoice()) {
+        if (! $this->isVoiceBased()) {
             return reject(new \RuntimeException('You cannot mute a member in a text channel.'));
         }
 
@@ -549,7 +549,7 @@ class Channel extends Part
      */
     public function unmuteMember($member, ?string $reason = null): ExtendedPromiseInterface
     {
-        if (! $this->allowVoice()) {
+        if (! $this->isVoiceBased()) {
             return reject(new \RuntimeException('You cannot unmute a member in a text channel.'));
         }
 
@@ -591,7 +591,7 @@ class Channel extends Part
      */
     public function createInvite($options = []): ExtendedPromiseInterface
     {
-        if (! $this->allowInvite()) {
+        if (! $this->canInvite()) {
             return reject(new \RuntimeException('You cannot create invite in this type of channel.'));
         }
 
@@ -1074,7 +1074,7 @@ class Channel extends Part
             }
         }
 
-        if (! $this->allowText()) {
+        if (! $this->isTextBased()) {
             return reject(new \RuntimeException('You can only send messages to text channels.'));
         }
 
@@ -1160,7 +1160,7 @@ class Channel extends Part
      */
     public function broadcastTyping(): ExtendedPromiseInterface
     {
-        if (! $this->allowText()) {
+        if (! $this->isTextBased()) {
             return reject(new \RuntimeException('You cannot broadcast typing to a voice channel.'));
         }
 
@@ -1225,28 +1225,64 @@ class Channel extends Part
      * Returns if allow text.
      *
      * @return bool if we can send text or not.
+     *
+     * @deprecated 10.0.0 Use `Channel::isTextBased()`
      */
     public function allowText()
     {
-        return in_array($this->type, [self::TYPE_GUILD_TEXT, self::TYPE_DM, self::TYPE_GUILD_VOICE, self::TYPE_GROUP_DM, self::TYPE_GUILD_ANNOUNCEMENT]);
+        return $this->isTextBased();
     }
 
     /**
      * Returns if allow voice.
      *
      * @return bool if we can send voice or not.
+     *
+     * @deprecated 10.0.0 Use `Channel::isVoiceBased()`
      */
     public function allowVoice()
     {
-        return in_array($this->type, [self::TYPE_GUILD_VOICE, self::TYPE_GUILD_STAGE_VOICE]);
+        return $this->isVoiceBased();
     }
 
     /**
      * Returns if allow invite.
      *
      * @return bool if we can make invite or not.
+     *
+     * @deprecated 10.0.0 Use `Channel::canInvite()`
      */
     public function allowInvite()
+    {
+        return $this->canInvite();
+    }
+
+    /**
+     * Returns if channel type is text based.
+     *
+     * @return bool Whether the channel is possible for sending text.
+     */
+    public function isTextBased()
+    {
+        return in_array($this->type, [self::TYPE_GUILD_TEXT, self::TYPE_DM, self::TYPE_GUILD_VOICE, self::TYPE_GROUP_DM, self::TYPE_GUILD_ANNOUNCEMENT]);
+    }
+
+    /**
+     * Returns if channel type is voice based.
+     *
+     * @return bool Wether the channel is possible for voice.
+     */
+    public function isVoiceBased()
+    {
+        return in_array($this->type, [self::TYPE_GUILD_VOICE, self::TYPE_GUILD_STAGE_VOICE]);
+    }
+
+    /**
+     * Returns if invite can be created in this type of channel.
+     *
+     * @return bool Whether the channel type is possible for creating invite.
+     */
+    public function canInvite()
     {
         return in_array($this->type, [self::TYPE_GUILD_TEXT, self::TYPE_GUILD_VOICE, self::TYPE_GUILD_ANNOUNCEMENT, self::TYPE_GUILD_STAGE_VOICE, self::TYPE_GUILD_FORUM]);
     }

--- a/src/Discord/Parts/Channel/Reaction.php
+++ b/src/Discord/Parts/Channel/Reaction.php
@@ -113,7 +113,7 @@ class Reaction extends Part
             ->setAllowedTypes('after', ['int', 'string', User::class])
             ->setAllowedTypes('limit', 'int')
             ->setNormalizer('after', normalizePartId())
-            ->setAllowedValues('limit', range(1, 100));
+            ->setAllowedValues('limit', fn ($value) => ($value >= 1 && $value <= 100));
 
         $options = $resolver->resolve($options);
 

--- a/src/Discord/Parts/Guild/Guild.php
+++ b/src/Discord/Parts/Guild/Guild.php
@@ -797,10 +797,11 @@ class Guild extends Part
             return reject(new \LengthException("Description must be 2 to 100 characters, given {$descLength}."));
         }
 
+        $extension = strtolower(pathinfo($filepath, PATHINFO_EXTENSION));
+
         if (function_exists('mime_content_type')) {
             $contentType = \mime_content_type($filepath);
         } else {
-            $extension = strtolower(pathinfo($filepath, PATHINFO_EXTENSION));
             $contentTypes = [
                 'png' => 'image/png',
                 'apng' => 'image/apng',

--- a/src/Discord/Parts/Guild/Guild.php
+++ b/src/Discord/Parts/Guild/Guild.php
@@ -43,6 +43,7 @@ use React\Promise\ExtendedPromiseInterface;
 use ReflectionClass;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
+use function Discord\normalizePartId;
 use function Discord\poly_strlen;
 use function React\Promise\reject;
 use function React\Promise\resolve;
@@ -950,17 +951,11 @@ class Guild extends Part
         ->setAllowedTypes('before', ['string', 'int', Entry::class])
         ->setAllowedTypes('limit', 'int')
         ->setAllowedValues('action_type', array_values((new ReflectionClass(Entry::class))->getConstants()))
-        ->setAllowedValues('limit', range(1, 100));
+        ->setAllowedValues('limit', range(1, 100))
+        ->setNormalizer('user_id', normalizePartId())
+        ->setNormalizer('before', normalizePartId());
 
         $options = $resolver->resolve($options);
-
-        if ($options['user_id'] ?? null instanceof Part) {
-            $options['user_id'] = $options['user_id']->id;
-        }
-
-        if ($options['before'] ?? null instanceof Part) {
-            $options['before'] = $options['before']->id;
-        }
 
         $botperms = $this->getBotPermissions();
         if ($botperms && ! $botperms->view_audit_log) {

--- a/src/Discord/Parts/Guild/Guild.php
+++ b/src/Discord/Parts/Guild/Guild.php
@@ -339,10 +339,17 @@ class Guild extends Part
      *
      * @link https://discord.com/developers/docs/resources/guild#get-guild-invites
      *
+     * @throws NoPermissionsException Missing manage_guild permission.
+     *
      * @return ExtendedPromiseInterface<Collection|Invite[]>
      */
     public function getInvites(): ExtendedPromiseInterface
     {
+        $botperms = $this->getBotPermissions();
+        if ($botperms && ! $botperms->manage_guild) {
+            return reject(new NoPermissionsException("You do not have permission to manage the guild {$this->guild_id}."));
+        }
+
         return $this->http->get(Endpoint::bind(Endpoint::GUILD_INVITES, $this->id))->then(function ($response) {
             $invites = Collection::for(Invite::class, 'code');
 

--- a/src/Discord/Parts/Guild/Guild.php
+++ b/src/Discord/Parts/Guild/Guild.php
@@ -347,7 +347,7 @@ class Guild extends Part
     {
         $botperms = $this->getBotPermissions();
         if ($botperms && ! $botperms->manage_guild) {
-            return reject(new NoPermissionsException("You do not have permission to manage the guild {$this->guild_id}."));
+            return reject(new NoPermissionsException("You do not have permission to manage the guild {$this->id}."));
         }
 
         return $this->http->get(Endpoint::bind(Endpoint::GUILD_INVITES, $this->id))->then(function ($response) {
@@ -377,7 +377,7 @@ class Guild extends Part
     {
         $botperms = $this->getBotPermissions();
         if ($botperms && ! $botperms->ban_members) {
-            return reject(new NoPermissionsException("You do not have permission to ban members in the guild {$this->guild_id}."));
+            return reject(new NoPermissionsException("You do not have permission to ban members in the guild {$this->id}."));
         }
 
         return $this->bans->unban($user);
@@ -666,7 +666,7 @@ class Guild extends Part
         $botperms = $this->getBotPermissions();
 
         if ($botperms && ! $botperms->manage_roles) {
-            return reject(new NoPermissionsException('You do not have permission to manage roles in the specified guild.'));
+            return reject(new NoPermissionsException("You do not have permission to manage roles in the guild {$this->id}."));
         }
 
         return $this->roles->save($this->factory->part(Role::class, $data), $reason);
@@ -712,7 +712,7 @@ class Guild extends Part
 
         $botperms = $this->getBotPermissions();
         if ($botperms && ! $botperms->manage_emojis_and_stickers) {
-            return reject(new NoPermissionsException("You do not have permission to manage emojis in the guild {$this->guild_id}."));
+            return reject(new NoPermissionsException("You do not have permission to manage emojis in the guild {$this->id}."));
         }
 
         if (isset($filepath)) {
@@ -784,7 +784,7 @@ class Guild extends Part
 
         $botperms = $this->getBotPermissions();
         if ($botperms && ! $botperms->manage_emojis_and_stickers) {
-            return reject(new NoPermissionsException("You do not have permission to manage stickers in the guild {$this->guild_id}."));
+            return reject(new NoPermissionsException("You do not have permission to manage stickers in the guild {$this->id}."));
         }
 
         if (! file_exists($filepath)) {
@@ -964,7 +964,7 @@ class Guild extends Part
 
         $botperms = $this->getBotPermissions();
         if ($botperms && ! $botperms->view_audit_log) {
-            return reject(new NoPermissionsException("You do not have permission to view audit log in the guild {$this->guild_id}."));
+            return reject(new NoPermissionsException("You do not have permission to view audit log in the guild {$this->id}."));
         }
 
         $endpoint = Endpoint::bind(Endpoint::AUDIT_LOG, $this->id);
@@ -1009,7 +1009,7 @@ class Guild extends Part
     {
         $botperms = $this->getBotPermissions();
         if ($botperms && ! $botperms->manage_roles) {
-            return reject(new NoPermissionsException("You do not have permission to manage roles in the guild {$this->guild_id}."));
+            return reject(new NoPermissionsException("You do not have permission to manage roles in the guild {$this->id}."));
         }
 
         $payload = [];
@@ -1110,7 +1110,7 @@ class Guild extends Part
 
         $botperms = $this->getBotPermissions();
         if ($botperms && ! $botperms->kick_members) {
-            return reject(new NoPermissionsException("You do not have permission to kick members in the guild {$this->guild_id}."));
+            return reject(new NoPermissionsException("You do not have permission to kick members in the guild {$this->id}."));
         }
 
         $endpoint = Endpoint::bind(Endpoint::GUILD_PRUNE, $this->id);
@@ -1158,7 +1158,7 @@ class Guild extends Part
 
         $botperms = $this->getBotPermissions();
         if ($botperms && ! $botperms->kick_members) {
-            return reject(new NoPermissionsException("You do not have permission to kick members in the guild {$this->guild_id}."));
+            return reject(new NoPermissionsException("You do not have permission to kick members in the guild {$this->id}."));
         }
 
         $headers = [];
@@ -1187,7 +1187,7 @@ class Guild extends Part
         if (! $this->feature_welcome_screen_enabled) {
             $botperms = $this->getBotPermissions();
             if ($botperms && ! $botperms->manage_guild) {
-                return reject(new NoPermissionsException("You do not have permission to manage the guild {$this->guild_id}."));
+                return reject(new NoPermissionsException("You do not have permission to manage the guild {$this->id}."));
             }
         }
 
@@ -1255,7 +1255,7 @@ class Guild extends Part
 
         $botperms = $this->getBotPermissions();
         if ($botperms && ! $botperms->manage_guild) {
-            return reject(new NoPermissionsException("You do not have permission to manage the guild {$this->guild_id}."));
+            return reject(new NoPermissionsException("You do not have permission to manage the guild {$this->id}."));
         }
 
         return $this->http->patch(Endpoint::bind(Endpoint::GUILD_WELCOME_SCREEN, $this->id), $options)->then(function ($response) {
@@ -1278,7 +1278,7 @@ class Guild extends Part
     {
         $botperms = $this->getBotPermissions();
         if ($botperms && ! $botperms->manage_guild) {
-            return reject(new NoPermissionsException("You do not have permission to manage the guild {$this->guild_id}."));
+            return reject(new NoPermissionsException("You do not have permission to manage the guild {$this->id}."));
         }
 
         return $this->http->get(Endpoint::bind(Endpoint::GUILD_WIDGET_SETTINGS, $this->id))->then(function ($response) {
@@ -1317,7 +1317,7 @@ class Guild extends Part
 
         $botperms = $this->getBotPermissions();
         if ($botperms && ! $botperms->manage_guild) {
-            return reject(new NoPermissionsException("You do not have permission to manage the guild {$this->guild_id}."));
+            return reject(new NoPermissionsException("You do not have permission to manage the guild {$this->id}."));
         }
 
         $headers = [];
@@ -1370,7 +1370,7 @@ class Guild extends Part
         });
 
         if (! $channel) {
-            return reject(new \RuntimeException('No channels found to create an Invite to the specified guild.'));
+            return reject(new \RuntimeException("No channels found to create an Invite to the guild {$this->id}."));
         }
 
         return $channel->createInvite($args);

--- a/src/Discord/Parts/Guild/Guild.php
+++ b/src/Discord/Parts/Guild/Guild.php
@@ -1270,10 +1270,17 @@ class Guild extends Part
      *
      * @link https://discord.com/developers/docs/resources/guild#get-guild-widget-settings
      *
+     * @throws NoPermissionsException Missing manage_guild permission.
+     *
      * @return ExtendedPromiseInterface
      */
     public function getWidgetSettings(): ExtendedPromiseInterface
     {
+        $botperms = $this->getBotPermissions();
+        if ($botperms && ! $botperms->manage_guild) {
+            return reject(new NoPermissionsException("You do not have permission to manage the guild {$this->guild_id}."));
+        }
+
         return $this->http->get(Endpoint::bind(Endpoint::GUILD_WIDGET_SETTINGS, $this->id))->then(function ($response) {
             $this->widget_enabled = $response->enabled;
             $this->widget_channel_id = $response->channel_id;
@@ -1292,6 +1299,8 @@ class Guild extends Part
      *                        channel_id => the widget channel id
      * @param string $reason  Reason for Audit Log.
      *
+     * @throws NoPermissionsException Missing manage_guild permission.
+     *
      * @return ExtendedPromiseInterface The updated guild widget object.
      */
     public function updateWidgetSettings(array $options, ?string $reason = null): ExtendedPromiseInterface
@@ -1305,6 +1314,11 @@ class Guild extends Part
         ->setAllowedTypes('channel_id', ['string', 'null']);
 
         $options = $resolver->resolve($options);
+
+        $botperms = $this->getBotPermissions();
+        if ($botperms && ! $botperms->manage_guild) {
+            return reject(new NoPermissionsException("You do not have permission to manage the guild {$this->guild_id}."));
+        }
 
         $headers = [];
         if (isset($reason)) {

--- a/src/Discord/Parts/Guild/Guild.php
+++ b/src/Discord/Parts/Guild/Guild.php
@@ -661,6 +661,8 @@ class Guild extends Part
     /**
      * Creates an Emoji for the guild.
      *
+     * @link https://discord.com/developers/docs/resources/emoji#create-guild-emoji
+     *
      * @param array       $options          An array of options.
      * @param string      $options['name']  Name of the emoji.
      * @param string|null $options['image'] The 128x128 emoji image (if not using `$filepath`).
@@ -672,8 +674,6 @@ class Guild extends Part
      * @throws FileNotFoundException  File does not exist.
      *
      * @return ExtendedPromiseInterface<Emoji>
-     *
-     * @link https://discord.com/developers/docs/resources/emoji#create-guild-emoji
      */
     public function createEmoji(array $options, ?string $filepath = null, ?string $reason = null): ExtendedPromiseInterface
     {
@@ -734,6 +734,8 @@ class Guild extends Part
     /**
      * Creates an Sticker for the guild.
      *
+     * @link https://discord.com/developers/docs/resources/sticker#create-guild-sticker
+     *
      * @param array       $options                An array of options.
      * @param string      $options['name']        Name of the sticker.
      * @param string|null $options['description'] Description of the sticker (empty or 2-100 characters).
@@ -748,8 +750,6 @@ class Guild extends Part
      * @throws \RuntimeException      Guild is not verified or partnered to upload Lottie stickers.
      *
      * @return ExtendedPromiseInterface<Sticker>
-     *
-     * @link https://discord.com/developers/docs/resources/sticker#create-guild-sticker
      */
     public function createSticker(array $options, string $filepath, ?string $reason = null): ExtendedPromiseInterface
     {

--- a/src/Discord/Parts/Guild/Guild.php
+++ b/src/Discord/Parts/Guild/Guild.php
@@ -926,11 +926,13 @@ class Guild extends Part
      *
      * @link https://discord.com/developers/docs/resources/audit-log#get-guild-audit-log
      *
-     * @param array $options An array of options.
-     *                       user_id => filter the log for actions made by a user
-     *                       action_type => the type of audit log event
-     *                       before => filter the log before a certain entry id
-     *                       limit => how many entries are returned (default 50, minimum 1, maximum 100)
+     * @param array                   $options An array of options.
+     * @param string|Member|User|null $options['user_id'] filter the log for actions made by a user
+     * @param int|null                $options['action_type'] the type of audit log event
+     * @param string|Entry|null       $options['before'] filter the log before a certain entry id
+     * @param int|null                $options['limit'] how many entries are returned (default 50, minimum 1, maximum 100)
+     *
+     * @throws NoPermissionsException Missing view_audit_log permission.
      *
      * @return ExtendedPromiseInterface<AuditLog>
      */
@@ -958,6 +960,11 @@ class Guild extends Part
 
         if ($options['before'] ?? null instanceof Part) {
             $options['before'] = $options['before']->id;
+        }
+
+        $botperms = $this->getBotPermissions();
+        if ($botperms && ! $botperms->view_audit_log) {
+            return reject(new NoPermissionsException("You do not have permission to view audit log in the guild {$this->guild_id}."));
         }
 
         $endpoint = Endpoint::bind(Endpoint::AUDIT_LOG, $this->id);

--- a/src/Discord/Parts/Guild/Guild.php
+++ b/src/Discord/Parts/Guild/Guild.php
@@ -633,7 +633,7 @@ class Guild extends Part
      *
      * @link https://discord.com/developers/docs/resources/voice#list-voice-regions
      *
-     * @return ExtendedPromiseInterface
+     * @return ExtendedPromiseInterface<Collection>
      */
     public function getVoiceRegions(): ExtendedPromiseInterface
     {
@@ -658,7 +658,7 @@ class Guild extends Part
      * @param array       $data   The data to fill the role with.
      * @param string|null $reason Reason for Audit Log.
      *
-     * @throws NoPermissionsException
+     * @throws NoPermissionsException Missing manage_roles permission.
      *
      * @return ExtendedPromiseInterface<Role>
      */
@@ -876,7 +876,7 @@ class Guild extends Part
      * @param Member|int  $member The member to transfer ownership to.
      * @param string|null $reason Reason for Audit Log.
      *
-     * @throws \RuntimeException
+     * @throws \RuntimeException Ownership not transferred correctly.
      *
      * @return ExtendedPromiseInterface
      */
@@ -1397,7 +1397,7 @@ class Guild extends Part
      * @param int         $level  The new MFA level `Guild::MFA_NONE` or `Guild::MFA_ELEVATED`.
      * @param string|null $reason Reason for Audit Log.
      *
-     * @return ExtendedPromiseInterface<Guild> This guild.
+     * @return ExtendedPromiseInterface<self> This guild.
      */
     public function updateMFALevel(int $level, ?string $reason = null): ExtendedPromiseInterface
     {
@@ -1421,7 +1421,7 @@ class Guild extends Part
      * @param bool[]      $features Array of features to set/unset, e.g. `['COMMUNITY' => true, 'INVITES_DISABLED' => false]`.
      * @param string|null $reason   Reason for Audit Log.
      *
-     * @return ExtendedPromiseInterface<Guild> This guild.
+     * @return ExtendedPromiseInterface<self> This guild.
      *
      * @throws \OutOfRangeException Feature is not mutable.
      * @throws \RuntimeException    Guild feature is already set.

--- a/src/Discord/Parts/Guild/Guild.php
+++ b/src/Discord/Parts/Guild/Guild.php
@@ -952,7 +952,7 @@ class Guild extends Part
         ->setAllowedTypes('before', ['string', 'int', Entry::class])
         ->setAllowedTypes('limit', 'int')
         ->setAllowedValues('action_type', array_values((new ReflectionClass(Entry::class))->getConstants()))
-        ->setAllowedValues('limit', range(1, 100))
+        ->setAllowedValues('limit', fn ($value) => ($value >= 1 && $value <= 100))
         ->setNormalizer('user_id', normalizePartId())
         ->setNormalizer('before', normalizePartId());
 
@@ -1053,7 +1053,7 @@ class Guild extends Part
         ->setDefault('limit', 1)
         ->setAllowedTypes('query', 'string')
         ->setAllowedTypes('limit', 'int')
-        ->setAllowedValues('limit', range(1, 1000));
+        ->setAllowedValues('limit', fn ($value) => ($value >= 1 && $value <= 1000));
 
         $options = $resolver->resolve($options);
 
@@ -1100,7 +1100,7 @@ class Guild extends Part
         ->setDefault('days', 7)
         ->setAllowedTypes('days', 'int')
         ->setAllowedTypes('include_roles', 'array')
-        ->setAllowedValues('days', range(1, 30))
+        ->setAllowedValues('days', fn ($value) => ($value >= 1 && $value <= 30))
         ->setNormalizer('include_roles', function ($option, $values) {
             foreach ($values as &$value) {
                 if ($value instanceof Role) {
@@ -1157,7 +1157,7 @@ class Guild extends Part
         ->setAllowedTypes('days', 'int')
         ->setAllowedTypes('compute_prune_count', 'bool')
         ->setAllowedTypes('include_roles', 'array')
-        ->setAllowedValues('days', range(1, 30))
+        ->setAllowedValues('days', fn ($value) => ($value >= 1 && $value <= 30))
         ->setNormalizer('include_roles', function ($option, $values) {
             foreach ($values as &$value) {
                 if ($value instanceof Role) {

--- a/src/Discord/Parts/Guild/Guild.php
+++ b/src/Discord/Parts/Guild/Guild.php
@@ -1041,9 +1041,9 @@ class Guild extends Part
      *
      * @link https://discord.com/developers/docs/resources/guild#search-guild-members
      *
-     * @param array $options An array of options.
-     *                       query => query string to match username(s) and nickname(s) against
-     *                       limit => how many entries are returned (default 1, minimum 1, maximum 1000)
+     * @param array       $options          An array of options. All fields are optional.
+     * @param string|null $options['query'] Query string to match username(s) and nickname(s) against
+     * @param int|null    $options['limit'] How many entries are returned (default 1, minimum 1, maximum 1000)
      *
      * @return ExtendedPromiseInterface<Collection|Member[]>
      */
@@ -1338,7 +1338,7 @@ class Guild extends Part
      *
      * @link https://discord.com/developers/docs/resources/guild#get-guild-widget
      *
-     * @return ExtendedPromiseInterface<WelcomeScreen>
+     * @return ExtendedPromiseInterface<Widget>
      */
     public function getWidget(): ExtendedPromiseInterface
     {

--- a/src/Discord/Parts/Guild/Guild.php
+++ b/src/Discord/Parts/Guild/Guild.php
@@ -1259,7 +1259,7 @@ class Guild extends Part
     public function createInvite(...$args): ExtendedPromiseInterface
     {
         $channel = $this->channels->find(function (Channel $channel) {
-            if ($channel->allowInvite()) {
+            if ($channel->canInvite()) {
                 if ($botperms = $channel->getBotPermissions()) {
                     return $botperms->create_instant_invite;
                 }

--- a/src/Discord/Parts/Guild/Guild.php
+++ b/src/Discord/Parts/Guild/Guild.php
@@ -1081,9 +1081,9 @@ class Guild extends Part
      *
      * @link https://discord.com/developers/docs/resources/guild#get-guild-prune-count
      *
-     * @param array         $options                  An array of options.
-     * @param int|null      $options['days']          Number of days to count prune for (1-30), defaults to 7.
-     * @param string[]|null $options['include_roles'] Role id(s) to include.
+     * @param array                $options                  An array of options.
+     * @param int|null             $options['days']          Number of days to count prune for (1-30), defaults to 7.
+     * @param string[]|Role[]|null $options['include_roles'] Roles to include, defaults to none.
      *
      * @throws NoPermissionsException Missing kick_members permission.
      *
@@ -1099,7 +1099,16 @@ class Guild extends Part
         ->setDefault('days', 7)
         ->setAllowedTypes('days', 'int')
         ->setAllowedTypes('include_roles', 'array')
-        ->setAllowedValues('days', range(1, 30));
+        ->setAllowedValues('days', range(1, 30))
+        ->setNormalizer('include_roles', function ($option, $values) {
+            foreach ($values as &$value) {
+                if ($value instanceof Role) {
+                    $value = $value->id;
+                }
+            }
+
+            return $values;
+        });
 
         $options = $resolver->resolve($options);
 
@@ -1125,11 +1134,11 @@ class Guild extends Part
      *
      * @link https://discord.com/developers/docs/resources/guild#begin-guild-prune
      *
-     * @param array         $options                        An array of options.
-     * @param int|null      $options['days']                Number of days to count prune for (1-30), defaults to 7.
-     * @param int|null      $options['compute_prune_count'] Whether 'pruned' is returned, discouraged for large guilds.
-     * @param string[]|null $options['include_roles']       Role id(s) to include.
-     * @param string        $reason                         Reason for Audit Log.
+     * @param array                $options                        An array of options.
+     * @param int|null             $options['days']                Number of days to count prune for (1-30), defaults to 7.
+     * @param int|null             $options['compute_prune_count'] Whether 'pruned' is returned, discouraged for large guilds.
+     * @param string[]|Role[]|null $options['include_roles']       Roles to include, defaults to none.
+     * @param string               $reason                         Reason for Audit Log.
      *
      * @throws NoPermissionsException Missing kick_members permission.
      *
@@ -1147,7 +1156,16 @@ class Guild extends Part
         ->setAllowedTypes('days', 'int')
         ->setAllowedTypes('compute_prune_count', 'bool')
         ->setAllowedTypes('include_roles', 'array')
-        ->setAllowedValues('days', range(1, 30));
+        ->setAllowedValues('days', range(1, 30))
+        ->setNormalizer('include_roles', function ($option, $values) {
+            foreach ($values as &$value) {
+                if ($value instanceof Role) {
+                    $value = $value->id;
+                }
+            }
+
+            return $values;
+        });
 
         $options = $resolver->resolve($options);
 

--- a/src/Discord/Parts/Guild/Guild.php
+++ b/src/Discord/Parts/Guild/Guild.php
@@ -997,15 +997,21 @@ class Guild extends Part
      *
      * @link https://discord.com/developers/docs/resources/guild#modify-guild-role-positions
      *
-     * The `$roles` array should be an associative array where the LHS key is the position,
-     * and the RHS value is a `Role` object or a string ID, e.g. [1 => 'role_id_1', 3 => 'role_id_3'].
+     * @param array $roles Associative array where the LHS key is the position,
+     *                     and the RHS value is a `Role` object or a string ID,
+     *                     e.g. `[1 => 'role_id_1', 3 => 'role_id_3']`.
      *
-     * @param array $roles
+     * @throws NoPermissionsException Missing manage_roles permission.
      *
-     * @return ExtendedPromiseInterface
+     * @return ExtendedPromiseInterface<self>
      */
     public function updateRolePositions(array $roles): ExtendedPromiseInterface
     {
+        $botperms = $this->getBotPermissions();
+        if ($botperms && ! $botperms->manage_roles) {
+            return reject(new NoPermissionsException("You do not have permission to manage roles in the guild {$this->guild_id}."));
+        }
+
         $payload = [];
 
         foreach ($roles as $position => $role) {

--- a/src/Discord/Parts/Guild/Guild.php
+++ b/src/Discord/Parts/Guild/Guild.php
@@ -369,10 +369,17 @@ class Guild extends Part
      *
      * @param User|string $user
      *
+     * @throws NoPermissionsException Missing ban_members permission.
+     *
      * @return ExtendedPromiseInterface
      */
     public function unban($user): ExtendedPromiseInterface
     {
+        $botperms = $this->getBotPermissions();
+        if ($botperms && ! $botperms->ban_members) {
+            return reject(new NoPermissionsException("You do not have permission to ban members in the guild {$this->guild_id}."));
+        }
+
         return $this->bans->unban($user);
     }
 

--- a/src/Discord/Parts/Guild/Guild.php
+++ b/src/Discord/Parts/Guild/Guild.php
@@ -690,6 +690,10 @@ class Guild extends Part
             ->setAllowedTypes('roles', 'array')
             ->setDefault('roles', []);
 
+        if (is_null($filepath)) {
+            $resolver->setRequired('image');
+        }
+
         $options = $resolver->resolve($options);
 
         $botperms = $this->getBotPermissions();

--- a/src/Discord/Parts/Guild/Guild.php
+++ b/src/Discord/Parts/Guild/Guild.php
@@ -31,6 +31,7 @@ use Discord\Repository\Guild\MemberRepository;
 use Discord\Repository\Guild\RoleRepository;
 use Discord\Parts\Guild\AuditLog\AuditLog;
 use Discord\Parts\Guild\AuditLog\Entry;
+use Discord\Parts\Permissions\RolePermission;
 use Discord\Repository\Guild\AutoModerationRuleRepository;
 use Discord\Repository\Guild\CommandPermissionsRepository;
 use Discord\Repository\Guild\GuildCommandRepository;

--- a/src/Discord/Parts/Guild/ScheduledEvent.php
+++ b/src/Discord/Parts/Guild/ScheduledEvent.php
@@ -103,7 +103,7 @@ class ScheduledEvent extends Part
         $resolver->setAllowedTypes('before', [User::class, 'string']);
         $resolver->setAllowedTypes('after', [User::class, 'string']);
         $resolver->setAllowedTypes('with_member', 'bool');
-        $resolver->setAllowedValues('limit', range(1, 100));
+        $resolver->setAllowedValues('limit', fn ($value) => ($value >= 1 && $value <= 100));
 
         $options = $resolver->resolve($options);
         if (isset($options['before'], $options['after'])) {

--- a/src/Discord/Parts/Thread/Thread.php
+++ b/src/Discord/Parts/Thread/Thread.php
@@ -545,7 +545,7 @@ class Thread extends Part
             ->setAllowedTypes('before', [Message::class, 'string'])
             ->setAllowedTypes('after', [Message::class, 'string'])
             ->setAllowedTypes('around', [Message::class, 'string'])
-            ->setAllowedValues('limit', range(1, 100));
+            ->setAllowedValues('limit', fn ($value) => ($value >= 1 && $value <= 100));
 
         $options = $resolver->resolve($options);
 

--- a/src/Discord/Parts/User/Member.php
+++ b/src/Discord/Parts/User/Member.php
@@ -698,7 +698,7 @@ class Member extends Part
     {
         if ($guild = $this->guild) {
             return $guild->channels->find(function (Channel $channel) {
-                if ($channel->allowVoice() && $members = $channel->members) {
+                if ($channel->isVoiceBased() && $members = $channel->members) {
                     return $members->offsetExists($this->id);
                 }
 

--- a/src/Discord/Repository/Channel/ReactionRepository.php
+++ b/src/Discord/Repository/Channel/ReactionRepository.php
@@ -58,7 +58,7 @@ class ReactionRepository extends AbstractRepository
     public function delete($part, ?string $reason = null): ExtendedPromiseInterface
     {
         // Deal with unicode emoji
-        if (! ($part instanceof Reaction) && ! is_numeric($part)) {
+        if (is_string($part) && ! is_numeric($part)) {
             $part = $this->create([$this->discrim => $part, 'emoji' => (object) ['id' => null, 'name' => $part]], true);
         }
 

--- a/src/Discord/Voice/VoiceClient.php
+++ b/src/Discord/Voice/VoiceClient.php
@@ -939,7 +939,7 @@ class VoiceClient extends EventEmitter
      */
     public function switchChannel(Channel $channel): void
     {
-        if (! $channel->allowVoice()) {
+        if (! $channel->isVoiceBased()) {
             throw new \InvalidArgumentException('Channel must be a voice channel to be able to switch');
         }
 

--- a/src/Discord/WebSockets/Events/VoiceStateUpdate.php
+++ b/src/Discord/WebSockets/Events/VoiceStateUpdate.php
@@ -34,7 +34,7 @@ class VoiceStateUpdate extends Event
         if ($guild = yield $this->discord->guilds->cacheGet($data->guild_id)) {
             /** @var ?Channel */
             foreach ($guild->channels as $channel) {
-                if (! $channel->allowVoice()) {
+                if (! $channel->isVoiceBased()) {
                     continue;
                 }
 


### PR DESCRIPTION
- The `$part` check was too loose for `ReactionRepository::delete()`, changed to use `is_string()`
- Deprecated Channel::allowText() in favor of Channel::isTextBased(), just like most of other libs
- Deprecated Channel::allowVoice() in favor of Channel::isVoiceBased(), just like most of other libs
- Deprecated Channel::allowInvite() in favor of Channel::canInvite()
- Handle exception for `Guild::createSticker()` permission and Lottie sticker type for verified / partnered servers only (https://github.com/discord-php/DiscordPHP/projects/5#card-79941275)
- Handle exception for `Guild::createEmoji()` permission
