### PR TITLE
Remove useless forced dependency (psr/simple-cache)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,8 +29,7 @@
         "react/child-process": "^0.6.3",
         "discord/interactions": "^2.2",
         "react/async": "^4.0 || ^3.0",
-        "react/cache": "^0.5 || ^0.6 || ^1.0",
-        "psr/simple-cache": "^1.0"
+        "react/cache": "^0.5 || ^0.6 || ^1.0"
     },
     "require-dev": {
         "symfony/var-dumper": "*",
@@ -53,7 +52,8 @@
         "ext-uv": "For a faster, and more performant loop. Preferred.",
         "ext-ev": "For a faster, and more performant loop.",
         "ext-event": "For a faster, and more performant loop.",
-        "ext-mbstring": "For accurate calculations of string length when handling non-english characters."
+        "ext-mbstring": "For accurate calculations of string length when handling non-english characters.",
+        "psr/simple-cache": "For implementing your own repository cache"
     },
     "scripts": {
         "cs": ["./vendor/bin/php-cs-fixer fix"],

--- a/src/Discord/Discord.php
+++ b/src/Discord/Discord.php
@@ -1360,6 +1360,12 @@ class Discord
      */
     protected function resolveOptions(array $options = []): array
     {
+        $cacheAllowedTypes = ['array', CacheConfig::class, \React\Cache\CacheInterface::class];
+
+        if (interface_exists('Psr\SimpleCache\CacheInterface')) {
+            $cacheAllowedTypes[] = \Psr\SimpleCache\CacheInterface::class;
+        }
+
         $resolver = new OptionsResolver();
 
         $resolver
@@ -1400,7 +1406,7 @@ class Discord
             ->setAllowedTypes('intents', ['array', 'int'])
             ->setAllowedTypes('socket_options', 'array')
             ->setAllowedTypes('dnsConfig', ['string', \React\Dns\Config\Config::class])
-            ->setAllowedTypes('cache', ['array', CacheConfig::class, \React\Cache\CacheInterface::class, \Psr\SimpleCache\CacheInterface::class])
+            ->setAllowedTypes('cache', $cacheAllowedTypes)
             ->setNormalizer('cache', function ($options, $value) {
                 if (! is_array($value)) {
                     if (! ($value instanceof CacheConfig)) {


### PR DESCRIPTION
Hello!

The dependency `psr/simple-cache` is locked at a very old version (~2017, 1.x, now the 3.x exists, the locked version blocks every recent library that we want to add). This dependency should not be required, only suggested because it's used only for resolving the cache configuration parameter.

I removed it from composer.json file and handled the case where the dependency does not exist.