### PR TITLE
Fix created status reference to its parent Part created status

### DIFF
--- a/src/Discord/Parts/Channel/Message.php
+++ b/src/Discord/Parts/Channel/Message.php
@@ -362,7 +362,7 @@ class Message extends Part
         $attachments = Collection::for(Attachment::class);
 
         foreach ($this->attributes['attachments'] ?? [] as $attachment) {
-            $attachments->pushItem($this->factory->part(Attachment::class, (array) $attachment, true));
+            $attachments->pushItem($this->createOf(Attachment::class, $attachment));
         }
 
         return $attachments;
@@ -379,12 +379,15 @@ class Message extends Part
         foreach ($reactions ?? [] as $reaction) {
             $keepReactions[] = $reactionKey = $reaction->emoji->id ?? $reaction->emoji->name;
             $reaction = (array) $reaction;
-            /** @var Reaction */
+            /** @var ?Reaction */
             if ($reactionPart = $this->reactions->offsetGet($reactionKey)) {
                 $reactionPart->fill($reaction);
-                $reactionPart->created = $this->created;
+            } else {
+                /** @var Reaction */
+                $reactionPart = $this->reactions->create($reaction, $this->created);
             }
-            $this->reactions->pushItem($reactionPart ?: $this->reactions->create($reaction, $this->created));
+            $reactionPart->created = &$this->created;
+            $this->reactions->pushItem($reactionPart);
         }
 
         $oldReactions = [];
@@ -451,7 +454,8 @@ class Message extends Part
                 if ($thread = $channel->threads->get('id', $this->channel_id)) {
                     return $thread;
                 }
-                $thread = $channel->threads->create((array) $this->attributes['thread'], true);
+                $thread = $channel->threads->create((array) $this->attributes['thread'], $channel->created);
+                $thread->created = &$channel->created;
                 $channel->threads->pushItem($thread);
             }
         }
@@ -581,7 +585,7 @@ class Message extends Part
         $embeds = new Collection([], null);
 
         foreach ($this->attributes['embeds'] ?? [] as $embed) {
-            $embeds->pushItem($this->factory->part(Embed::class, (array) $embed, true));
+            $embeds->pushItem($this->createOf(Embed::class, $embed));
         }
 
         return $embeds;
@@ -598,7 +602,7 @@ class Message extends Part
             return null;
         }
 
-        return $this->factory->part(MessageInteraction::class, (array) $this->attributes['interaction'] + ['guild_id' => $this->guild_id], true);
+        return $this->createOf(MessageInteraction::class, (array) $this->attributes['interaction'] + ['guild_id' => $this->guild_id]);
     }
 
     /**
@@ -685,7 +689,7 @@ class Message extends Part
         $components = Collection::for(Component::class, null);
 
         foreach ($this->attributes['components'] as $component) {
-            $components->pushItem($this->factory->part(Component::class, (array) $component, true));
+            $components->pushItem($this->createOf(Component::class, $component));
         }
 
         return $components;
@@ -797,12 +801,13 @@ class Message extends Part
             $this->attributes['thread'] ??= $response;
             if ($channel) {
                 /** @var ?Thread */
-                if (! $threadPart = $channel->threads->offsetGet($response->id)) {
-                    /** @var Thread */
-                    $threadPart = $channel->threads->create((array) $response, true);
-                } else {
+                if ($threadPart = $channel->threads->offsetGet($response->id)) {
                     $threadPart->fill((array) $response);
+                } else {
+                    /** @var Thread */
+                    $threadPart = $channel->threads->create((array) $response, $channel->created);
                 }
+                $threadPart->created = &$channel->created;
                 $channel->threads->pushItem($threadPart);
 
                 return $threadPart;

--- a/src/Discord/Parts/Channel/Overwrite.php
+++ b/src/Discord/Parts/Channel/Overwrite.php
@@ -54,7 +54,7 @@ class Overwrite extends Part
     protected function setAllowAttribute($allow): void
     {
         if (! ($allow instanceof ChannelPermission)) {
-            $allow = $this->factory->part(ChannelPermission::class, ['bitwise' => $allow], true);
+            $allow = $this->createOf(ChannelPermission::class, ['bitwise' => $allow]);
         }
 
         $this->attributes['allow'] = $allow;
@@ -68,7 +68,7 @@ class Overwrite extends Part
     protected function setDenyAttribute($deny): void
     {
         if (! ($deny instanceof ChannelPermission)) {
-            $deny = $this->factory->part(ChannelPermission::class, ['bitwise' => $deny], true);
+            $deny = $this->createOf(ChannelPermission::class, ['bitwise' => $deny]);
         }
 
         $this->attributes['deny'] = $deny;

--- a/src/Discord/Parts/Embed/Embed.php
+++ b/src/Discord/Parts/Embed/Embed.php
@@ -147,7 +147,7 @@ class Embed extends Part
 
         foreach ($this->attributes['fields'] as $field) {
             if (! ($field instanceof Field)) {
-                $field = $this->factory->part(Field::class, (array) $field, true);
+                $field = $this->createOf(Field::class, $field);
             }
 
             $fields->pushItem($field);

--- a/src/Discord/Parts/Guild/AuditLog/AuditLog.php
+++ b/src/Discord/Parts/Guild/AuditLog/AuditLog.php
@@ -97,7 +97,7 @@ class AuditLog extends Part
         $collection = Collection::for(Entry::class);
 
         foreach ($this->attributes['audit_log_entries'] ?? [] as $entry) {
-            $collection->pushItem($this->factory->part(Entry::class, (array) $entry, true));
+            $collection->pushItem($this->createOf(Entry::class, $entry));
         }
 
         return $collection;

--- a/src/Discord/Parts/Guild/AuditLog/Entry.php
+++ b/src/Discord/Parts/Guild/AuditLog/Entry.php
@@ -133,6 +133,6 @@ class Entry extends Part
      */
     protected function getOptionsAttribute(): Options
     {
-        return $this->factory->part(Options::class, (array) $this->attributes['options'] ?? [], true);
+        return $this->createOf(Options::class, $this->attributes['options'] ?? []);
     }
 }

--- a/src/Discord/Parts/Guild/AutoModeration/Rule.php
+++ b/src/Discord/Parts/Guild/AutoModeration/Rule.php
@@ -102,7 +102,7 @@ class Rule extends Part
         $actions = Collection::for(Action::class, null);
 
         foreach ($this->attributes['actions'] as $action) {
-            $actions->pushItem($this->factory->part(Action::class, (array) $action, true));
+            $actions->pushItem($this->createOf(Action::class, $action));
         }
 
         return $actions;

--- a/src/Discord/Parts/Guild/GuildTemplate.php
+++ b/src/Discord/Parts/Guild/GuildTemplate.php
@@ -79,7 +79,7 @@ class GuildTemplate extends Part
             return $guild;
         }
 
-        return $this->factory->part(Guild::class, (array) $this->attributes['serialized_source_guild'], true);
+        return $this->createOf(Guild::class, $this->attributes['serialized_source_guild']);
     }
 
     /**

--- a/src/Discord/Parts/Guild/Role.php
+++ b/src/Discord/Parts/Guild/Role.php
@@ -68,7 +68,7 @@ class Role extends Part
     protected function setPermissionsAttribute($permission): void
     {
         if (! ($permission instanceof RolePermission)) {
-            $permission = $this->factory->part(RolePermission::class, ['bitwise' => $permission], true);
+            $permission = $this->createOf(RolePermission::class, ['bitwise' => $permission]);
         }
 
         $this->attributes['permissions'] = $permission;

--- a/src/Discord/Parts/Guild/WelcomeScreen.php
+++ b/src/Discord/Parts/Guild/WelcomeScreen.php
@@ -44,7 +44,7 @@ class WelcomeScreen extends Part
         $collection = Collection::for(WelcomeChannel::class, null);
 
         foreach ($this->attributes['welcome_channels'] ?? [] as $welcome_channel) {
-            $collection->pushItem($this->factory->part(WelcomeChannel::class, (array) $welcome_channel, true));
+            $collection->pushItem($this->createOf(WelcomeChannel::class, $welcome_channel));
         }
 
         return $collection;

--- a/src/Discord/Parts/Guild/Widget.php
+++ b/src/Discord/Parts/Guild/Widget.php
@@ -91,6 +91,7 @@ class Widget extends Part
         return $this->http->get(Endpoint::bind(Endpoint::GUILD_WIDGET, $this->id))
             ->then(function ($response) {
                 $this->fill((array) $response);
+                $this->created = true;
 
                 return $this;
             });

--- a/src/Discord/Parts/Interactions/Command/Command.php
+++ b/src/Discord/Parts/Interactions/Command/Command.php
@@ -89,7 +89,7 @@ class Command extends Part
         $options = Collection::for(Option::class, null);
 
         foreach ($this->attributes['options'] ?? [] as $option) {
-            $options->pushItem($this->factory->part(Option::class, (array) $option, true));
+            $options->pushItem($this->createOf(Option::class, $option));
         }
 
         return $options;

--- a/src/Discord/Parts/Interactions/Command/Option.php
+++ b/src/Discord/Parts/Interactions/Command/Option.php
@@ -86,7 +86,7 @@ class Option extends Part
         $choices = Collection::for(Choice::class, null);
 
         foreach ($this->attributes['choices'] ?? [] as $choice) {
-            $choices->pushItem($this->factory->part(Choice::class, (array) $choice, true));
+            $choices->pushItem($this->createOf(Choice::class, $choice));
         }
 
         return $choices;
@@ -102,7 +102,7 @@ class Option extends Part
         $options = Collection::for(Option::class, null);
 
         foreach ($this->attributes['options'] ?? [] as $option) {
-            $options->pushItem($this->factory->part(Option::class, (array) $option, true));
+            $options->pushItem($this->createOf(Option::class, $option));
         }
 
         return $options;

--- a/src/Discord/Parts/Interactions/Interaction.php
+++ b/src/Discord/Parts/Interactions/Interaction.php
@@ -108,12 +108,12 @@ class Interaction extends Part
             return null;
         }
 
-        $adata = (array) $this->attributes['data'];
-        if (! isset($adata['guild_id']) && isset($this->attributes['guild_id'])) {
-            $adata['guild_id'] = $this->guild_id;
+        $adata = $this->attributes['data'];
+        if (! isset($adata->guild_id) && isset($this->attributes['guild_id'])) {
+            $adata->guild_id = $this->guild_id;
         }
 
-        return $this->factory->part(InteractionData::class, $adata, true);
+        return $this->createOf(InteractionData::class, $adata);
     }
 
     /**

--- a/src/Discord/Parts/Interactions/Request/Component.php
+++ b/src/Discord/Parts/Interactions/Request/Component.php
@@ -80,7 +80,7 @@ class Component extends Part
         $components = Collection::for(Component::class, null);
 
         foreach ($this->attributes['components'] ?? [] as $component) {
-            $components->pushItem($this->factory->part(Component::class, (array) $component, true));
+            $components->pushItem($this->createOf(Component::class, $component));
         }
 
         return $components;

--- a/src/Discord/Parts/Interactions/Request/InteractionData.php
+++ b/src/Discord/Parts/Interactions/Request/InteractionData.php
@@ -69,7 +69,7 @@ class InteractionData extends Part
         $options = Collection::for(Option::class, 'name');
 
         foreach ($this->attributes['options'] ?? [] as $option) {
-            $options->pushItem($this->factory->part(Option::class, (array) $option, true));
+            $options->pushItem($this->createOf(Option::class, $option));
         }
 
         return $options;
@@ -89,7 +89,7 @@ class InteractionData extends Part
         $components = Collection::for(Component::class, null);
 
         foreach ($this->attributes['components'] as $component) {
-            $components->pushItem($this->factory->part(Component::class, (array) $component, true));
+            $components->pushItem($this->createOf(Component::class, $component));
         }
 
         return $components;
@@ -111,6 +111,6 @@ class InteractionData extends Part
             $adata->guild_id = $this->guild_id;
         }
 
-        return $this->factory->part(Resolved::class, (array) $adata, true);
+        return $this->createOf(Resolved::class, $adata);
     }
 }

--- a/src/Discord/Parts/Interactions/Request/Option.php
+++ b/src/Discord/Parts/Interactions/Request/Option.php
@@ -55,7 +55,7 @@ class Option extends Part
         $options = Collection::for(Option::class, 'name');
 
         foreach ($this->attributes['options'] ?? [] as $option) {
-            $options->pushItem($this->factory->part(Option::class, (array) $option, true));
+            $options->pushItem($this->createOf(Option::class, $option));
         }
 
         return $options;

--- a/src/Discord/Parts/Part.php
+++ b/src/Discord/Parts/Part.php
@@ -442,6 +442,28 @@ abstract class Part implements ArrayAccess, JsonSerializable
     }
 
     /**
+     * Create a Part where the `created` status is referenced by this Part.
+     *
+     * @internal
+     *
+     * @see \Discord\Factory\Factory::part()
+     *
+     * @since 10.0.0
+     *
+     * @param string       $class The attribute Part class to build.
+     * @param array|object $data  Data to create the object.
+     *
+     * @return Part
+     */
+    public function createOf(string $class, array|object $data): Part
+    {
+        $ofPart = $this->factory->part($class, (array) $data, $this->created);
+        $ofPart->created = &$this->created;
+
+        return $ofPart;
+    }
+
+    /**
      * Converts a string to studlyCase.
      *
      * This is a port of updated Laravel's implementation, a non-regex with

--- a/src/Discord/Parts/User/Member.php
+++ b/src/Discord/Parts/User/Member.php
@@ -413,7 +413,7 @@ class Member extends Part
 
         // Create from computed base permissions
         /** @var RolePermission */
-        $newPermission = $this->factory->part(RolePermission::class, ['bitwise' => $bitwise]);
+        $newPermission = $guild->createOf(RolePermission::class, ['bitwise' => $bitwise]);
 
         // If computed roles has Administrator permission
         if ($newPermission->administrator) {
@@ -472,7 +472,7 @@ class Member extends Part
         }
 
         // Re-create the Role Permissions from the computed overwrites
-        return $this->factory->part(RolePermission::class, ['bitwise' => $bitwise]);
+        return $guild->createOf(RolePermission::class, ['bitwise' => $bitwise]);
     }
 
     /**
@@ -581,7 +581,7 @@ class Member extends Part
         $activities = Collection::for(Activity::class, null);
 
         foreach ($this->attributes['activities'] ?? [] as $activity) {
-            $activities->pushItem($this->factory->part(Activity::class, (array) $activity, true));
+            $activities->pushItem($this->createOf(Activity::class, $activity));
         }
 
         return $activities;

--- a/src/Discord/Parts/WebSockets/AutoModerationActionExecution.php
+++ b/src/Discord/Parts/WebSockets/AutoModerationActionExecution.php
@@ -81,7 +81,7 @@ class AutoModerationActionExecution extends Part
      */
     protected function getActionAttribute(): Action
     {
-        return $this->factory->part(Action::class, (array) $this->attributes['action'], true);
+        return $this->createOf(Action::class, $this->attributes['action']);
     }
 
     /**


### PR DESCRIPTION
When creating a new member Part from its Parent, it should follow the Parent Part created status instead of always true.