### PR TITLE
Fix docstring type for Message->channel

### DIFF
--- a/src/Discord/Parts/Channel/Message.php
+++ b/src/Discord/Parts/Channel/Message.php
@@ -46,7 +46,7 @@ use function React\Promise\reject;
  *
  * @property      string                      $id                 The unique identifier of the message.
  * @property      string                      $channel_id         The unique identifier of the channel that the message was went in.
- * @property-read Channel|Thread|null         $channel            The channel that the message was sent in.
+ * @property-read Channel|Thread              $channel            The channel that the message was sent in.
  * @property      User|null                   $author             The author of the message. Will be a webhook if sent from one.
  * @property-read string|null                 $user_id            The user id of the author.
  * @property      string                      $content            The content of the message if it is a normal message.


### PR DESCRIPTION
Since `Message::getChannelAttribute` can only return Channel|Thread, it is not possible for the `channel` attribute to be null.

This appears to have been erroneously introduced in b972af99c05e5e.

Please let me know if any additional changes are needed here. Thanks for your time!