### PR TITLE
Allow line breaks in default logger

### DIFF
--- a/src/Discord/Discord.php
+++ b/src/Discord/Discord.php
@@ -47,6 +47,7 @@ use Discord\Helpers\RegisteredCommand;
 use Discord\Http\Drivers\React;
 use Discord\Http\Endpoint;
 use Evenement\EventEmitterTrait;
+use Monolog\Formatter\LineFormatter;
 use Psr\Log\LoggerInterface;
 use React\Cache\ArrayCache;
 use React\Promise\ExtendedPromiseInterface;
@@ -1433,8 +1434,10 @@ class Discord
         $options['loop'] ??= LoopFactory::create();
 
         if (null === $options['logger']) {
-            $logger = new Monolog('DiscordPHP');
-            $logger->pushHandler(new StreamHandler('php://stdout', Monolog::DEBUG));
+            $streamHandler = new StreamHandler('php://stdout', Monolog::DEBUG);
+            $lineFormatter = new LineFormatter(null, null, true, true);
+            $streamHandler->setFormatter($lineFormatter);
+            $logger = new Monolog('DiscordPHP', [$streamHandler]);
             $options['logger'] = $logger;
         }
 


### PR DESCRIPTION
This formats the default log nicely like this:
```
[2023-04-25T14:43:36.238477+00:00] DiscordPHP.WARNING: REQ POST channels/872531139275919423/messages failed: Discord\Http\Exceptions\NoPermissionsException: Forbidden - {
    "message": "Cannot reply without permission to read message history",
    "code": 160002
} in D:\Data\DiscordPHP\vendor\discord-php\http\src\Discord\Http.php:514
Stack trace:
#0 D:\Data\DiscordPHP\vendor\discord-php\http\src\Discord\Http.php(398): Discord\Http\Http->handleError()
#1 D:\Data\DiscordPHP\vendor\react\promise\src\FulfilledPromise.php(42): Discord\Http\Http->Discord\Http\{closure}()
#2 D:\Data\DiscordPHP\vendor\react\promise\src\Promise.php(66): React\Promise\FulfilledPromise->done()
#3 D:\Data\DiscordPHP\vendor\react\promise\src\Promise.php(168): React\Promise\Promise::React\Promise\{closure}()
#4 D:\Data\DiscordPHP\vendor\react\promise\src\Promise.php(231): React\Promise\Promise->settle()
#5 D:\Data\DiscordPHP\vendor\react\promise\src\Deferred.php(36): React\Promise\Promise::React\Promise\{closure}()
#6 D:\Data\DiscordPHP\vendor\react\http\src\Io\Transaction.php(89): React\Promise\Deferred->resolve()
#7 D:\Data\DiscordPHP\vendor\react\promise\src\FulfilledPromise.php(28): React\Http\Io\Transaction->React\Http\Io\{closure}()
#8 D:\Data\DiscordPHP\vendor\react\promise\src\Promise.php(134): React\Promise\FulfilledPromise->then()
#9 D:\Data\DiscordPHP\vendor\react\promise\src\Promise.php(168): React\Promise\Promise::React\Promise\{closure}()
#10 D:\Data\DiscordPHP\vendor\react\promise\src\Promise.php(231): React\Promise\Promise->settle()
#11 D:\Data\DiscordPHP\vendor\react\promise\src\FulfilledPromise.php(42): React\Promise\Promise::React\Promise\{closure}()
#12 D:\Data\DiscordPHP\vendor\react\promise\src\Promise.php(135): React\Promise\FulfilledPromise->done()
#13 D:\Data\DiscordPHP\vendor\react\promise\src\Promise.php(168): React\Promise\Promise::React\Promise\{closure}()
#14 D:\Data\DiscordPHP\vendor\react\promise\src\Promise.php(231): React\Promise\Promise->settle()
#15 D:\Data\DiscordPHP\vendor\react\promise\src\FulfilledPromise.php(42): React\Promise\Promise::React\Promise\{closure}()
#16 D:\Data\DiscordPHP\vendor\react\promise\src\Promise.php(66): React\Promise\FulfilledPromise->done()
#17 D:\Data\DiscordPHP\vendor\react\promise\src\Promise.php(168): React\Promise\Promise::React\Promise\{closure}()
#18 D:\Data\DiscordPHP\vendor\react\promise\src\Promise.php(231): React\Promise\Promise->settle()
#19 D:\Data\DiscordPHP\vendor\react\promise\src\FulfilledPromise.php(42): React\Promise\Promise::React\Promise\{closure}()
#20 D:\Data\DiscordPHP\vendor\react\promise\src\Promise.php(135): React\Promise\FulfilledPromise->done()
#21 D:\Data\DiscordPHP\vendor\react\promise\src\Promise.php(168): React\Promise\Promise::React\Promise\{closure}()
#22 D:\Data\DiscordPHP\vendor\react\promise\src\Promise.php(231): React\Promise\Promise->settle()
#23 D:\Data\DiscordPHP\vendor\react\promise\src\FulfilledPromise.php(42): React\Promise\Promise::React\Promise\{closure}()
#24 D:\Data\DiscordPHP\vendor\react\promise\src\Promise.php(135): React\Promise\FulfilledPromise->done()
#25 D:\Data\DiscordPHP\vendor\react\promise\src\Promise.php(168): React\Promise\Promise::React\Promise\{closure}()
#26 D:\Data\DiscordPHP\vendor\react\promise\src\Promise.php(231): React\Promise\Promise->settle()
#27 D:\Data\DiscordPHP\vendor\react\promise-stream\src\functions.php(79): React\Promise\Promise::React\Promise\{closure}()
#28 D:\Data\DiscordPHP\vendor\evenement\evenement\src\Evenement\EventEmitterTrait.php(123): React\Promise\Stream\{closure}()
#29 D:\Data\DiscordPHP\vendor\react\http\src\Io\ReadableBodyStream.php(50): Evenement\EventEmitter->emit()
#30 D:\Data\DiscordPHP\vendor\react\http\src\Io\ReadableBodyStream.php(151): React\Http\Io\ReadableBodyStream->close()
#31 D:\Data\DiscordPHP\vendor\react\http\src\Io\ReadableBodyStream.php(33): React\Http\Io\ReadableBodyStream->handleEnd()
#32 D:\Data\DiscordPHP\vendor\evenement\evenement\src\Evenement\EventEmitterTrait.php(123): React\Http\Io\ReadableBodyStream->React\Http\Io\{closure}()
#33 D:\Data\DiscordPHP\vendor\react\http\src\Client\Request.php(163): Evenement\EventEmitter->emit()
#34 D:\Data\DiscordPHP\vendor\evenement\evenement\src\Evenement\EventEmitterTrait.php(123): React\Http\Client\Request->handleData()   
#35 D:\Data\DiscordPHP\vendor\react\stream\src\Util.php(71): Evenement\EventEmitter->emit()
#36 D:\Data\DiscordPHP\vendor\evenement\evenement\src\Evenement\EventEmitterTrait.php(123): React\Stream\Util::React\Stream\{closure}()
#37 D:\Data\DiscordPHP\vendor\react\stream\src\DuplexResourceStream.php(196): Evenement\EventEmitter->emit()
#38 D:\Data\DiscordPHP\vendor\react\event-loop\src\StreamSelectLoop.php(246): React\Stream\DuplexResourceStream->handleData()
#39 D:\Data\DiscordPHP\vendor\react\event-loop\src\StreamSelectLoop.php(213): React\EventLoop\StreamSelectLoop->waitForStreamActivity()
#40 D:\Data\DiscordPHP\src\Discord\Discord.php(1502): React\EventLoop\StreamSelectLoop->run()
#41 D:\Data\DiscordPHP\test1.php(180): Discord\Discord->run()
#42 {main}
```