### PR TITLE
Allow non react/cache interface to use compress option

### DIFF
--- a/src/Discord/Discord.php
+++ b/src/Discord/Discord.php
@@ -194,8 +194,7 @@ class Discord
     protected $voiceClients = [];
 
     /**
-     * An array of large guilds that need to be requested for
-     * members.
+     * An array of large guilds that need to be requested for members.
      *
      * @var array Large guilds.
      */
@@ -294,8 +293,7 @@ class Discord
     protected $zlibDecompressor;
 
     /**
-     * Tracks the number of payloads the client
-     * has sent in the past 60 seconds.
+     * Tracks the number of payloads the client has sent in the past 60 seconds.
      *
      * @var int
      */

--- a/src/Discord/Helpers/CacheConfig.php
+++ b/src/Discord/Helpers/CacheConfig.php
@@ -66,10 +66,12 @@ class CacheConfig
     {
         $this->interface = $interface;
         $this->sweep = $sweep;
-        $this->compress = $compress;
+        $interfaceName = get_class($interface);
+        if ($this->compress = $compress && stripos($interfaceName, 'Symfony') !== false) {
+            trigger_error('Symfony cache is not compatible with option `$compress = true`, Use the DeflateMarshaller to compress data!');
+        }
         if (null === $separator) {
             $separator = '.';
-            $interfaceName = get_class($interface);
             if (stripos($interfaceName, 'Redis') !== false || stripos($interfaceName, 'Memcached') !== false) {
                 $separator = ':';
             }

--- a/src/Discord/Helpers/CacheConfig.php
+++ b/src/Discord/Helpers/CacheConfig.php
@@ -67,7 +67,7 @@ class CacheConfig
         $this->interface = $interface;
         $this->sweep = $sweep;
         $interfaceName = get_class($interface);
-        if ($this->compress = $compress && stripos($interfaceName, 'Symfony') !== false) {
+        if (($this->compress = $compress) && stripos($interfaceName, 'Symfony') !== false) {
             trigger_error('Symfony cache is not compatible with option `$compress = true`, Use the DeflateMarshaller to compress data!');
         }
         if (null === $separator) {


### PR DESCRIPTION
Previously the compress option only takes effect on react/cache interface, this PR allows other.

However it is not compatible with Symfony cache since the serialization takes place after this library `serliazer()`, it is however still possible to compress data by [using the `DeflateMarshaller` from the Symfony class](https://symfony.com/doc/current/components/cache.html#marshalling-serializing-data), and this library `$compress` option must be set to `false`, so added the warning `PHP Notice:  Symfony cache is not compatible with option $compress = true, Use the DeflateMarshaller to compress data! in D:\Data\DiscordPHP\src\Discord\Helpers\CacheConfig.php on line 71`.
Example:
```php
$cache = new CacheConfig(new Psr16Cache(new RedisAdapter($redis, 'dphp', 0, new DeflateMarshaller(new DefaultMarshaller()))), compress: false);
```

Tested.