### PR TITLE
Add CacheConfig, replacing cacheInterface, cacheSweep and cacheCompress

### DIFF
--- a/src/Discord/Helpers/CacheConfig.php
+++ b/src/Discord/Helpers/CacheConfig.php
@@ -1,0 +1,71 @@
+<?php
+
+/*
+ * This file is a part of the DiscordPHP project.
+ *
+ * Copyright (c) 2015-present David Cole <david.cole1340@gmail.com>
+ *
+ * This file is subject to the MIT license that is bundled
+ * with this source code in the LICENSE.md file.
+ */
+
+namespace Discord\Helpers;
+
+/**
+ * Cache configuration class. To be used with Discord `cache` Options.
+ *
+ * @see Discord
+ *
+ * @since 10.0.0
+ */
+class CacheConfig
+{
+    /**
+     * The PSR-16 cache interface.
+     *
+     * @var \React\Cache\CacheInterface|\Psr\SimpleCache\CacheInterface
+     */
+    public $interface;
+
+    /**
+     * Whether to compress cache data before serialization, disabled by default, ignored in ArrayCache.
+     *
+     * @var bool
+     */
+    public bool $compress = false;
+
+    /**
+     * Whether to automatically sweep cached items from memory, disabled by default.
+     *
+     * @var bool
+     */
+    public bool $sweep = false;
+
+    /**
+     * The cache key prefix separator if supported by the interface.
+     *
+     * @var string|null Usually dot `.` for generic cache or colon `:` for Redis/Memcached.
+     */
+    public string $separator;
+
+    /**
+     * @param \React\Cache\CacheInterface|\Psr\SimpleCache\CacheInterface $interface The PSR-16 Cache Interface.
+     * @param bool                                                        $compress  Whether to compress cache data before serialization, ignored in ArrayCache.
+     * @param bool                                                        $sweep     Whether to automatically sweep cache.
+     * @param string|null                                                 $separator The cache key prefix separator.
+     */
+    public function __construct($interface, bool $compress = false, bool $sweep = false, ?string $separator = null)
+    {
+        $this->interface = $interface;
+        $this->sweep = $sweep;
+        $this->compress = $compress;
+        if (null === $separator) {
+            $separator = '.';
+            $interfaceName = get_class($interface);
+            if (stripos($interfaceName, 'Redis') !== false || stripos($interfaceName, 'Memcached') !== false) {
+                $separator = ':';
+            }
+        }
+        $this->separator = $separator;
+    }
+}

--- a/src/Discord/Helpers/CacheConfig.php
+++ b/src/Discord/Helpers/CacheConfig.php
@@ -17,15 +17,16 @@ namespace Discord\Helpers;
  * @see Discord
  *
  * @since 10.0.0
+ *
+ * @property-read \React\Cache\CacheInterface|\Psr\SimpleCache\CacheInterface $interface The PSR-16 cache interface.
+ * @property-read bool                                                        $separator The cache key prefix separator if supported by the interface. Usually dot `.` for generic cache or colon `:` for Redis/Memcached.
  */
 class CacheConfig
 {
     /**
-     * The PSR-16 cache interface.
-     *
      * @var \React\Cache\CacheInterface|\Psr\SimpleCache\CacheInterface
      */
-    public $interface;
+    protected $interface;
 
     /**
      * Whether to compress cache data before serialization, disabled by default, ignored in ArrayCache.
@@ -42,17 +43,15 @@ class CacheConfig
     public bool $sweep = false;
 
     /**
-     * The cache key prefix separator if supported by the interface.
-     *
-     * @var string|null Usually dot `.` for generic cache or colon `:` for Redis/Memcached.
+     * @var string
      */
-    public string $separator;
+    protected string $separator = '.';
 
     /**
      * @param \React\Cache\CacheInterface|\Psr\SimpleCache\CacheInterface $interface The PSR-16 Cache Interface.
      * @param bool                                                        $compress  Whether to compress cache data before serialization, ignored in ArrayCache.
      * @param bool                                                        $sweep     Whether to automatically sweep cache.
-     * @param string|null                                                 $separator The cache key prefix separator.
+     * @param string|null                                                 $separator The cache key prefix separator, null for default.
      */
     public function __construct($interface, bool $compress = false, bool $sweep = false, ?string $separator = null)
     {
@@ -67,5 +66,12 @@ class CacheConfig
             }
         }
         $this->separator = $separator;
+    }
+
+    public function __get(string $name)
+    {
+        if (in_array($name, ['interface', 'separator'])) {
+            return $this->$name;
+        }
     }
 }

--- a/src/Discord/Helpers/CacheWrapper.php
+++ b/src/Discord/Helpers/CacheWrapper.php
@@ -67,11 +67,18 @@ class CacheWrapper
     protected $prefix;
 
     /**
-     * @param Discord                                                     $discord
-     * @param \React\Cache\CacheInterface|\Psr\SimpleCache\CacheInterface $cacheInterface The actual CacheInterface.
-     * @param array                                                       &$items         Repository items passed by reference.
-     * @param string                                                      &$class         Part class name.
-     * @param string[]                                                    $vars           Variable containing hierarchy parent IDs.
+     * Cache configuration.
+     *
+     * @var CacheConfig
+     */
+    protected $config;
+
+    /**
+     * @param Discord     $discord
+     * @param CacheConfig $config  The cache configuration.
+     * @param array       &$items  Repository items passed by reference.
+     * @param string      &$class  Part class name.
+     * @param string[]    $vars    Variable containing hierarchy parent IDs.
      *
      * @internal
      */

--- a/src/Discord/Repository/AbstractRepository.php
+++ b/src/Discord/Repository/AbstractRepository.php
@@ -90,7 +90,7 @@ abstract class AbstractRepository extends Collection
         $this->http = $discord->getHttpClient();
         $this->factory = $discord->getFactory();
         $this->vars = $vars;
-        $this->cache = new CacheWrapper($discord, $discord->getCache(static::class), $this->items, $this->class, $this->vars);
+        $this->cache = new CacheWrapper($discord, $discord->getCacheConfig(static::class), $this->items, $this->class, $this->vars);
 
         parent::__construct([], $this->discrim, $this->class);
     }


### PR DESCRIPTION
This also takes benefit of object reference to be used in multiple repository for same configuration. And in future library can add more options easily.

This also solve problem with PSR-6 implementation that cant be detected as redis/memcached to set the prefix separator, so user can manually specify it.

i.e. before
```php
$cache = new Redis($redis, 'dphp:');
```
```php
'cacheInterface' => $cache,
'cacheSweep' = > true,
'cacheCompres' => true,
```
after:
```php
$cache = new Redis($redis, 'dphp:');
```
```php
'cache' => new CacheConfig($cache, true, true, ':');
```
or the cool PHP 8 way
```php
'cache' => new CacheConfig(interface: $cache, compress: true, sweep: true, separator: ':');
```

Of course specifying repository still work like before:
```php
$cache = new Redis($redis, 'dphp:');
$redisCacheConfig = new CacheConfig($cache, $separator = ':');
```
```php
'cache' => [
    AbstractRepository::class => new CacheConfig(new ArrayCache()), // Default use ArrayCache
    MessageRepository::class => $redisCacheConfig, // Message use Redis
    ReactionRepository::class => $redisCacheConfig, // Reactions too
]
```

The `$discord->cache` getter is removed though since at first time it is irrelevant and there can be different cache interfaces.

I need opinion about the CacheConfig properties visibility though, either make it public to allow set/get or just allow getter/read only.