### PR TITLE
The actual pause/unpause bug fix 

### DIFF
--- a/src/Discord/Voice/VoiceClient.php
+++ b/src/Discord/Voice/VoiceClient.php
@@ -346,13 +346,6 @@ class VoiceClient extends EventEmitter
     protected $buffer;
 
     /**
-     * Paused Timestamp
-     * 
-     * @var float Microtime of when the playback was paused
-     */
-    protected $pausedTimestamp = 0;
-
-    /**
      * Constructs the Voice Client instance.
      *
      * @param WebSocket       $websocket The main WebSocket client.
@@ -1225,7 +1218,6 @@ class VoiceClient extends EventEmitter
             throw new \RuntimeException('Audio is already paused.');
         }
 
-        $this->pausedTimestamp = microtime(true);
         $this->paused = true;
         $this->silenceRemaining = 5;
     }


### PR DESCRIPTION
It seems that $delay was negative after unpausing because $loops wasn't getting incremented while the stream is paused. This unexpected side effect seemed to be cause the issue. My """fix""" bypassed $loops which is why it seemed to worked but I neglected to test on windows (woops). This new fix however was tested on Windows and Linux. I also had the person who said my original """fix""" broke audio streams test it and they said it works. Note the second commit was me removing some test properties I created in my many many attempts to fix this.