### PR TITLE
Add default_thread_rate_limit_per_user in Channel creatable attributes

### DIFF
--- a/src/Discord/Parts/Channel/Channel.php
+++ b/src/Discord/Parts/Channel/Channel.php
@@ -1365,11 +1365,14 @@ class Channel extends Part
             'default_auto_archive_duration' => $this->default_auto_archive_duration,
         ];
 
-        if ($attr['type'] == self::TYPE_GUILD_FORUM) {
+        if ($attr['type'] == self::TYPE_GUILD_TEXT) {
+            $attr['default_thread_rate_limit_per_user'] = $this->default_thread_rate_limit_per_user ?? null;
+        } elseif ($attr['type'] == self::TYPE_GUILD_FORUM) {
             if (array_key_exists('default_reaction_emoji', $this->attributes)) {
                 $attr['default_reaction_emoji'] = $this->attributes['default_reaction_emoji'];
             }
 
+            $attr['flags'] = $this->flags ?? null;
             $attr['available_tags'] = $this->attributes['available_tags'] ?? null;
 
             if (array_key_exists('default_sort_order', $this->attributes)) {
@@ -1379,6 +1382,8 @@ class Channel extends Part
             if (array_key_exists('default_forum_layout', $this->attributes)) {
                 $attr['default_forum_layout'] = $this->default_forum_layout;
             }
+
+            $attr['default_thread_rate_limit_per_user'] = $this->default_thread_rate_limit_per_user ?? null;
         }
 
         return $attr;

--- a/src/Discord/Parts/Channel/Channel.php
+++ b/src/Discord/Parts/Channel/Channel.php
@@ -134,6 +134,7 @@ class Channel extends Part
     public const VIDEO_QUALITY_AUTO = 1;
     public const VIDEO_QUALITY_FULL = 2;
 
+    /** @deprecated 10.0.0 Use `Thread::FLAG_PINNED` */
     public const FLAG_PINNED = (1 << 1);
     public const FLAG_REQUIRE_TAG = (1 << 4);
 

--- a/src/Discord/Parts/Channel/Channel.php
+++ b/src/Discord/Parts/Channel/Channel.php
@@ -1373,7 +1373,6 @@ class Channel extends Part
                 $attr['default_reaction_emoji'] = $this->attributes['default_reaction_emoji'];
             }
 
-            $attr['flags'] = $this->flags ?? null;
             $attr['available_tags'] = $this->attributes['available_tags'] ?? null;
 
             if (array_key_exists('default_sort_order', $this->attributes)) {

--- a/src/Discord/Parts/Thread/Thread.php
+++ b/src/Discord/Parts/Thread/Thread.php
@@ -75,6 +75,8 @@ use function React\Promise\resolve;
  */
 class Thread extends Part
 {
+    public const FLAG_PINNED = (1 << 1);
+
     /**
      * {@inheritDoc}
      */

--- a/src/Discord/Parts/Thread/Thread.php
+++ b/src/Discord/Parts/Thread/Thread.php
@@ -792,7 +792,7 @@ class Thread extends Part
 
         return $deferred->promise();
     }
-    
+
     /**
      * Returns the bot's permissions in the thread.
      *
@@ -823,6 +823,10 @@ class Thread extends Part
 
         if ($this->type == Channel::TYPE_PRIVATE_THREAD) {
             $attr['invitable'] = $this->invitable;
+        }
+
+        if (array_key_exists('flags', $this->attributes)) {
+            $attr['flags'] = $this->flags;
         }
 
         return $attr;

--- a/src/Discord/Parts/Thread/Thread.php
+++ b/src/Discord/Parts/Thread/Thread.php
@@ -827,10 +827,6 @@ class Thread extends Part
             $attr['invitable'] = $this->invitable;
         }
 
-        if (array_key_exists('flags', $this->attributes)) {
-            $attr['flags'] = $this->flags;
-        }
-
         return $attr;
     }
 


### PR DESCRIPTION
https://github.com/discord/discord-api-docs/pull/5606

`default_thread_rate_limit_per_user` is for setting the thread default `rate_limit_per_user` which exists on the text channel and forum channel.

~~Since right now `flags` only relevant to forums, i only added flags for forum.~~

Also deprecated Channel flag pinned and moved it to Thread class