### PR TITLE
Add legacy cache wrapper

### DIFF
--- a/src/Discord/Discord.php
+++ b/src/Discord/Discord.php
@@ -369,7 +369,9 @@ class Discord
         $this->logger->debug('Initializing DiscordPHP '.self::VERSION.' (DiscordPHP-Http: '.Http::VERSION.' & Gateway: v'.self::GATEWAY_VERSION.') on PHP '.PHP_VERSION);
 
         $this->cacheConfig = $options['cache'];
-        $this->logger->warning('Attached experimental CacheInterface: '.get_class($this->getCacheConfig()->interface));
+        if ($cacheConfig = $this->getCacheConfig()) {
+            $this->logger->warning('Attached experimental CacheInterface: '.get_class($cacheConfig->interface));
+        }
 
         $connector = new SocketConnector($options['socket_options'], $this->loop);
         $this->wsFactory = new Connector($this->loop, $connector);
@@ -1579,11 +1581,11 @@ class Discord
      *
      * @param string $name Repository class name.
      *
-     * @return CacheConfig
+     * @return ?CacheConfig
      */
     public function getCacheConfig($repository_class = AbstractRepository::class)
     {
-        if (! isset($this->cacheConfig[$repository_class])) {
+        if (! array_key_exists($repository_class, $this->cacheConfig)) {
             $repository_class = AbstractRepository::class;
         }
 

--- a/src/Discord/Helpers/CacheWrapper.php
+++ b/src/Discord/Helpers/CacheWrapper.php
@@ -29,8 +29,7 @@ use function React\Promise\resolve;
  *
  * @since 10.0.0
  *
- * @property-read \React\Cache\CacheInterface|\Psr\SimpleCache\CacheInterface $interface The actual ReactPHP PSR-16 CacheInterface.
- * @property-read CacheConfig                                                 $config    Cache configuration.
+ * @property-read CacheConfig $config Cache configuration.
  */
 class CacheWrapper
 {
@@ -506,8 +505,8 @@ class CacheWrapper
 
     public function __get(string $name)
     {
-        if (in_array($name, ['interface', 'config'])) {
-            return $this->$name;
+        if ($name === 'config') {
+            return $this->config;
         }
     }
 }

--- a/src/Discord/Helpers/LegacyCacheWrapper.php
+++ b/src/Discord/Helpers/LegacyCacheWrapper.php
@@ -1,0 +1,207 @@
+<?php
+
+/*
+ * This file is a part of the DiscordPHP project.
+ *
+ * Copyright (c) 2015-present David Cole <david.cole1340@gmail.com>
+ *
+ * This file is subject to the MIT license that is bundled
+ * with this source code in the LICENSE.md file.
+ */
+
+namespace Discord\Helpers;
+
+use Discord\Discord;
+use Discord\Parts\Part;
+use React\Promise\PromiseInterface;
+
+use function React\Promise\resolve;
+
+/**
+ * Legacy v7.x in memory cache behavior
+ *
+ * @since 10.0.0
+ * @internal
+ */
+final class LegacyCacheWrapper extends CacheWrapper
+{
+    /**
+     * Repository items array reference.
+     *
+     * @var ?Part[] Cache Key => Cache Part.
+     */
+    protected $items;
+
+    /**
+     * @param Discord $discord
+     * @param array   &$items  Repository items passed by reference.
+     * @param string  &$class  Part class name.
+     *
+     * @internal
+     */
+    public function __construct(Discord $discord, &$items, string &$class)
+    {
+        $this->discord = $discord;
+        $this->items = &$items;
+        $this->class = &$class;
+
+        $this->prefix = '';
+    }
+
+    public function __destruct()
+    {
+    }
+
+    /**
+     * Get Part from cache.
+     *
+     * @param string $key
+     * @param mixed  $default
+     *
+     * @return PromiseInterface<mixed>
+     */
+    public function get($key, $default = null)
+    {
+        return resolve($this->items[$key] ?? $default);
+    }
+
+    /**
+     * Set Part into cache.
+     *
+     * @param string $key
+     * @param Part   $value
+     *
+     * @return PromiseInterface<bool>
+     */
+    public function set($key, $value, $ttl = null)
+    {
+        $this->items[$key] = $value;
+
+        return resolve(true);
+    }
+
+    /**
+     * Delete Part from cache.
+     *
+     * @param string $key
+     *
+     * @return PromiseInterface<bool>
+     */
+    public function delete($key)
+    {
+        if (!array_key_exists($key, $this->items)) {
+            return resolve(false);
+        }
+
+        unset($this->items[$key]);
+
+        return resolve(true);
+    }
+
+    /**
+     * Get multiple Parts from cache.
+     *
+     * @param array $keys
+     * @param ?Part $default
+     *
+     * @return PromiseInterface<array>
+     */
+    public function getMultiple(array $keys, $default = null)
+    {
+        $items = [];
+        foreach ($keys as $key) {
+            $items[$key] = $this->items[$key] ?? $default;
+        }
+
+        return resolve($items);
+    }
+
+    /**
+     * Set multiple Parts into cache.
+     *
+     * @param Part[] $values
+     *
+     * @return PromiseInterface<bool>
+     */
+    public function setMultiple(array $values, $ttl = null)
+    {
+        foreach ($values as $key => $value) {
+            $this->items[$key] = $value;
+        }
+
+        return resolve(true);
+    }
+
+    /**
+     * Delete multiple Parts from cache.
+     *
+     * @param array $keys
+     *
+     * @return PromiseInterface<bool>
+     */
+    public function deleteMultiple(array $keys)
+    {
+        foreach ($keys as $key) {
+            unset($this->items[$key]);
+        }
+
+        return resolve(true);
+    }
+
+    /**
+     * Clear all Parts from cache.
+     *
+     * @return PromiseInterface<bool>
+     */
+    public function clear()
+    {
+        $this->items = [];
+
+        return resolve(true);
+    }
+
+    /**
+     * Check if Part is present in cache.
+     *
+     * @param string $key
+     *
+     * @return PromiseInterface<bool>
+     */
+    public function has($key)
+    {
+        return resolve(array_key_exists($key, $this->items));
+    }
+
+    /**
+     * @param Part $part
+     *
+     * @return object
+     */
+    public function serializer($part)
+    {
+        return (object) (get_object_vars($part) + ['attributes' => $part->getRawAttributes()]);
+    }
+
+    /**
+     * @param object $value
+     *
+     * @return ?Part
+     */
+    public function unserializer($value)
+    {
+        if (empty($value->attributes)) {
+            $this->discord->getLogger()->warning('Cached Part::$attributes is empty', ['class' => $this->class, 'interface' => 'LEGACY', 'data' => $value]);
+        }
+        if (empty($value->created)) {
+            $this->discord->getLogger()->warning('Cached Part::$created is empty', ['class' => $this->class, 'interface' => 'LEGACY', 'data' => $value]);
+        }
+        $part = $this->discord->getFactory()->part($this->class, $value->attributes, $value->created);
+        foreach ($value as $name => $var) {
+            if (!in_array($name, ['created', 'attributes'])) {
+                $part->{$name} = $var;
+            }
+        }
+
+        return $part;
+    }
+}


### PR DESCRIPTION
Another attempts to solve huge memory in v10 cache. This brings back the Collection (in-memory) caching behavior that used to exists in v7 and prior. While not 100% the same, this reduce one layer of abstraction to the cache interface.

To use on all repository, the option needs to be set `null` like this:
```php
'cache' => [
    AbstractRepository::class => null,
]
```
Or you can selectively choose the repository class, but I don't recommend mixing both ReactPHP's cache interface (including ArrayCache) with this way, unexpected behavior may happen.

I don't have big enough data to compare, but it is 18.8 MB vs 20.9 MB

BC:
CacheWrapper no longer exposes interface object to public, use the CacheConfig to get the interface
Discord::getCacheConfig() may returns null now

Tested