### PR TITLE
Fixed ready deprecation warning always being emitted

### DIFF
--- a/src/Discord/Discord.php
+++ b/src/Discord/Discord.php
@@ -1134,7 +1134,7 @@ class Discord
         $this->emit('init', [$this]);
 
         /* deprecated */
-        if (isset($this->listeners['ready'])) {
+        if (count($this->listeners['ready']) > 1) {
             $this->logger->info('The \'ready\' event is deprecated and will be removed in a future version of DiscordPHP. Please use \'init\' instead.');
             $this->emit('ready', [$this]);
         }


### PR DESCRIPTION
Since there's always at least one ready event being listened for internally this message was already being emitted, so the message is now only emitted if there's 2 or more listeners for ready