### PR TITLE
Add Part::getDiscord()

### DIFF
--- a/src/Discord/Parts/Part.php
+++ b/src/Discord/Parts/Part.php
@@ -432,6 +432,16 @@ abstract class Part implements ArrayAccess, JsonSerializable
     }
 
     /**
+     * Get the Discord instance that owns this Part.
+     *
+     * @return Discord
+     */
+    public function getDiscord()
+    {
+        return $this->discord;
+    }
+
+    /**
      * Converts a string to studlyCase.
      *
      * This is a port of updated Laravel's implementation, a non-regex with


### PR DESCRIPTION
Since v10 has separated its concern from referencing Http & Factory client to just one Discord in constructor, we can add this getter method to be used by public.

To be noted It is not good idea to use mutator as this is not part of attributes, and the Discord property must not be changed.

It has been tested and can be merged once approved.