### PR TITLE
fix $interaction->resolved->messages  no guild_id uncached

### DIFF
--- a/src/Discord/Parts/Interactions/Request/Resolved.php
+++ b/src/Discord/Parts/Interactions/Request/Resolved.php
@@ -196,7 +196,7 @@ class Resolved extends Part
                 }
             }
 
-            $collection->pushItem($messagePart ?? $this->factory->part(Message::class, (array) $message, true));
+            $collection->pushItem($messagePart ?? $this->factory->part(Message::class, (array) $message + ['guild_id' => $this->guild_id], true));
         }
 
         return $collection;


### PR DESCRIPTION
This fix missing `guild_id` from resolved message objects in interactions.

Reported by @oliverschloebe on Discord Server.

Tested & can be merged.

TODO: backport to v7