### PR TITLE
Add a handle on GUILD_CREATE event and logger when presence data exists but no member data

### DIFF
--- a/src/Discord/WebSockets/Events/GuildCreate.php
+++ b/src/Discord/WebSockets/Events/GuildCreate.php
@@ -51,6 +51,18 @@ class GuildCreate extends Event
             }
         }
         foreach ($data->presences as $presence) {
+            if (! array_key_exists($presence->user->id, $members)) {
+                $this->discord->getLogger()->warning('Presence data exists but no member data was received', [
+                    'user_id' => $presence->user->id,
+                    'guild_id' => $data->id,
+                    'large' => $data->large,
+                    'member_count' => $data->member_count,
+                    'members_count' => count($data->members),
+                    'rawMembers_looped' => count($rawMembers),
+                    'presences_count' => count($data->presences),
+                ]);
+                continue;
+            }
             $members[$presence->user->id]->fill((array) $presence);
         }
         if (! empty($members)) {


### PR DESCRIPTION
There was strange issue happened when D.PHP bot reconnected
```
[2023-05-11T16:12:13.248543+00:00] D.PHP.DEBUG: ready packet received [] []
[2023-05-11T16:12:13.248647+00:00] D.PHP.DEBUG: resume_gateway_url received {"url":"wss://gateway-us-east1-c.discord.gg"} []
[2023-05-11T16:12:13.248673+00:00] D.PHP.DEBUG: websocket reconnected to discord through identify [] []
[2023-05-11T16:12:18.524034+00:00] D.PHP.DEBUG: sending 1 chunks with 3 large guilds overall [] []
[2023-05-11T16:12:18.524145+00:00] D.PHP.DEBUG: sending chunk with 3 large guilds [] []
>> PHP Warning:  Undefined array key 781652104002928680 in /home/dphp/D.PHP/vendor/team-reflex/discord-php/src/Discord/WebSockets/Events/GuildCreate.php on line 54
PHP Fatal error:  Uncaught Error: Call to a member function fill() on null in /home/dphp/D.PHP/vendor/team-reflex/discord-php/src/Discord/WebSockets/Events/GuildCreate.php:54
Stack trace:
#0 [internal function]: Discord\WebSockets\Events\GuildCreate->handle()
#1 /home/dphp/D.PHP/vendor/react/async/src/functions.php(497): Generator->valid()
#2 /home/dphp/D.PHP/vendor/react/async/src/functions.php(528): React\Async\{closure}()
#3 /home/dphp/D.PHP/vendor/team-reflex/discord-php/src/Discord/Discord.php(815): React\Async\coroutine()
#4 /home/dphp/D.PHP/vendor/team-reflex/discord-php/src/Discord/Discord.php(666): Discord\Discord->handleDispatch()
#5 /home/dphp/D.PHP/vendor/team-reflex/discord-php/src/Discord/Discord.php(632): Discord\Discord->processWsMessage()
#6 /home/dphp/D.PHP/vendor/evenement/evenement/src/Evenement/EventEmitterTrait.php(123): Discord\Discord->handleWsMessage()
#7 /home/dphp/D.PHP/vendor/ratchet/pawl/src/WebSocket.php(72): Ratchet\Client\WebSocket->emit()
#8 /home/dphp/D.PHP/vendor/ratchet/rfc6455/src/Messaging/MessageBuffer.php(248): Ratchet\Client\WebSocket->Ratchet\Client\{closure}()
#9 /home/dphp/D.PHP/vendor/ratchet/rfc6455/src/Messaging/MessageBuffer.php(194): Ratchet\RFC6455\Messaging\MessageBuffer->processData()
#10 /home/dphp/D.PHP/vendor/evenement/evenement/src/Evenement/EventEmitterTrait.php(123): Ratchet\RFC6455\Messaging\MessageBuffer->onData()
#11 /home/dphp/D.PHP/vendor/react/stream/src/Util.php(71): Evenement\EventEmitter->emit()
#12 /home/dphp/D.PHP/vendor/evenement/evenement/src/Evenement/EventEmitterTrait.php(123): React\Stream\Util::React\Stream\{closure}()
#13 /home/dphp/D.PHP/vendor/react/stream/src/DuplexResourceStream.php(196): Evenement\EventEmitter->emit()
#14 /home/dphp/D.PHP/vendor/react/event-loop/src/ExtUvLoop.php(310): React\Stream\DuplexResourceStream->handleData()
#15 [internal function]: React\EventLoop\ExtUvLoop->React\EventLoop\{closure}()
#16 /home/dphp/D.PHP/vendor/react/event-loop/src/ExtUvLoop.php(232): uv_run()
#17 /home/dphp/D.PHP/run.php(130): React\EventLoop\ExtUvLoop->run()
#18 {main}
  thrown in /home/dphp/D.PHP/vendor/team-reflex/discord-php/src/Discord/WebSockets/Events/GuildCreate.php on line 54
```

Added a code to prevent the crash and a logger if this happen again in future (since we don't know why)