### PR TITLE
Update cached message thread attributes with newly created thread

### DIFF
--- a/src/Discord/Parts/Channel/Message.php
+++ b/src/Discord/Parts/Channel/Message.php
@@ -763,6 +763,7 @@ class Message extends Part
         }
 
         return $this->http->post(Endpoint::bind(Endpoint::CHANNEL_MESSAGE_THREADS, $this->channel_id, $this->id), $options, $headers)->then(function ($response) use ($channel) {
+            $this->attributes['thread'] ??= $response;
             if ($channel) {
                 /** @var ?Thread */
                 if (! $threadPart = $channel->threads->offsetGet($response->id)) {

--- a/src/Discord/WebSockets/Events/ThreadCreate.php
+++ b/src/Discord/WebSockets/Events/ThreadCreate.php
@@ -37,6 +37,7 @@ class ThreadCreate extends Event
             /** @var ?Channel */
             if ($parent = yield $guild->channels->cacheGet($data->parent_id)) {
                 $parent->last_message_id = $data->id;
+                $parent->threads->set($data->id, $threadPart);
                 /** @var ?Message */
                 if ($messageSource = yield $parent->messages->cacheGet($data->id)) {
                     if ($messageSource->has_thread) {
@@ -44,7 +45,6 @@ class ThreadCreate extends Event
                         $parent->messages->set($messageSource->id, $messageSource);
                     }
                 }
-                $parent->threads->set($data->id, $threadPart);
             }
         }
 

--- a/src/Discord/WebSockets/Events/ThreadCreate.php
+++ b/src/Discord/WebSockets/Events/ThreadCreate.php
@@ -12,6 +12,7 @@
 namespace Discord\WebSockets\Events;
 
 use Discord\Parts\Channel\Channel;
+use Discord\Parts\Channel\Message;
 use Discord\Parts\Guild\Guild;
 use Discord\Parts\Thread\Thread;
 use Discord\WebSockets\Event;
@@ -36,6 +37,13 @@ class ThreadCreate extends Event
             /** @var ?Channel */
             if ($parent = yield $guild->channels->cacheGet($data->parent_id)) {
                 $parent->last_message_id = $data->id;
+                /** @var ?Message */
+                if ($messageSource = yield $parent->messages->cacheGet($data->id)) {
+                    if ($messageSource->has_thread) {
+                        $messageSource->thread = $data;
+                        $parent->messages->set($messageSource->id, $messageSource);
+                    }
+                }
                 $parent->threads->set($data->id, $threadPart);
             }
         }


### PR DESCRIPTION
This only update `$message->thread` with the new thread only if the `$message` is cached previously

While this doesn't always fill `thread` during thread creation, it should solve the #1074 case