### PR TITLE
Fix Member::getDisplayameAttribute()

### DIFF
--- a/src/Discord/Parts/User/Member.php
+++ b/src/Discord/Parts/User/Member.php
@@ -43,7 +43,7 @@ use function React\Promise\reject;
  * @property-read string|null         $username                     The username of the member.
  * @property-read string|null         $discriminator                The discriminator of the member.
  * @property      ?string|null        $nick                         The nickname of the member.
- * @property-read string              $displayname                  The nickname or username with discriminator of the member.
+ * @property-read string              $displayname                  The nickname or display name with discriminator of the member.
  * @property      ?string|null        $avatar                       The avatar URL of the member or null if member has no guild avatar.
  * @property      ?string|null        $avatar_hash                  The avatar hash of the member or null if member has no guild avatar.
  * @property      Collection|Role[]   $roles                        A collection of Roles that the member has.
@@ -510,13 +510,15 @@ class Member extends Part
     }
 
     /**
-     * Returns the member nickname or username with the discriminator.
+     * Returns the member nickname or display name with optional #discriminator.
      *
-     * @return string Nickname#Discriminator
+     * @return string Either nick or global_name or username with optional #discriminator.
      */
     protected function getDisplaynameAttribute(): string
     {
-        return ($this->nick ?? $this->username).'#'.$this->discriminator;
+        $user = $this->user;
+
+        return ($this->nick ?? $user->global_name ?? $user->username) . ($user->discriminator ? '#' . $this->discriminator : '');
     }
 
     /**

--- a/src/Discord/Parts/User/Member.php
+++ b/src/Discord/Parts/User/Member.php
@@ -517,7 +517,7 @@ class Member extends Part
     {
         $user = $this->user;
 
-        return ($this->nick ?? $user->global_name ?? $user->username) . ($user->discriminator ? '#' . $this->discriminator : '');
+        return ($this->nick ?? $user->global_name ?? $user->username) . ($user->discriminator ? '#' . $user->discriminator : '');
     }
 
     /**

--- a/src/Discord/Parts/User/Member.php
+++ b/src/Discord/Parts/User/Member.php
@@ -41,7 +41,6 @@ use function React\Promise\reject;
  *
  * @property      User|null           $user                         The user part of the member.
  * @property-read string|null         $username                     The username of the member.
- * @property-read string|null         $discriminator                The discriminator of the member.
  * @property      ?string|null        $nick                         The nickname of the member.
  * @property-read string              $displayname                  The nickname or display name with discriminator of the member.
  * @property      ?string|null        $avatar                       The avatar URL of the member or null if member has no guild avatar.
@@ -570,6 +569,8 @@ class Member extends Part
 
     /**
      * Returns the discriminator attribute.
+     *
+     * @deprecated 10.0.0 Use `$member->user->discriminator`
      *
      * @return string|null The discriminator of the member.
      */

--- a/src/Discord/Parts/User/Member.php
+++ b/src/Discord/Parts/User/Member.php
@@ -42,7 +42,7 @@ use function React\Promise\reject;
  * @property      User|null           $user                         The user part of the member.
  * @property-read string|null         $username                     The username of the member.
  * @property      ?string|null        $nick                         The nickname of the member.
- * @property-read string              $displayname                  The nickname or display name with discriminator of the member.
+ * @property-read string              $displayname                  The nickname or display name with optional discriminator of the member.
  * @property      ?string|null        $avatar                       The avatar URL of the member or null if member has no guild avatar.
  * @property      ?string|null        $avatar_hash                  The avatar hash of the member or null if member has no guild avatar.
  * @property      Collection|Role[]   $roles                        A collection of Roles that the member has.


### PR DESCRIPTION
Forgotten in #1134 

Also deprecated `$member->discriminator`, $member->user->discriminator should be used instead for consistency, also discord are removing discriminator from most users names