### PR TITLE
Improve repository cache handling

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,6 @@
         "friendsofphp/php-cs-fixer": "^3",
         "phpunit/phpunit": "^9.4.4",
         "davidcole1340/reactsh": "dev-master",
-        "seregazhuk/react-cache-memcached": "^1.0",
         "wyrihaximus/react-cache-redis": "^3.0 || ^4.0",
         "symfony/cache": "^5.4"
     },

--- a/src/Discord/Parts/Channel/Channel.php
+++ b/src/Discord/Parts/Channel/Channel.php
@@ -875,8 +875,8 @@ class Channel extends Part
             $this->overwrites->pushItem($overwritePart ?: $this->overwrites->create($overwrite, true));
         }
 
-        if (! empty($this->attributes['permission_overwrites'])) {
-            $this->overwrites->cache->deleteMultiple(array_diff(array_column($this->attributes['permission_overwrites'], 'id'), array_column($overwrites ?? [], 'id')));
+        if (! empty($this->attributes['permission_overwrites']) && $clean = array_diff(array_column($this->attributes['permission_overwrites'], 'id'), array_column($overwrites ?? [], 'id'))) {
+            $this->overwrites->cache->deleteMultiple($clean);
         }
 
         $this->attributes['permission_overwrites'] = $overwrites;

--- a/src/Discord/Parts/Channel/Channel.php
+++ b/src/Discord/Parts/Channel/Channel.php
@@ -172,6 +172,9 @@ class Channel extends Part
 
         // @internal
         'is_private',
+
+        // repositories
+        'permission_overwrites',
     ];
 
     /**
@@ -186,18 +189,6 @@ class Channel extends Part
         'invites' => InviteRepository::class,
         'stage_instances' => StageInstanceRepository::class,
     ];
-
-    /**
-     * @inheritDoc
-     */
-    public function fill(array $attributes): void
-    {
-        parent::fill($attributes);
-
-        if (isset($attributes['permission_overwrites'])) {
-            $this->setPermissionOverwritesAttribute($attributes['permission_overwrites']);
-        }
-    }
 
     /**
      * @inheritDoc

--- a/src/Discord/Parts/Channel/Channel.php
+++ b/src/Discord/Parts/Channel/Channel.php
@@ -862,13 +862,11 @@ class Channel extends Part
     /**
      * Sets the permission overwrites attribute.
      *
-     * @param array $overwrites
+     * @param ?array $overwrites
      */
     protected function setPermissionOverwritesAttribute(?array $overwrites): void
     {
-        $this->attributes['permission_overwrites'] = $overwrites;
-
-        foreach ($overwrites as $overwrite) {
+        foreach ($overwrites ?? [] as $overwrite) {
             $overwrite = (array) $overwrite;
             /** @var Overwrite */
             if ($overwritePart = $this->overwrites->offsetGet($overwrite['id'])) {
@@ -876,6 +874,12 @@ class Channel extends Part
             }
             $this->overwrites->pushItem($overwritePart ?: $this->overwrites->create($overwrite, true));
         }
+
+        if (! empty($this->attributes['permission_overwrites'])) {
+            $this->overwrites->cache->deleteMultiple(array_diff(array_column($this->attributes['permission_overwrites'], 'id'), array_column($overwrites ?? [], 'id')));
+        }
+
+        $this->attributes['permission_overwrites'] = $overwrites;
     }
 
     /**
@@ -953,7 +957,7 @@ class Channel extends Part
             ->setAllowedValues('auto_archive_duration', fn ($value) => in_array($value, [60, 1440, 4320, 10080]))
             ->setAllowedValues('rate_limit_per_user', fn ($value) => $value >= 0 && $value <= 21600)
             ->setRequired('name');
-  
+
         $botperms = $this->getBotPermissions();
 
         if ($this->type == self::TYPE_GUILD_FORUM) {
@@ -991,7 +995,7 @@ class Channel extends Part
                 ->setAllowedTypes('private', 'bool')
                 ->setAllowedTypes('invitable', 'bool')
                 ->setDefaults(['private' => false]);
-            
+
             $options = $resolver->resolve($options);
 
             if ($options['private']) {
@@ -1012,7 +1016,7 @@ class Channel extends Part
                 if ($options['private']) {
                     return reject(new \RuntimeException('You cannot start a private thread within a news channel.'));
                 }
-    
+
                 $options['type'] = self::TYPE_ANNOUNCEMENT_THREAD;
             } elseif ($this->type == self::TYPE_GUILD_TEXT) {
                 $options['type'] = $options['private'] ? self::TYPE_PRIVATE_THREAD : self::TYPE_PUBLIC_THREAD;

--- a/src/Discord/Parts/Channel/Message.php
+++ b/src/Discord/Parts/Channel/Message.php
@@ -186,7 +186,6 @@ class Message extends Part
         'mention_channels',
         'attachments',
         'embeds',
-        'reactions',
         'nonce',
         'pinned',
         'webhook_id',
@@ -207,6 +206,9 @@ class Message extends Part
         // @internal
         'guild_id',
         'member',
+
+        // repositories
+        'reactions',
     ];
 
     /**
@@ -351,11 +353,11 @@ class Message extends Part
     }
 
     /**
-     * Sets the reactions attriubte.
+     * Sets the reactions attribute.
      *
      * @param array $reactions
      */
-    protected function setReactionsAttribute(array $reactions)
+    protected function setReactionsAttribute(?array $reactions)
     {
         $this->attributes['reactions'] = $reactions;
 

--- a/src/Discord/Parts/Channel/Message.php
+++ b/src/Discord/Parts/Channel/Message.php
@@ -376,7 +376,9 @@ class Message extends Part
             foreach ($this->attributes['reactions'] as $oldReaction) {
                 $oldReactions[] = $oldReaction->emoji->id ?? $oldReaction->emoji->name;
             }
-            $this->reactions->cache->deleteMultiple(array_diff($oldReactions, $keepReactions));
+            if ($clean = array_diff($oldReactions, $keepReactions)) {
+                $this->reactions->cache->deleteMultiple($clean);
+            }
         }
 
         $this->attributes['reactions'] = $reactions;

--- a/src/Discord/Parts/Guild/Guild.php
+++ b/src/Discord/Parts/Guild/Guild.php
@@ -227,6 +227,11 @@ class Guild extends Part
         'joined_at',
         'large',
         'member_count',
+
+        // repositories
+        'emojis',
+        'roles',
+        'stickers',
     ];
 
     /**
@@ -259,9 +264,6 @@ class Guild extends Part
         'feature_verified',
         'feature_vip_regions',
         'feature_welcome_screen_enabled',
-        'emojis',
-        'roles',
-        'stickers',
     ];
 
     /**
@@ -297,18 +299,6 @@ class Guild extends Part
     public function fill(array $attributes): void
     {
         parent::fill($attributes);
-
-        if (isset($attributes['roles'])) {
-            $this->setRolesAttribute($attributes['roles']);
-        }
-
-        if (isset($attributes['emojis'])) {
-            $this->setEmojisAttribute($attributes['emojis']);
-        }
-
-        if (isset($attributes['stickers'])) {
-            $this->setStickersAttribute($attributes['stickers']);
-        }
 
         // @todo move each repository fill to the setChannelAttributes methods?
         foreach ($attributes['channels'] ?? [] as $channel) {

--- a/src/Discord/Parts/Guild/Guild.php
+++ b/src/Discord/Parts/Guild/Guild.php
@@ -327,8 +327,8 @@ class Guild extends Part
             $this->roles->pushItem($rolePart ?: $this->roles->create($role, $this->created));
         }
 
-        if (! empty($this->attributes['roles'])) {
-            $this->roles->cache->deleteMultiple(array_diff(array_column($this->attributes['roles'], 'id'), array_column($roles ?? [], 'id')));
+        if (! empty($this->attributes['roles']) && $clean = array_diff(array_column($this->attributes['roles'], 'id'), array_column($roles ?? [], 'id'))) {
+            $this->roles->cache->deleteMultiple($clean);
         }
 
         $this->attributes['roles'] = $roles;
@@ -350,8 +350,8 @@ class Guild extends Part
             $this->emojis->pushItem($emojiPart ?: $this->emojis->create($emoji, $this->created));
         }
 
-        if (! empty($this->attributes['emojis'])) {
-            $this->emojis->cache->deleteMultiple(array_diff(array_column($this->attributes['emojis'], 'id'), array_column($emojis ?? [], 'id')));
+        if (! empty($this->attributes['emojis']) && $clean = array_diff(array_column($this->attributes['emojis'], 'id'), array_column($emojis ?? [], 'id'))) {
+            $this->emojis->cache->deleteMultiple($clean);
         }
 
         $this->attributes['emojis'] = $emojis;
@@ -373,8 +373,8 @@ class Guild extends Part
             $this->stickers->pushItem($stickerPart ?: $this->stickers->create($sticker, $this->created));
         }
 
-        if (! empty($this->attributes['stickers'])) {
-            $this->stickers->cache->deleteMultiple(array_diff(array_column($this->attributes['stickers'], 'id'), array_column($stickers ?? [], 'id')));
+        if (! empty($this->attributes['stickers']) && $clean = array_diff(array_column($this->attributes['stickers'], 'id'), array_column($stickers ?? [], 'id'))) {
+            $this->stickers->cache->deleteMultiple($clean);
         }
 
         $this->attributes['stickers'] = $stickers;

--- a/src/Discord/Parts/Guild/Guild.php
+++ b/src/Discord/Parts/Guild/Guild.php
@@ -312,7 +312,9 @@ class Guild extends Part
     }
 
     /**
-     * @inheritDoc
+     * Sets the roles attribute.
+     *
+     * @param ?array $roles
      */
     protected function setRolesAttribute(?array $roles): void
     {
@@ -325,11 +327,17 @@ class Guild extends Part
             $this->roles->pushItem($rolePart ?: $this->roles->create($role, $this->created));
         }
 
+        if (! empty($this->attributes['roles'])) {
+            $this->roles->cache->deleteMultiple(array_diff(array_column($this->attributes['roles'], 'id'), array_column($roles ?? [], 'id')));
+        }
+
         $this->attributes['roles'] = $roles;
     }
 
     /**
-     * @inheritDoc
+     * Sets the emojis attribute.
+     *
+     * @param ?array $emojis
      */
     protected function setEmojisAttribute(?array $emojis): void
     {
@@ -342,11 +350,17 @@ class Guild extends Part
             $this->emojis->pushItem($emojiPart ?: $this->emojis->create($emoji, $this->created));
         }
 
+        if (! empty($this->attributes['emojis'])) {
+            $this->emojis->cache->deleteMultiple(array_diff(array_column($this->attributes['emojis'], 'id'), array_column($emojis ?? [], 'id')));
+        }
+
         $this->attributes['emojis'] = $emojis;
     }
 
     /**
-     * @inheritDoc
+     * Sets the stickers attribute.
+     *
+     * @param ?array $stickers
      */
     protected function setStickersAttribute(?array $stickers): void
     {
@@ -357,6 +371,10 @@ class Guild extends Part
                 $stickerPart->fill($sticker);
             }
             $this->stickers->pushItem($stickerPart ?: $this->stickers->create($sticker, $this->created));
+        }
+
+        if (! empty($this->attributes['stickers'])) {
+            $this->stickers->cache->deleteMultiple(array_diff(array_column($this->attributes['stickers'], 'id'), array_column($stickers ?? [], 'id')));
         }
 
         $this->attributes['stickers'] = $stickers;

--- a/src/Discord/Parts/Part.php
+++ b/src/Discord/Parts/Part.php
@@ -161,9 +161,9 @@ abstract class Part implements ArrayAccess, JsonSerializable
      */
     public function fill(array $attributes): void
     {
-        foreach ($attributes as $key => $value) {
-            if (in_array($key, $this->fillable)) {
-                $this->setAttribute($key, $value);
+        foreach ($this->fillable as $key) {
+            if (array_key_exists($key, $attributes)) {
+                $this->setAttribute($key, $attributes[$key]);
             }
         }
     }

--- a/src/Discord/Parts/Permissions/Permission.php
+++ b/src/Discord/Parts/Permissions/Permission.php
@@ -210,11 +210,7 @@ abstract class Permission extends Part
         }
 
         foreach ($this->permissions as $permission => $value) {
-            if (BigInt::test($bitwise, $value)) {
-                $this->attributes[$permission] = true;
-            } else {
-                $this->attributes[$permission] = false;
-            }
+            $this->attributes[$permission] = BigInt::test($bitwise, $value);
         }
     }
 

--- a/src/Discord/Repository/AbstractRepository.php
+++ b/src/Discord/Repository/AbstractRepository.php
@@ -620,6 +620,16 @@ abstract class AbstractRepository extends Collection
     }
 
     /**
+     * Get the keys of the items.
+     *
+     * @return int[]|string[]
+     */
+    public function keys()
+    {
+        return array_keys($this->items);
+    }
+
+    /**
      * If the repository has an offset.
      *
      * @deprecated 10.0.0 Use async `$repository->cache->has()`

--- a/src/Discord/Repository/AbstractRepository.php
+++ b/src/Discord/Repository/AbstractRepository.php
@@ -34,7 +34,8 @@ use function React\Promise\resolve;
  * @author Aaron Scherer <aequasi@gmail.com>
  * @author David Cole <david.cole1340@gmail.com>
  *
- * @property-read CacheWrapper $cache The react/cache wrapper.
+ * @property-read string       $discrim The discriminator.
+ * @property-read CacheWrapper $cache   The react/cache wrapper.
  */
 abstract class AbstractRepository extends Collection
 {
@@ -725,7 +726,7 @@ abstract class AbstractRepository extends Collection
 
     public function __get(string $key)
     {
-        if (in_array($key, ['cache'])) {
+        if (in_array($key, ['discrim', 'cache'])) {
             return $this->$key;
         }
     }


### PR DESCRIPTION
- Add `$repository->discrim` getter
- Add `$repositiory->keys()` to return item keys (reference: https://laravel.com/api/5.5/Illuminate/Support/Collection.html#method_keys note: I'm not adding this to Collection since that originally designed to return a Collection instead of just the keys array)
- Change behavior with `Part::fill()` to fill according the `fillables` order, instead of the `attributes` which might have random key order, so no longer need to override the `fill()` method. The main point here is to not fill the repository attributes before other attributes have been filled, notice they are placed at bottom of the fillables array.
- Clean up old items from repository for: `$channel->permission_overwrites`, `$guild->roles`, `$guild->emojis`, `$guild->stickers`, and `$message->reactions`. While the items are replaced with new one, old items are unset from memory, but not from the cache, this PR fixes that.

Partially tested.