### PR TITLE
Fix variable becomes undefined in Event handler codes

### DIFF
--- a/src/Discord/Parts/Channel/Channel.php
+++ b/src/Discord/Parts/Channel/Channel.php
@@ -143,7 +143,7 @@ class Channel extends Part
     public const FORUM_LAYOUT_DEFAULT = 0;
     public const FORUM_LAYOUT_LIST = 1;
     public const FORUM_LAYOUT_GRID = 2;
-    
+
     /**
      * @inheritDoc
      */

--- a/src/Discord/WebSockets/Events/ApplicationCommandPermissionsUpdate.php
+++ b/src/Discord/WebSockets/Events/ApplicationCommandPermissionsUpdate.php
@@ -51,7 +51,7 @@ class ApplicationCommandPermissionsUpdate extends Event
             $commandPermissionsPart = $this->factory->part(CommandPermissions::class, (array) $data, true);
         }
 
-        if ($guild && $commandPermissionsPart) {
+        if (isset($guild) && $commandPermissionsPart) {
             // Permission set / updated
             $guild->command_permissions->set($data->id, $commandPermissionsPart);
         }

--- a/src/Discord/WebSockets/Events/AutoModerationRuleUpdate.php
+++ b/src/Discord/WebSockets/Events/AutoModerationRuleUpdate.php
@@ -46,7 +46,7 @@ class AutoModerationRuleUpdate extends Event
             $rulePart = $this->factory->part(Rule::class, (array) $data, true);
         }
 
-        if ($guild) {
+        if (isset($guild)) {
             $guild->auto_moderation_rules->set($data->id, $rulePart);
         }
 

--- a/src/Discord/WebSockets/Events/GuildEmojisUpdate.php
+++ b/src/Discord/WebSockets/Events/GuildEmojisUpdate.php
@@ -50,7 +50,7 @@ class GuildEmojisUpdate extends Event
             $emojiParts->pushItem($this->factory->part(Emoji::class, (array) $emoji, true));
         }
 
-        if ($guild) {
+        if (isset($guild)) {
             yield $guild->emojis->cache->setMultiple($emojiParts->toArray());
         }
 

--- a/src/Discord/WebSockets/Events/GuildMemberUpdate.php
+++ b/src/Discord/WebSockets/Events/GuildMemberUpdate.php
@@ -46,7 +46,7 @@ class GuildMemberUpdate extends Event
             $memberPart = $this->factory->part(Member::class, (array) $data, true);
         }
 
-        if ($guild) {
+        if (isset($guild)) {
             $guild->members->set($data->user->id, $memberPart);
         }
 

--- a/src/Discord/WebSockets/Events/GuildRoleUpdate.php
+++ b/src/Discord/WebSockets/Events/GuildRoleUpdate.php
@@ -27,8 +27,7 @@ class GuildRoleUpdate extends Event
      */
     public function handle($data)
     {
-        $role = (array) $data->role;
-        $role['guild_id'] = $data->guild_id;
+        $role = (array) $data->role + ['guild_id' => $data->guild_id];
         $rolePart = $oldRole = null;
 
         /** @var ?Guild */
@@ -48,7 +47,7 @@ class GuildRoleUpdate extends Event
             $rolePart = $this->factory->part(Role::class, $role, true);
         }
 
-        if ($guild) {
+        if (isset($guild)) {
             $guild->roles->set($data->role->id, $rolePart);
         }
 

--- a/src/Discord/WebSockets/Events/GuildScheduledEventUpdate.php
+++ b/src/Discord/WebSockets/Events/GuildScheduledEventUpdate.php
@@ -46,7 +46,7 @@ class GuildScheduledEventUpdate extends Event
             $scheduledEventPart = $this->factory->part(ScheduledEvent::class, (array) $data, true);
         }
 
-        if ($guild) {
+        if (isset($guild)) {
             $guild->guild_scheduled_events->set($data->id, $scheduledEventPart);
         }
 

--- a/src/Discord/WebSockets/Events/GuildStickersUpdate.php
+++ b/src/Discord/WebSockets/Events/GuildStickersUpdate.php
@@ -49,7 +49,7 @@ class GuildStickersUpdate extends Event
             $stickerParts->pushItem($this->factory->part(Sticker::class, (array) $sticker, true));
         }
 
-        if ($guild) {
+        if (isset($guild)) {
             yield $guild->stickers->cache->setMultiple($stickerParts->toArray());
         }
 

--- a/src/Discord/WebSockets/Events/IntegrationUpdate.php
+++ b/src/Discord/WebSockets/Events/IntegrationUpdate.php
@@ -46,7 +46,7 @@ class IntegrationUpdate extends Event
             $integrationPart = $this->factory->part(Integration::class, (array) $data, true);
         }
 
-        if ($guild) {
+        if (isset($guild)) {
             $guild->integrations->set($data->id, $integrationPart);
         }
 

--- a/src/Discord/WebSockets/Events/MessageCreate.php
+++ b/src/Discord/WebSockets/Events/MessageCreate.php
@@ -69,7 +69,7 @@ class MessageCreate extends Event
             }
         }
 
-        if ($channel) { 
+        if (isset($channel)) { 
             $channel->last_message_id = $data->id;
         }
 

--- a/src/Discord/WebSockets/Events/MessageCreate.php
+++ b/src/Discord/WebSockets/Events/MessageCreate.php
@@ -69,7 +69,7 @@ class MessageCreate extends Event
             }
         }
 
-        if (isset($channel)) { 
+        if (isset($channel)) {
             $channel->last_message_id = $data->id;
         }
 

--- a/src/Discord/WebSockets/Events/MessageDelete.php
+++ b/src/Discord/WebSockets/Events/MessageDelete.php
@@ -52,7 +52,7 @@ class MessageDelete extends Event
                     }
                 }
 
-                if ($channel) {
+                if (isset($channel)) {
                     /** @var ?Message */
                     $messagePart = yield $channel->messages->cachePull($data->id);
                     if ($channel instanceof Thread) {

--- a/src/Discord/WebSockets/Events/MessageReactionAdd.php
+++ b/src/Discord/WebSockets/Events/MessageReactionAdd.php
@@ -52,7 +52,7 @@ class MessageReactionAdd extends Event
         $reaction = new MessageReaction($this->discord, (array) $data, true);
 
         /** @var ?Message */
-        if ($channel && $message = yield $channel->messages->cacheGet($data->message_id)) {
+        if (isset($channel) && $message = yield $channel->messages->cacheGet($data->message_id)) {
             $me = $data->user_id == $this->discord->id;
 
             /** @var ?Reaction */

--- a/src/Discord/WebSockets/Events/MessageReactionRemove.php
+++ b/src/Discord/WebSockets/Events/MessageReactionRemove.php
@@ -52,7 +52,7 @@ class MessageReactionRemove extends Event
         $reaction = new MessageReaction($this->discord, (array) $data, true);
 
         /** @var ?Message */
-        if ($channel && $message = yield $channel->messages->cacheGet($data->message_id)) {
+        if (isset($channel) && $message = yield $channel->messages->cacheGet($data->message_id)) {
             /** @var Reaction */
             if ($react = yield $message->reactions->cacheGet($reaction->reaction_id)) {
                 if ($data->user_id == $this->discord->id) {

--- a/src/Discord/WebSockets/Events/MessageReactionRemoveAll.php
+++ b/src/Discord/WebSockets/Events/MessageReactionRemoveAll.php
@@ -51,7 +51,7 @@ class MessageReactionRemoveAll extends Event
         $reaction = new MessageReaction($this->discord, (array) $data, true);
 
         /** @var ?Message */
-        if ($channel && $message = yield $channel->messages->cacheGet($data->message_id)) {
+        if (isset($channel) && $message = yield $channel->messages->cacheGet($data->message_id)) {
             yield $message->reactions->cache->clear();
         }
 

--- a/src/Discord/WebSockets/Events/MessageReactionRemoveEmoji.php
+++ b/src/Discord/WebSockets/Events/MessageReactionRemoveEmoji.php
@@ -51,7 +51,7 @@ class MessageReactionRemoveEmoji extends Event
         $reaction = new MessageReaction($this->discord, (array) $data, true);
 
         /** @var ?Message */
-        if ($channel && $message = yield $channel->messages->cacheGet($data->message_id)) {
+        if (isset($channel) && $message = yield $channel->messages->cacheGet($data->message_id)) {
             yield $message->reactions->cache->delete($reaction->reaction_id);
         }
 


### PR DESCRIPTION
Reported by Discord Member Tady#5553
```
Undefined variable $channel in /root/test/vendor/team-reflex/discord-php/src/Discord/WebSockets/Events/MessageCreate.php on line 72
```

While these code seems fine (even the syntax is OK and no compile error), somehow that some times they are being undefined. I guess it has something to do with the react/async coroutines `yield` when the variable is prepared in the if condition scope like that, does not guarantee it to be set.

So I added `isset()` as a safe workaround.

Tested.