### PR TITLE
(BC) fix embeds cant have 2 fields with same name

### DIFF
--- a/src/Discord/Parts/Embed/Embed.php
+++ b/src/Discord/Parts/Embed/Embed.php
@@ -139,7 +139,7 @@ class Embed extends Part
      */
     protected function getFieldsAttribute(): Collection
     {
-        $fields = new Collection([], 'name', Field::class);
+        $fields = Collection::for(Field::class, null);
 
         if (! array_key_exists('fields', $this->attributes)) {
             return $fields;


### PR DESCRIPTION
Fixes #1142 

Breaking changes for people using `$embed->fields->offsetGet('name')` or `$embed->fields['name']`

Tested using code from issue

```
Discord\Parts\Embed\Embed Object
(
    [title] =>
    [type] =>
    [description] =>
    [url] =>
    [timestamp] =>
    [color] => 16777215
    [footer] => Discord\Parts\Embed\Footer Object
        (
            [text] =>
            [icon_url] =>
            [proxy_icon_url] =>
        )

    [image] => Discord\Parts\Embed\Image Object
        (
            [url] =>
            [proxy_url] =>
            [height] =>
            [width] =>
        )

    [thumbnail] => Discord\Parts\Embed\Image Object
        (
            [url] =>
            [proxy_url] =>
            [height] =>
            [width] =>
        )

    [video] => Discord\Parts\Embed\Video Object
        (
            [url] =>
            [proxy_url] =>
            [height] =>
            [width] =>
        )

    [provider] =>
    [author] => Discord\Parts\Embed\Author Object
        (
            [name] =>
            [url] =>
            [icon_url] =>
            [proxy_icon_url] =>
        )

    [fields] => Discord\Helpers\Collection Object
        (
            [0] => Discord\Parts\Embed\Field Object
                (
                    [name] => ​
                    [value] => ​
                    [inline] =>
                )

            [1] => Discord\Parts\Embed\Field Object
                (
                    [name] => ​
                    [value] => ​
                    [inline] =>
                )

        )

)
```