### PR TITLE
Allow guild ids to be passed to retrieveBans option

### DIFF
--- a/src/Discord/Discord.php
+++ b/src/Discord/Discord.php
@@ -1412,7 +1412,7 @@ class Discord
             ->setAllowedTypes('loadAllMembers', ['bool', 'array'])
             ->setAllowedTypes('disabledEvents', 'array')
             ->setAllowedTypes('storeMessages', 'bool')
-            ->setAllowedTypes('retrieveBans', 'bool')
+            ->setAllowedTypes('retrieveBans', ['bool', 'array'])
             ->setAllowedTypes('intents', ['array', 'int'])
             ->setAllowedTypes('socket_options', 'array')
             ->setAllowedTypes('dnsConfig', ['string', \React\Dns\Config\Config::class])

--- a/src/Discord/WebSockets/Events/GuildCreate.php
+++ b/src/Discord/WebSockets/Events/GuildCreate.php
@@ -93,7 +93,14 @@ class GuildCreate extends Event
             });
         });
 
-        if ($this->discord->options['retrieveBans'] && $members[$this->discord->id]->getPermissions()->ban_members ?? true) {
+        if (
+            ($this->discord->options['retrieveBans'] === true
+                || (is_array($this->discord->options['retrieveBans'])
+                    && in_array($data->id, $this->discord->options['retrieveBans'])
+                )
+            )
+            && $members[$this->discord->id]->getPermissions()->ban_members ?? true
+        ) {
             $loadBans = new Deferred();
             $banPagination = function ($lastUserId = null) use (&$banPagination, $guildPart, $loadBans) {
                 $bind = Endpoint::bind(Endpoint::GUILD_BANS, $guildPart->id);


### PR DESCRIPTION
While this might not solve the OP's issue in #1061 this option allows only specific guild ids in array to have its bans loaded (just like `loadAllMembers` have)

e.g.
```php
'retrieveBans' => ['872531095621615646', '115233111977099271'],
```