### PR TITLE
Fix variable name typo

### DIFF
--- a/src/Discord/Discord.php
+++ b/src/Discord/Discord.php
@@ -752,7 +752,7 @@ class Discord
     {
         $hData = $this->handlers->getHandler($data->t);
 
-        if (null === $hdata) {
+        if (null === $hData) {
             $handlers = [
                 Event::VOICE_SERVER_UPDATE => 'handleVoiceServerUpdate',
                 Event::RESUMED => 'handleResume',


### PR DESCRIPTION
Bot is not able to start cuz of that typo