### PR TITLE
move voice heartbeat ack emiter

### DIFF
--- a/src/Discord/Voice/VoiceClient.php
+++ b/src/Discord/Voice/VoiceClient.php
@@ -523,6 +523,7 @@ class VoiceClient extends EventEmitter
 
                     $this->logger->debug('received heartbeat ack', ['response_time' => $diff]);
                     $this->emit('ws-ping', [$diff]);
+                    $this->emit('ws-heartbeat-ack', [$data->d]);
                     break;
                 case Op::VOICE_DESCRIPTION: // ready
                     $this->ready = true;
@@ -547,9 +548,6 @@ class VoiceClient extends EventEmitter
                     $this->emit('speaking', [$data->d->speaking, $data->d->user_id, $this]);
                     $this->emit("speaking.{$data->d->user_id}", [$data->d->speaking, $this]);
                     $this->speakingStatus[$data->d->ssrc] = $data->d;
-                    break;
-                case Op::VOICE_HEARTBEAT_ACK:
-                    $this->emit('ws-heartbeat-ack', [$data]);
                     break;
                 case Op::VOICE_HELLO:
                     $this->heartbeat_interval = $data->d->heartbeat_interval;


### PR DESCRIPTION
Reported by Discord User dseguy that noticed there is duplicated switch value.

At first i thought the first one is supposed to be `Op::VOICE_HEARTBEAT` and checked the history it was replaced https://github.com/discord-php/DiscordPHP/commit/f18fe92033ddbfac4df178c6afe2aaeb340b3404#diff-7a2f3798bc3eb078cbf2d218a055dafd03180366955c157e610bc585940e634a 
I double checked the doc to see what `Op::VOICE_HEARTBEAT` does https://discord.com/developers/docs/topics/voice-connections#heartbeating, it is something that the voice client needs to send, not something that will be received, so the code is already correct, and so I'm just moving the event emitter so it gets triggered.

Tested.