### PR TITLE
BC: MESSAGE_UPDATE first argument typehint is now object|Message

### DIFF
--- a/docs/src/pages/api/03_events/07_messages.md
+++ b/docs/src/pages/api/03_events/07_messages.md
@@ -18,13 +18,16 @@ $discord->on(Event::MESSAGE_CREATE, function (Message $message, Discord $discord
 
 ### Message Update
 
-Called with two `Message` objects when a message is updated in a guild or private channel.
+Called with `Message` or `stdClass` objects when a message is updated in a guild or private channel.
+The `$message` may be an instance of `stdClass` if it was partial, otherwise a `Message`.
 The old message may be null if `storeMessages` is not enabled _or_ the message was sent before the Bot was started.
 Discord does not provide a way to get message update history.
 
 ```php
-$discord->on(Event::MESSAGE_UPDATE, function (Message $message, Discord $discord, ?Message $oldMessage) {
-    // ...
+$discord->on(Event::MESSAGE_UPDATE, function (object $message, Discord $discord, ?Message $oldMessage) {
+    if ($message instanceof Message) { // Check for non partial message
+        // ...
+    }
 });
 ```
 

--- a/guide/events/messages.rst
+++ b/guide/events/messages.rst
@@ -21,7 +21,7 @@ Called with a ``Message`` object when a message is sent in a guild or private ch
 Message Update
 ==============
 
-Called with two ``Message`` objects when a message is updated in a guild or private channel. The old message may be null if ``storeMessages`` is not enabled *or* the message was sent before the Bot was started. Discord does not provide a way to get message update history.
+Called with ``Message`` objects when a message is updated in a guild or private channel. The `$message` may be an instance of `stdClass` if it was partial, otherwise a `Message`. The old message may be null if ``storeMessages`` is not enabled *or* the message was sent before the Bot was started. Discord does not provide a way to get message update history.
 
 .. code:: php
 

--- a/src/Discord/WebSockets/Events/MessageUpdate.php
+++ b/src/Discord/WebSockets/Events/MessageUpdate.php
@@ -66,13 +66,13 @@ class MessageUpdate extends Event
             }
         }
 
-        if ($oldMessagePart === null) {
+        if ($oldMessagePart === null && isset($data->type)) { // Message has type means not partial
             /** @var Message */
             $messagePart = $this->factory->part(Message::class, (array) $data, true);
         }
 
-        if (isset($channel) && ($oldMessagePart || $this->discord->options['storeMessages'])) {
-            $channel->messages->set($data->id, $cacheMessagePart ?? $messagePart);
+        if (isset($channel) && ($oldMessagePart || $this->discord->options['storeMessages']) && $setMessageData = $cacheMessagePart ?? $messagePart) { // Skip partial messages
+            $channel->messages->set($data->id, $setMessageData);
         }
 
         if (isset($data->author) && ! isset($data->webhook_id)) {
@@ -89,6 +89,6 @@ class MessageUpdate extends Event
             $this->cacheUser($user);
         }
 
-        return [$messagePart, $oldMessagePart];
+        return [$messagePart ?? $data, $oldMessagePart];
     }
 }


### PR DESCRIPTION
This is due to fact that MESSAGE_UPDATE event may send a partial data which only contains ids, and a flag. We check if the data contains a type to make sure that it is not partial.

Fixes #1107

- [x] Tested