### PR TITLE
Fix callable typehints

### DIFF
--- a/src/Discord/CommandClient/Command.php
+++ b/src/Discord/CommandClient/Command.php
@@ -95,7 +95,7 @@ class Command
      */
     protected $client;
     /**
-     * @var Callable
+     * @var callable
      */
     protected $callable;
 
@@ -104,7 +104,7 @@ class Command
      *
      * @param DiscordCommandClient $client          The Discord Command Client.
      * @param string               $command         The command trigger.
-     * @param \Callable            $callable        The callable function.
+     * @param callable             $callable        The callable function.
      * @param string               $description     The short description of the command.
      * @param string               $longDescription The long description of the command.
      * @param string               $usage           The usage of the command.
@@ -159,7 +159,7 @@ class Command
      * Registers a new command.
      *
      * @param string           $command  The command name.
-     * @param \Callable|string $callable The function called when the command is executed.
+     * @param callable|string  $callable The function called when the command is executed.
      * @param array            $options  An array of options.
      *
      * @return Command    The command instance.

--- a/src/Discord/DiscordCommandClient.php
+++ b/src/Discord/DiscordCommandClient.php
@@ -232,7 +232,7 @@ class DiscordCommandClient extends Discord
      * Registers a new command.
      *
      * @param string           $command  The command name.
-     * @param \Callable|string $callable The function called when the command is executed.
+     * @param callable|string  $callable The function called when the command is executed.
      * @param array            $options  An array of options.
      *
      * @return Command    The command instance.
@@ -326,7 +326,7 @@ class DiscordCommandClient extends Discord
      * Builds a command and returns it.
      *
      * @param string           $command  The command name.
-     * @param \Callable|string $callable The function called when the command is executed.
+     * @param callable|string  $callable The function called when the command is executed.
      * @param array            $options  An array of options.
      *
      * @return Command[]|array[] The command instance and options.


### PR DESCRIPTION
The `callable` keyword does not refer to a class or global function, so it should not be prefixed with a backslash. We replace `\Callable` with `callable` (the capitalization change is cosmetic, since it is standard for non-class types to be lowercase).

This was causing errors in static analysis for dependent libraries when calling into the methods that used the `\Callable` typehint.