### PR TITLE
Add CacheConfig::$ttl

### DIFF
--- a/src/Discord/Helpers/CacheConfig.php
+++ b/src/Discord/Helpers/CacheConfig.php
@@ -49,12 +49,20 @@ class CacheConfig
     protected string $separator = '.';
 
     /**
+     * The Time To Live for `$interface::set()` and `$interface::setMultiple()`.
+     *
+     * @var null|int|\DateInterval
+     */
+    public $ttl;
+
+    /**
      * @param \React\Cache\CacheInterface|\Psr\SimpleCache\CacheInterface $interface The PSR-16 Cache Interface.
      * @param bool                                                        $compress  Whether to compress cache data before serialization, ignored in ArrayCache.
      * @param bool                                                        $sweep     Whether to automatically sweep cache.
      * @param string|null                                                 $separator The cache key prefix separator, null for default.
+     * @param null|int|\DateInterval                                      $ttl       The cache time to live value to pass to the interface.
      */
-    public function __construct($interface, bool $compress = false, bool $sweep = false, ?string $separator = null)
+    public function __construct($interface, bool $compress = false, bool $sweep = false, ?string $separator = null, $ttl = null)
     {
         $this->interface = $interface;
         $this->sweep = $sweep;
@@ -67,6 +75,7 @@ class CacheConfig
             }
         }
         $this->separator = $separator;
+        $this->ttl = $ttl;
     }
 
     public function __get(string $name)

--- a/src/Discord/Helpers/CacheWrapper.php
+++ b/src/Discord/Helpers/CacheWrapper.php
@@ -144,6 +144,7 @@ class CacheWrapper
      */
     public function set($key, $value, $ttl = null)
     {
+        $ttl ??= $this->config->ttl;
         $item = $this->serializer($value);
 
         $handleValue = function ($success) use ($key, $value) {


### PR DESCRIPTION
Useful to set default expiry of cache items if supported by the interface.

BC: a `$ttl = null` value when manually used in `$cache->set(..., null)` will be overriden by the provided `CacheConfig::$ttl`. It can be worked around by temporary switching the `CacheConfig::$ttl` to `null`.