### PR TITLE
fix messages thread stored as normal channel, fix ReactionRepository::delete() typehint

### DIFF
--- a/src/Discord/Parts/Channel/Message.php
+++ b/src/Discord/Parts/Channel/Message.php
@@ -382,6 +382,7 @@ class Message extends Part
             if ($channel = $channels->get('id', $this->channel_id)) {
                 return $channel;
             }
+
             foreach ($channels as $parent) {
                 if ($thread = $parent->threads->get('id', $this->channel_id)) {
                     return $thread;

--- a/src/Discord/Parts/Channel/Reaction.php
+++ b/src/Discord/Parts/Channel/Reaction.php
@@ -206,24 +206,29 @@ class Reaction extends Part
      *
      * @return Channel|Thread
      */
-    protected function getChannelAttribute()
+    protected function getChannelAttribute(): Part
     {
-        if ($channel = $this->discord->getChannel($this->channel_id)) {
-            return $channel;
-        }
-
         if ($guild = $this->guild) {
-            foreach ($guild->channels as $channel) {
-                if ($thread = $channel->threads->get('id', $this->channel_id)) {
+            $channels = $guild->channels;
+            if ($channel = $channels->get('id', $this->channel_id)) {
+                return $channel;
+            }
+            foreach ($channels as $parent) {
+                if ($thread = $parent->threads->get('id', $this->channel_id)) {
                     return $thread;
                 }
             }
         }
 
+        // @todo potentially slow
+        if ($channel = $this->discord->getChannel($this->channel_id)) {
+            return $channel;
+        }
+
         return $this->factory->part(Channel::class, [
             'id' => $this->channel_id,
             'type' => Channel::TYPE_DM,
-        ]);
+        ], true);
     }
 
     /**

--- a/src/Discord/Parts/Guild/ScheduledEvent.php
+++ b/src/Discord/Parts/Guild/ScheduledEvent.php
@@ -155,12 +155,18 @@ class ScheduledEvent extends Part
     /**
      * Returns the channel attribute.
      *
-     * @return Channel The channel in which the scheduled event will be hosted, or null.
+     * @return Channel|null The channel in which the scheduled event will be hosted, or null.
      */
     protected function getChannelAttribute(): ?Channel
     {
         if (! isset($this->attributes['channel_id'])) {
             return null;
+        }
+
+        if ($guild = $this->guild) {
+            if ($channel = $guild->channels->get('id', $this->channel_id)) {
+                return $channel;
+            }
         }
 
         return $this->discord->getChannel($this->attributes['channel_id']);

--- a/src/Discord/Parts/Interactions/Interaction.php
+++ b/src/Discord/Parts/Interactions/Interaction.php
@@ -129,13 +129,19 @@ class Interaction extends Part
     /**
      * Returns the channel the interaction was invoked from.
      *
-     * @return Channel|null
+     * @return Channel|Thread|null
      */
-    protected function getChannelAttribute(): ?Channel
+    protected function getChannelAttribute(): ?Part
     {
         if ($guild = $this->guild) {
-            if ($channel = $guild->channels->get('id', $this->channel_id)) {
+            $channels = $guild->channels;
+            if ($channel = $channels->get('id', $this->channel_id)) {
                 return $channel;
+            }
+            foreach ($channels as $parent) {
+                if ($thread = $parent->threads->get('id', $this->channel_id)) {
+                    return $thread;
+                }
             }
         }
 

--- a/src/Discord/Parts/Thread/Thread.php
+++ b/src/Discord/Parts/Thread/Thread.php
@@ -367,7 +367,7 @@ class Thread extends Part
             $headers['X-Audit-Log-Reason'] = $reason;
         }
 
-        return $this->http->patch(Endpoint::bind(Endpoint::CHANNEL, $this->id), ['name' => $name], $headers)
+        return $this->http->patch(Endpoint::bind(Endpoint::THREAD, $this->id), ['name' => $name], $headers)
             ->then(function ($response) {
                 $this->name = $response->name;
 
@@ -389,7 +389,7 @@ class Thread extends Part
             $headers['X-Audit-Log-Reason'] = $reason;
         }
 
-        return $this->http->patch(Endpoint::bind(Endpoint::CHANNEL, $this->id), ['archived' => true], $headers)
+        return $this->http->patch(Endpoint::bind(Endpoint::THREAD, $this->id), ['archived' => true], $headers)
             ->then(function ($response) {
                 $this->archived = $response->thread_metadata->archived;
 
@@ -411,7 +411,7 @@ class Thread extends Part
             $headers['X-Audit-Log-Reason'] = $reason;
         }
 
-        return $this->http->patch(Endpoint::bind(Endpoint::CHANNEL, $this->id), ['archived' => false], $headers)
+        return $this->http->patch(Endpoint::bind(Endpoint::THREAD, $this->id), ['archived' => false], $headers)
             ->then(function ($response) {
                 $this->archived = $response->thread_metadata->archived;
 
@@ -434,7 +434,7 @@ class Thread extends Part
             $headers['X-Audit-Log-Reason'] = $reason;
         }
 
-        return $this->http->patch(Endpoint::bind(Endpoint::CHANNEL, $this->id), ['auto_archive_duration' => $duration], $headers)
+        return $this->http->patch(Endpoint::bind(Endpoint::THREAD, $this->id), ['auto_archive_duration' => $duration], $headers)
             ->then(function ($response) {
                 $this->auto_archive_duration = $response->thread_metadata->auto_archive_duration;
 

--- a/src/Discord/Parts/Thread/Thread.php
+++ b/src/Discord/Parts/Thread/Thread.php
@@ -367,7 +367,7 @@ class Thread extends Part
             $headers['X-Audit-Log-Reason'] = $reason;
         }
 
-        return $this->http->patch(Endpoint::bind(Endpoint::THREAD, $this->id), ['name' => $name], $headers)
+        return $this->http->patch(Endpoint::bind(Endpoint::CHANNEL, $this->id), ['name' => $name], $headers)
             ->then(function ($response) {
                 $this->name = $response->name;
 
@@ -389,7 +389,7 @@ class Thread extends Part
             $headers['X-Audit-Log-Reason'] = $reason;
         }
 
-        return $this->http->patch(Endpoint::bind(Endpoint::THREAD, $this->id), ['archived' => true], $headers)
+        return $this->http->patch(Endpoint::bind(Endpoint::CHANNEL, $this->id), ['archived' => true], $headers)
             ->then(function ($response) {
                 $this->archived = $response->thread_metadata->archived;
 
@@ -411,7 +411,7 @@ class Thread extends Part
             $headers['X-Audit-Log-Reason'] = $reason;
         }
 
-        return $this->http->patch(Endpoint::bind(Endpoint::THREAD, $this->id), ['archived' => false], $headers)
+        return $this->http->patch(Endpoint::bind(Endpoint::CHANNEL, $this->id), ['archived' => false], $headers)
             ->then(function ($response) {
                 $this->archived = $response->thread_metadata->archived;
 
@@ -434,7 +434,7 @@ class Thread extends Part
             $headers['X-Audit-Log-Reason'] = $reason;
         }
 
-        return $this->http->patch(Endpoint::bind(Endpoint::THREAD, $this->id), ['auto_archive_duration' => $duration], $headers)
+        return $this->http->patch(Endpoint::bind(Endpoint::CHANNEL, $this->id), ['auto_archive_duration' => $duration], $headers)
             ->then(function ($response) {
                 $this->auto_archive_duration = $response->thread_metadata->auto_archive_duration;
 
@@ -846,7 +846,6 @@ class Thread extends Part
             'guild_id' => $this->guild_id,
             'parent_id' => $this->parent_id,
             'channel_id' => $this->id,
-            'thread_id' => $this->id,
         ];
     }
 

--- a/src/Discord/Parts/Thread/Thread.php
+++ b/src/Discord/Parts/Thread/Thread.php
@@ -842,11 +842,17 @@ class Thread extends Part
      */
     public function getRepositoryAttributes(): array
     {
-        return [
+        $attr = [
             'guild_id' => $this->guild_id,
             'parent_id' => $this->parent_id,
             'channel_id' => $this->id,
         ];
+
+        if ($this->created) {
+            $attr['thread_id'] = $this->id;
+        }
+
+        return $attr;
     }
 
     /**

--- a/src/Discord/Parts/WebSockets/MessageReaction.php
+++ b/src/Discord/Parts/WebSockets/MessageReaction.php
@@ -134,15 +134,16 @@ class MessageReaction extends Part
      *
      * @return Channel|Thread
      */
-    protected function getChannelAttribute()
+    protected function getChannelAttribute(): Part
     {
         if ($guild = $this->guild) {
-            if ($channel = $guild->channels->get('id', $this->channel_id)) {
+            $channels = $guild->channels;
+            if ($channel = $channels->get('id', $this->channel_id)) {
                 return $channel;
             }
 
-            foreach ($guild->channels as $channel) {
-                if ($thread = $channel->threads->get('id', $this->channel_id)) {
+            foreach ($channels as $parent) {
+                if ($thread = $parent->threads->get('id', $this->channel_id)) {
                     return $thread;
                 }
             }
@@ -157,7 +158,7 @@ class MessageReaction extends Part
         return $this->factory->part(Channel::class, [
             'id' => $this->channel_id,
             'type' => Channel::TYPE_DM,
-        ]);
+        ], true);
     }
 
     /**

--- a/src/Discord/Parts/WebSockets/TypingStart.php
+++ b/src/Discord/Parts/WebSockets/TypingStart.php
@@ -53,15 +53,16 @@ class TypingStart extends Part
      *
      * @return Channel|Thread|null The channel that the user started typing in.
      */
-    protected function getChannelAttribute()
+    protected function getChannelAttribute(): ?Part
     {
         if ($guild = $this->guild) {
-            if ($channel = $guild->channels->get('id', $this->channel_id)) {
+            $channels = $guild->channels;
+            if ($channel = $channels->get('id', $this->channel_id)) {
                 return $channel;
             }
 
-            foreach ($guild->channels as $channel) {
-                if ($thread = $channel->threads->get('id', $this->channel_id)) {
+            foreach ($channels as $parent) {
+                if ($thread = $parent->threads->get('id', $this->channel_id)) {
                     return $thread;
                 }
             }

--- a/src/Discord/Repository/Channel/ReactionRepository.php
+++ b/src/Discord/Repository/Channel/ReactionRepository.php
@@ -49,7 +49,7 @@ class ReactionRepository extends AbstractRepository
      *
      * {@inheritDoc}
      *
-     * @param Part|string $part The Reaction part or unicode emoji to delete.
+     * @param Reaction|string $part The Reaction part or unicode emoji to delete.
      *
      * @return ExtendedPromiseInterface<Reaction>
      *

--- a/src/Discord/Repository/Channel/ThreadRepository.php
+++ b/src/Discord/Repository/Channel/ThreadRepository.php
@@ -11,7 +11,6 @@
 
 namespace Discord\Repository\Channel;
 
-use Discord\Discord;
 use Discord\Helpers\Collection;
 use Discord\Http\Endpoint;
 use Discord\Parts\Thread\Member;

--- a/src/Discord/Repository/Channel/ThreadRepository.php
+++ b/src/Discord/Repository/Channel/ThreadRepository.php
@@ -51,16 +51,6 @@ class ThreadRepository extends AbstractRepository
     protected $class = Thread::class;
 
     /**
-     * @inheritDoc
-     */
-    public function __construct(Discord $discord, array $vars = [])
-    {
-        $vars['thread_id'] = $vars['channel_id']; // For backward compatibility with thread_id HTTP endpoint params
-
-        parent::__construct($discord, $vars);
-    }
-
-    /**
      * Fetches all the active threads on the channel.
      *
      * @link https://discord.com/developers/docs/resources/channel#list-active-threads

--- a/src/Discord/Repository/Channel/ThreadRepository.php
+++ b/src/Discord/Repository/Channel/ThreadRepository.php
@@ -11,6 +11,7 @@
 
 namespace Discord\Repository\Channel;
 
+use Discord\Discord;
 use Discord\Helpers\Collection;
 use Discord\Http\Endpoint;
 use Discord\Parts\Thread\Member;
@@ -38,9 +39,9 @@ class ThreadRepository extends AbstractRepository
      */
     protected $endpoints = [
         'all' => Endpoint::GUILD_THREADS_ACTIVE,
-        'get' => Endpoint::THREAD,
-        'update' => Endpoint::THREAD,
-        'delete' => Endpoint::THREAD,
+        'get' => Endpoint::CHANNEL,
+        'update' => Endpoint::CHANNEL,
+        'delete' => Endpoint::CHANNEL,
         'create' => Endpoint::CHANNEL_THREADS,
     ];
 
@@ -48,6 +49,16 @@ class ThreadRepository extends AbstractRepository
      * @inheritDoc
      */
     protected $class = Thread::class;
+
+    /**
+     * @inheritDoc
+     */
+    public function __construct(Discord $discord, array $vars = [])
+    {
+        $vars['thread_id'] = $vars['id']; // For Backward compatibility with thread_id HTTP endpoint params
+
+        parent::__construct($discord, $vars);
+    }
 
     /**
      * Fetches all the active threads on the channel.

--- a/src/Discord/Repository/Channel/ThreadRepository.php
+++ b/src/Discord/Repository/Channel/ThreadRepository.php
@@ -39,9 +39,9 @@ class ThreadRepository extends AbstractRepository
      */
     protected $endpoints = [
         'all' => Endpoint::GUILD_THREADS_ACTIVE,
-        'get' => Endpoint::CHANNEL,
-        'update' => Endpoint::CHANNEL,
-        'delete' => Endpoint::CHANNEL,
+        'get' => Endpoint::THREAD,
+        'update' => Endpoint::THREAD,
+        'delete' => Endpoint::THREAD,
         'create' => Endpoint::CHANNEL_THREADS,
     ];
 

--- a/src/Discord/Repository/Channel/ThreadRepository.php
+++ b/src/Discord/Repository/Channel/ThreadRepository.php
@@ -55,7 +55,7 @@ class ThreadRepository extends AbstractRepository
      */
     public function __construct(Discord $discord, array $vars = [])
     {
-        $vars['thread_id'] = $vars['id']; // For Backward compatibility with thread_id HTTP endpoint params
+        $vars['thread_id'] = $vars['channel_id']; // For backward compatibility with thread_id HTTP endpoint params
 
         parent::__construct($discord, $vars);
     }

--- a/src/Discord/WebSockets/Events/MessageUpdate.php
+++ b/src/Discord/WebSockets/Events/MessageUpdate.php
@@ -15,6 +15,7 @@ use Discord\Parts\Channel\Message;
 use Discord\WebSockets\Event;
 use Discord\Parts\Channel\Channel;
 use Discord\Parts\Guild\Guild;
+use Discord\Parts\Thread\Thread;
 use Discord\WebSockets\Intents;
 
 /**
@@ -36,7 +37,16 @@ class MessageUpdate extends Event
             /** @var ?Guild */
             if ($guild = yield $this->discord->guilds->cacheGet($data->guild_id)) {
                 /** @var ?Channel */
-                $channel = yield $guild->channels->cacheGet($data->channel_id);
+                if (! $channel = yield $guild->channels->cacheGet($data->channel_id)) {
+                    /** @var Channel */
+                    foreach ($guild->channels as $parent) {
+                        /** @var ?Thread */
+                        if ($thread = yield $parent->threads->cacheGet($data->channel_id)) {
+                            $channel = $thread;
+                            break;
+                        }
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
It was reported that threads are not properly handled, apparently messages events mistakenly treat threads as normal channels.

~~Untested.~~