### PR TITLE
Fix thread id repository and cache, thread last_message_id

### DIFF
--- a/src/Discord/Parts/Thread/Thread.php
+++ b/src/Discord/Parts/Thread/Thread.php
@@ -857,17 +857,12 @@ class Thread extends Part
      */
     public function getRepositoryAttributes(): array
     {
-        $attr = [
+        return [
             'guild_id' => $this->guild_id,
             'parent_id' => $this->parent_id,
             'channel_id' => $this->id,
+            'thread_id' => $this->id,
         ];
-
-        if ($this->created) {
-            $attr['thread_id'] = $this->id;
-        }
-
-        return $attr;
     }
 
     /**

--- a/src/Discord/Repository/Channel/MessageRepository.php
+++ b/src/Discord/Repository/Channel/MessageRepository.php
@@ -11,6 +11,7 @@
 
 namespace Discord\Repository\Channel;
 
+use Discord\Discord;
 use Discord\Http\Endpoint;
 use Discord\Parts\Channel\Message;
 use Discord\Repository\AbstractRepository;
@@ -44,4 +45,13 @@ class MessageRepository extends AbstractRepository
      * @inheritDoc
      */
     protected $class = Message::class;
+
+    /**
+     * @inheritDoc
+     */
+    public function __construct(Discord $discord, array $vars = [])
+    {
+        unset($vars['thread_id']); // For thread
+        parent::__construct($discord, $vars);
+    }
 }

--- a/src/Discord/Repository/Thread/MemberRepository.php
+++ b/src/Discord/Repository/Thread/MemberRepository.php
@@ -11,6 +11,7 @@
 
 namespace Discord\Repository\Thread;
 
+use Discord\Discord;
 use Discord\Http\Endpoint;
 use Discord\Parts\Thread\Member;
 use Discord\Repository\AbstractRepository;
@@ -48,4 +49,13 @@ class MemberRepository extends AbstractRepository
      * @inheritDoc
      */
     protected $class = Member::class;
+
+    /**
+     * @inheritDoc
+     */
+    public function __construct(Discord $discord, array $vars = [])
+    {
+        unset($vars['channel_id']); // For thread
+        parent::__construct($discord, $vars);
+    }
 }

--- a/src/Discord/WebSockets/Events/ThreadCreate.php
+++ b/src/Discord/WebSockets/Events/ThreadCreate.php
@@ -36,7 +36,6 @@ class ThreadCreate extends Event
             /** @var ?Channel */
             if ($parent = yield $guild->channels->cacheGet($data->parent_id)) {
                 $parent->last_message_id = $data->id;
-                $threadPart->last_message_id = $data->id;
                 $parent->threads->set($data->id, $threadPart);
             }
         }


### PR DESCRIPTION
Fixed thread_id failed to bind when fetching thread from repository
And removed the duplicates of thread_id & channel_id in (Thread) MemberRepository (removes channel_id because the endpoint binds to thread_id) & MessageRepository (removes thread_id because the endpoint binds to channel_id).

Fixed thread last_message_id on THREAD_CREATE Event, According to API (also when re-freshen), the newly created thread would have `last_message_id = null` due to the message thread will have it after MESSAGE_CREATE event.

Tested.