### PR TITLE
Fixed Emoji __toString being malformed

### DIFF
--- a/src/Discord/Parts/Guild/Emoji.php
+++ b/src/Discord/Parts/Guild/Emoji.php
@@ -127,7 +127,7 @@ class Emoji extends Part
     public function __toString(): string
     {
         if ($this->id) {
-            return '<'.($this->animated ? 'a:' : '')."{$this->name}:{$this->id}>";
+            return '<'.($this->animated ? 'a:' : ':')."{$this->name}:{$this->id}>";
         }
 
         return $this->name;


### PR DESCRIPTION
As of now the `Emoji::__toString()` method returned `<name:id>` when it should be returning `<:name:id>` 