### PR TITLE
replace Role::permissions setter with getter to save up memory

### DIFF
--- a/src/Discord/Parts/Guild/Role.php
+++ b/src/Discord/Parts/Guild/Role.php
@@ -61,17 +61,15 @@ class Role extends Part
     ];
 
     /**
-     * Sets the permissions attribute.
+     * Gets the permissions attribute.
      *
-     * @param RolePermission|int $permission The permissions to set.
+     * @return RolePermission The role permission.
+     *
+     * @since 10.0.0 Replaced setPermissionsAttribute() to save up memory.
      */
-    protected function setPermissionsAttribute($permission): void
+    protected function getPermissionsAttribute(): Part
     {
-        if (! ($permission instanceof RolePermission)) {
-            $permission = $this->createOf(RolePermission::class, ['bitwise' => $permission]);
-        }
-
-        $this->attributes['permissions'] = $permission;
+        return $this->createOf(RolePermission::class, ['bitwise' => $this->attributes['permissions']]);
     }
 
     /**
@@ -138,10 +136,10 @@ class Role extends Part
     {
         return $this->makeOptionalAttributes([
             'name' => $this->name,
-            'permissions' => (string) $this->permissions,
+            'permissions' => (string) $this->getPermissionsAttribute(),
             'color' => $this->color,
             'hoist' => $this->hoist,
-            'icon' => $this->icon_hash,
+            'icon' => $this->getIconHashAttribute(),
             'unicode_emoji' => $this->unicode_emoji,
             'mentionable' => $this->mentionable,
         ]);
@@ -156,10 +154,10 @@ class Role extends Part
     {
         return $this->makeOptionalAttributes([
             'name' => $this->name,
-            'permissions' => (string) $this->permissions,
+            'permissions' => (string) $this->getPermissionsAttribute(),
             'color' => $this->color,
             'hoist' => $this->hoist,
-            'icon' => $this->icon_hash,
+            'icon' => $this->getIconHashAttribute(),
             'unicode_emoji' => $this->unicode_emoji,
             'mentionable' => $this->mentionable,
         ]);
@@ -183,16 +181,5 @@ class Role extends Part
     public function __toString(): string
     {
         return "<@&{$this->id}>";
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function getRawAttributes(): array
-    {
-        $attributes = $this->attributes;
-        $attributes['permissions'] = (string) $attributes['permissions'];
-
-        return $attributes;
     }
 }


### PR DESCRIPTION
To optimize Role object, its permission values wont be created unless manually get. I have tested this to lower the memory usage from 20 MB to 18 MB and faster init time in my Bot. 

Also a new practice that should be done: When there is a fillable that is handled with custom attribute mutator, the method should be called instead of the magic property, right now this should only apply to the same class
e.g. `$this->icon_hash` is override by `$this->getIconHashAttribute()` so the `Role` class should always use `$this->getIconHashAttribute()` instead of the `$this->icon_hash`. Does not apply to object instances e.g. `$role->icon_hash` should stay.

Not fully tested.