### PR TITLE
BC Message::startThread arguments with OptionResolver, Require GMP for 32 bits php

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Before you start using this Library, you **need** to know how PHP works, you nee
 ### Requirements
 
 - PHP 8.0
-	- x86 (32-bit) PHP requires [`ext-gmp` extension](https://www.php.net/manual/en/book.gmp.php) enabled for handling Permissions.
+	- x86 (32-bit) PHP requires [`ext-gmp` extension](https://www.php.net/manual/en/book.gmp.php) enabled.
 - Composer
 - `ext-json`
 - `ext-zlib`

--- a/composer.json
+++ b/composer.json
@@ -44,11 +44,11 @@
         }
     },
     "suggest": {
+        "ext-gmp": "For 64 bit calculations on x86 (32 bit) PHP.",
         "ext-uv": "For a faster, and more performant loop. Preferred.",
         "ext-libev": "For a faster, and more performant loop.",
         "ext-event": "For a faster, and more performant loop.",
         "ext-mbstring": "For accurate calculations of string length when handling non-english characters.",
-        "ext-gmp": "For Permissions and 64 bit calculations on x86 (32 bit) PHP.",
         "clue/zlib-react": "For gateway message transport compression with zlib-stream."
     },
     "scripts": {

--- a/src/Discord/Discord.php
+++ b/src/Discord/Discord.php
@@ -356,7 +356,7 @@ class Discord
 
         // x86 need gmp extension for big integer operation
         if (PHP_INT_SIZE === 4 && ! BigInt::init()) {
-            trigger_error('ext-gmp is not loaded. Big integer calculations (e.g. Permissions) will NOT work correctly!', E_USER_WARNING);
+            trigger_error('ext-gmp is not loaded, it is required for 32-bits (x86) PHP.', E_USER_ERROR);
         }
 
         $options = $this->resolveOptions($options);

--- a/src/Discord/Parts/Channel/Channel.php
+++ b/src/Discord/Parts/Channel/Channel.php
@@ -645,14 +645,14 @@ class Channel extends Part
      * @param array|Traversable $messages An array of messages to delete.
      * @param string|null       $reason   Reason for Audit Log (only for bulk messages).
      *
-     * @throws \UnexpectedValueException
+     * @throws \InvalidArgumentException
      *
      * @return ExtendedPromiseInterface
      */
     public function deleteMessages($messages, ?string $reason = null): ExtendedPromiseInterface
     {
         if (! is_array($messages) && ! ($messages instanceof Traversable)) {
-            return reject(new \UnexpectedValueException('$messages must be an array or implement Traversable.'));
+            return reject(new \InvalidArgumentException('$messages must be an array or implement Traversable.'));
         }
 
         $headers = $promises = $messagesBulk = $messagesSingle = [];
@@ -916,7 +916,6 @@ class Channel extends Part
      * @param string|null    $reason                           Reason for Audit Log.
      *
      * @throws \RuntimeException
-     * @throws \UnexpectedValueException `$auto_archive_duration` is not one of 60, 1440, 4320, 10080.
      *
      * @return ExtendedPromiseInterface<Thread>
      *

--- a/src/Discord/Parts/Channel/Channel.php
+++ b/src/Discord/Parts/Channel/Channel.php
@@ -362,8 +362,8 @@ class Channel extends Part
      * @param Overwrite   $overwrite An overwrite object.
      * @param string|null $reason    Reason for Audit Log.
      *
-     * @throws NoPermissionsException
-     * @throws InvalidOverwriteException
+     * @throws NoPermissionsException    Missing manage_roles permission.
+     * @throws InvalidOverwriteException Overwrite type is not member or role.
      *
      * @return ExtendedPromiseInterface
      */
@@ -371,7 +371,7 @@ class Channel extends Part
     {
         if ($this->guild_id && $botperms = $this->getBotPermissions()) {
             if (! $botperms->manage_roles) {
-                return reject(new NoPermissionsException('You do not have permission to edit roles in the specified channel.'));
+                return reject(new NoPermissionsException("You do not have permission to manage roles in the channel {$this->id}."));
             }
         }
 
@@ -415,7 +415,7 @@ class Channel extends Part
      *
      * @throws \RuntimeException
      * @throws \InvalidArgumentException
-     * @throws NoPermissionsException
+     * @throws NoPermissionsException    Missing manage_channels permission in either channel.
      */
     public function setCategory($category, ?int $position = null, ?string $reason = null): ExtendedPromiseInterface
     {
@@ -425,7 +425,7 @@ class Channel extends Part
 
         if ($botperms = $this->getBotPermissions()) {
             if (! $botperms->manage_channels) {
-                return reject(new NoPermissionsException('You do not have permission to manage this channel.'));
+                return reject(new NoPermissionsException("You do not have permission to manage the channel {$this->id}."));
             }
         }
 
@@ -441,7 +441,7 @@ class Channel extends Part
 
             if ($botperms = $category->getBotPermissions()) {
                 if (! $botperms->manage_channels) {
-                    return reject(new NoPermissionsException('You do not have permission to manage the specified channel.'));
+                    return reject(new NoPermissionsException("You do not have permission to manage the category channel {$category->id}."));
                 }
             }
 
@@ -473,7 +473,7 @@ class Channel extends Part
      * @param string|null   $reason Reason for Audit Log.
      *
      * @throws \RuntimeException
-     * @throws NoPermissionsException
+     * @throws NoPermissionsException Missing move_members permission.
      *
      * @return ExtendedPromiseInterface
      */
@@ -485,7 +485,7 @@ class Channel extends Part
 
         if ($botperms = $this->getBotPermissions()) {
             if (! $botperms->move_members) {
-                return reject(new NoPermissionsException('You do not have permission to move members in the specified channel.'));
+                return reject(new NoPermissionsException("You do not have permission to move members in the channel {$this->id}."));
             }
         }
 
@@ -508,7 +508,7 @@ class Channel extends Part
      * @param string|null   $reason Reason for Audit Log.
      *
      * @throws \RuntimeException
-     * @throws NoPermissionsException
+     * @throws NoPermissionsException Missing mute_members permission.
      *
      * @return ExtendedPromiseInterface
      */
@@ -520,7 +520,7 @@ class Channel extends Part
 
         if ($botperms = $this->getBotPermissions()) {
             if (! $botperms->mute_members) {
-                return reject(new NoPermissionsException('You do not have permission to mute members in the specified channel.'));
+                return reject(new NoPermissionsException("You do not have permission to mute members in the channel {$this->id}."));
             }
         }
 
@@ -543,7 +543,7 @@ class Channel extends Part
      * @param string|null   $reason Reason for Audit Log.
      *
      * @throws \RuntimeException
-     * @throws NoPermissionsException
+     * @throws NoPermissionsException Missing mute_members permission.
      *
      * @return ExtendedPromiseInterface
      */
@@ -555,7 +555,7 @@ class Channel extends Part
 
         if ($botperms = $this->getBotPermissions()) {
             if (! $botperms->mute_members) {
-                return reject(new NoPermissionsException('You do not have permission to unmute members in the specified channel.'));
+                return reject(new NoPermissionsException("You do not have permission to unmute members in the channel {$this->id}."));
             }
         }
 
@@ -585,7 +585,7 @@ class Channel extends Part
      * @param string $options['target_user_id']        The id of the user whose stream to display for this invite, required if target_type is `Invite::TARGET_TYPE_STREAM`, the user must be streaming in the channel.
      * @param string $options['target_application_id'] The id of the embedded application to open for this invite, required if target_type is `Invite::TARGET_TYPE_EMBEDDED_APPLICATION`, the application must have the EMBEDDED flag.
      *
-     * @throws NoPermissionsException
+     * @throws NoPermissionsException Missing create_instant_invite permission.
      *
      * @return ExtendedPromiseInterface<Invite>
      */
@@ -597,7 +597,7 @@ class Channel extends Part
 
         if ($botperms = $this->getBotPermissions()) {
             if (! $botperms->create_instant_invite) {
-                return reject(new NoPermissionsException('You do not have permission to create an invite for the specified channel.'));
+                return reject(new NoPermissionsException("You do not have permission to create instant invite in the channel {$this->id}."));
             }
         }
 
@@ -710,7 +710,7 @@ class Channel extends Part
      *
      * @param array $options
      *
-     * @throws NoPermissionsException
+     * @throws NoPermissionsException Missing read_message_history permission.
      * @throws \RangeException
      *
      * @return ExtendedPromiseInterface<Collection<Message>>
@@ -719,7 +719,7 @@ class Channel extends Part
     {
         if (! $this->is_private && $botperms = $this->getBotPermissions()) {
             if (! $botperms->read_message_history) {
-                return reject(new NoPermissionsException('You do not have permission to read the specified channel\'s message history.'));
+                return reject(new NoPermissionsException("You do not have permission to read message history in the channel {$this->id}."));
             }
         }
 
@@ -773,7 +773,7 @@ class Channel extends Part
      * @param Message     $message The message to pin.
      * @param string|null $reason  Reason for Audit Log.
      *
-     * @throws NoPermissionsException
+     * @throws NoPermissionsException Missing manage_messages permission.
      * @throws \RuntimeException
      *
      * @return ExtendedPromiseInterface<Message>
@@ -782,7 +782,7 @@ class Channel extends Part
     {
         if (! $this->is_private && $botperms = $this->getBotPermissions()) {
             if (! $botperms->manage_messages) {
-                return reject(new NoPermissionsException('You do not have permission to pin messages in the specified channel.'));
+                return reject(new NoPermissionsException("You do not have permission to pin messages in the channel {$this->id}."));
             }
         }
 
@@ -814,7 +814,7 @@ class Channel extends Part
      * @param Message     $message The message to un-pin.
      * @param string|null $reason  Reason for Audit Log.
      *
-     * @throws NoPermissionsException
+     * @throws NoPermissionsException Missing manage_messages permission.
      * @throws \RuntimeException
      *
      * @return ExtendedPromiseInterface
@@ -823,7 +823,7 @@ class Channel extends Part
     {
         if (! $this->is_private && $botperms = $this->getBotPermissions()) {
             if (! $botperms->manage_messages) {
-                return reject(new NoPermissionsException('You do not have permission to unpin messages in the specified channel.'));
+                return reject(new NoPermissionsException("You do not have permission to unpin messages in the channel {$this->id}."));
             }
         }
 
@@ -1046,7 +1046,7 @@ class Channel extends Part
      * @param Message|null          $replyTo          Sends the message as a reply to the given message instance.
      *
      * @throws \RuntimeException
-     * @throws NoPermissionsException
+     * @throws NoPermissionsException Missing various permissions depending on the message body.
      *
      * @return ExtendedPromiseInterface<Message>
      */
@@ -1080,15 +1080,15 @@ class Channel extends Part
 
         if (! $this->is_private && $botperms = $this->getBotPermissions()) {
             if (! $botperms->send_messages) {
-                return reject(new NoPermissionsException('You do not have permission to send messages in the specified channel.'));
+                return reject(new NoPermissionsException("You do not have permission to send messages in the channel {$this->id}."));
             }
 
             if ($message->getTts() && ! $botperms->send_tts_messages) {
-                return reject(new NoPermissionsException('You do not have permission to send tts messages in the specified channel.'));
+                return reject(new NoPermissionsException("You do not have permission to send tts messages in the channel {$this->id}."));
             }
 
             if ($message->numFiles() > 0 && ! $botperms->attach_files) {
-                return reject(new NoPermissionsException('You do not have permission to send files in the specified channel.'));
+                return reject(new NoPermissionsException("You do not have permission to send files in the channel {$this->id}."));
             }
         }
 

--- a/src/Discord/Parts/Channel/Channel.php
+++ b/src/Discord/Parts/Channel/Channel.php
@@ -629,7 +629,7 @@ class Channel extends Part
                 /** @var ?Invite */
                 if (! $invitePart = $this->invites->get('code', $response->code)) {
                     /** @var Invite */
-                    $invitePart = $this->factory->part(Invite::class, (array) $response, true);
+                    $invitePart = $this->invites->create((array) $response, true);
                     $this->invites->pushItem($invitePart);
                 }
 
@@ -934,8 +934,8 @@ class Channel extends Part
             ->setAllowedTypes('name', 'string')
             ->setAllowedTypes('auto_archive_duration', 'int')
             ->setAllowedTypes('rate_limit_per_user', ['null', 'int'])
-            ->setAllowedValues('auto_archive_duration', fn ($values) => in_array($values, [60, 1440, 4320, 10080]))
-            ->setAllowedValues('rate_limit_per_user', fn ($values) => $values >= 0 && $values <= 21600)
+            ->setAllowedValues('auto_archive_duration', fn ($value) => in_array($value, [60, 1440, 4320, 10080]))
+            ->setAllowedValues('rate_limit_per_user', fn ($value) => $value >= 0 && $value <= 21600)
             ->setRequired('name');
 
         if ($this->type == self::TYPE_GUILD_FORUM) {
@@ -1016,7 +1016,7 @@ class Channel extends Part
                 $threadPart->fill((array) $response);
             } else {
                 /** @var Thread */
-                $threadPart = $this->factory->part(Thread::class, (array) $response, true);
+                $threadPart = $this->threads->create((array) $response, true);
             }
             $this->threads->pushItem($threadPart);
             if ($messageId = ($response->message->id ?? null)) {
@@ -1101,7 +1101,7 @@ class Channel extends Part
 
             return $this->http->post(Endpoint::bind(Endpoint::CHANNEL_MESSAGES, $this->id), $message);
         })()->then(function ($response) {
-            return $this->messages->get('id', $response->id) ?? $this->factory->part(Message::class, (array) $response + ['guild_id' => $this->guild_id], true);
+            return $this->messages->get('id', $response->id) ?? $this->messages->create((array) $response, true);
         });
     }
 

--- a/src/Discord/Parts/Channel/Reaction.php
+++ b/src/Discord/Parts/Channel/Reaction.php
@@ -128,6 +128,7 @@ class Reaction extends Part
             foreach ((array) $response as $user) {
                 if (! $part = $this->discord->users->get('id', $user->id)) {
                     $part = $this->factory->part(User::class, (array) $user, true);
+                    $this->discord->users->pushItem($part);
                 }
 
                 $users->pushItem($part);

--- a/src/Discord/Parts/Guild/Guild.php
+++ b/src/Discord/Parts/Guild/Guild.php
@@ -738,7 +738,7 @@ class Guild extends Part
         return $this->http->post(Endpoint::bind(Endpoint::GUILD_EMOJIS, $this->id), $options, $headers)
             ->then(function ($response) {
                 if (! $emojiPart = $this->emojis->get('id', $response->id)) {
-                    $emojiPart = $this->factory->part(Emoji::class, (array) $response, true);
+                    $emojiPart = $this->emojis->create((array) $response, true);
                     $this->emojis->pushItem($emojiPart);
                 }
 
@@ -852,7 +852,7 @@ class Guild extends Part
         return $this->http->post(Endpoint::bind(Endpoint::GUILD_STICKERS, $this->id), (string) $multipart, $headers)
             ->then(function ($response) {
                 if (! $stickerPart = $this->stickers->get('id', $response->id)) {
-                    $stickerPart = $this->factory->part(Sticker::class, (array) $response, true);
+                    $stickerPart = $this->stickers->create((array) $response, true);
                     $this->stickers->pushItem($stickerPart);
                 }
 

--- a/src/Discord/Parts/Thread/Thread.php
+++ b/src/Discord/Parts/Thread/Thread.php
@@ -709,7 +709,7 @@ class Thread extends Part
 
             return $this->http->post(Endpoint::bind(Endpoint::CHANNEL_MESSAGES, $this->id), $message);
         })()->then(function ($response) {
-            return $this->messages->get('id', $response->id) ?? $this->factory->part(Message::class, (array) $response, true);
+            return $this->messages->get('id', $response->id) ?? $this->messages->create((array) $response, true);
         });
     }
 

--- a/src/Discord/Parts/User/Member.php
+++ b/src/Discord/Parts/User/Member.php
@@ -437,7 +437,7 @@ class Member extends Part
      * @param Carbon|null $communication_disabled_until When the user's timeout will expire and the user will be able to communicate in the guild again, null or a time in the past if the user is not timed out.
      * @param string|null $reason                       Reason for Audit Log.
      *
-     * @throws NoPermissionsException
+     * @throws NoPermissionsException Missing moderate_members permission.
      *
      * @return ExtendedPromiseInterface<Member>
      */
@@ -446,7 +446,7 @@ class Member extends Part
         if ($guild = $this->guild) {
             if ($botperms = $guild->getBotPermissions()) {
                 if (! $botperms->moderate_members) {
-                    return reject(new NoPermissionsException('You do not have permission to time out members in the specified guild.'));
+                    return reject(new NoPermissionsException("You do not have permission to time out members in the guild {$guild->id}."));
                 }
             }
         }


### PR DESCRIPTION
Requires `ext-gmp` extension on 32-bits (x86) PHP. https://github.com/discord-php/DiscordPHP/issues/806#issue-1245485387

Also follow up to #952

tested