### PR TITLE
fix phpdocumentor reflector

### DIFF
--- a/src/Discord/Voice/OggPage.php
+++ b/src/Discord/Voice/OggPage.php
@@ -114,7 +114,7 @@ class OggPage
      * array containing binary data and whether the packet is complete, from
      * a generator.
      *
-     * @return Generator<int,(string|bool)[],mixed,void>
+     * @return Generator
      */
     public function iterPackets()
     {


### PR DESCRIPTION
Was causing error with D.PHP
> PHP Fatal error:  Uncaught RuntimeException: Unexpected character ",", ">" is missing in /vendor/phpdocumentor/type-resolver/src/TypeResolver.php:687

Tested & can be merged