### PR TITLE
make Part::$http property dynamic only when needed

### DIFF
--- a/src/Discord/Parts/Part.php
+++ b/src/Discord/Parts/Part.php
@@ -15,7 +15,6 @@ use ArrayAccess;
 use Carbon\Carbon;
 use Discord\Discord;
 use Discord\Factory\Factory;
-use Discord\Http\Http;
 use JsonSerializable;
 use React\Promise\ExtendedPromiseInterface;
 
@@ -24,16 +23,11 @@ use React\Promise\ExtendedPromiseInterface;
  * off this base class.
  *
  * @since 2.0.0
+ *
+ * @property-read Http $http The DiscordPHP-Http Client
  */
 abstract class Part implements ArrayAccess, JsonSerializable
 {
-    /**
-     * The HTTP client.
-     *
-     * @var Http Client.
-     */
-    protected $http;
-
     /**
      * The factory.
      *
@@ -117,7 +111,6 @@ abstract class Part implements ArrayAccess, JsonSerializable
     public function __construct(Discord $discord, array $attributes = [], bool $created = false)
     {
         $this->discord = $discord;
-        $this->http = $discord->getHttpClient();
         $this->factory = $discord->getFactory();
 
         $this->created = $created;
@@ -497,6 +490,10 @@ abstract class Part implements ArrayAccess, JsonSerializable
      */
     public function __get(string $key)
     {
+        if ($key == 'http') {
+            return $this->discord->getHttpClient();
+        }
+
         return $this->getAttribute($key);
     }
 


### PR DESCRIPTION
Not All Part classes needed the http client stored as property, this PR makes it optional that only the Part classes that needs the http client. While this add overhead to the getter, this in hope reduces memory by removing unused property.

So far there is no significance difference, testing it with D.PHP bot for atleast 24 hours.