### PR TITLE
Added fix for sub command group sub command autocompletes

### DIFF
--- a/src/Discord/WebSockets/Events/InteractionCreate.php
+++ b/src/Discord/WebSockets/Events/InteractionCreate.php
@@ -69,7 +69,7 @@ class InteractionCreate extends Event
                             }
                         } elseif (! empty($option->focused)) {
                             return $command->suggest($interaction);
-                        } elseif ($option->type === Option::SUB_COMMAND_GROUP) {
+                        } elseif ($option->type === Option::SUB_COMMAND_GROUP || $option->type === Option::SUB_COMMAND) {
                             $checkSubCommandGroup = function ($options) use ($command, $interaction, &$checkSubCommandGroup) {
                                 foreach ($options as $option) {
                                     if (! empty($option->focused)) {

--- a/src/Discord/WebSockets/Events/InteractionCreate.php
+++ b/src/Discord/WebSockets/Events/InteractionCreate.php
@@ -12,6 +12,7 @@
 namespace Discord\WebSockets\Events;
 
 use Discord\InteractionType;
+use Discord\Parts\Interactions\Command\Option;
 use Discord\Parts\Interactions\Interaction;
 use Discord\Parts\User\User;
 use Discord\WebSockets\Event;
@@ -68,6 +69,21 @@ class InteractionCreate extends Event
                             }
                         } elseif (! empty($option->focused)) {
                             return $command->suggest($interaction);
+                        } elseif ($option->type === Option::SUB_COMMAND_GROUP) {
+                            $checkSubCommandGroup = function ($options) use ($command, $interaction, &$checkSubCommandGroup) {
+                                foreach ($options as $option) {
+                                    if (! empty($option->focused)) {
+                                        return $command->suggest($interaction);
+                                    }
+
+                                    if (! empty($option->options)) {
+                                        return $checkSubCommandGroup($option->options);
+                                    }
+                                }
+                            };
+
+                            $options = $option->options;
+                            $checkSubCommandGroup($options);
                         }
                     }
 


### PR DESCRIPTION
From my 3 hours of digging around I have found that sub command group sub commands are never added the application_commands array when you begin listening for a command. This check uses similar logic to the anonymous checkCommand function but instead loops through sub_command_group options. Probably not the best way but it is working, my guess on a better fix would be to add sub command group sub commands to the application_commands array so it can be checked by checkCommand.