### PR TITLE
do not reset `seq` and `timestamp` in voice client

### DIFF
--- a/src/Discord/Voice/VoiceClient.php
+++ b/src/Discord/Voice/VoiceClient.php
@@ -1002,8 +1002,6 @@ class VoiceClient extends EventEmitter
         }
 
         $this->setSpeaking(false);
-        $this->seq = 0;
-        $this->timestamp = 0;
         $this->streamTime = 0;
         $this->startTime = 0;
         $this->isPaused = false;


### PR DESCRIPTION
discord will get confused if these values are changed during a single voice client session. they should not be reset when finishing audio playback, only when disconnecting (but in that case a new voice client would be created).

fixes #814 and #444