### PR TITLE
`Undefined array key "emoji"` occurs in Event::MESSAGE_REACTION_REMOVE_ALL

### DIFF
--- a/src/Discord/Parts/WebSockets/MessageReaction.php
+++ b/src/Discord/Parts/WebSockets/MessageReaction.php
@@ -220,7 +220,7 @@ class MessageReaction extends Part
      */
     protected function getEmojiAttribute(): Emoji
     {
-        return $this->factory->part(Emoji::class, (array) $this->attributes['emoji'], true);
+        return $this->factory->part(Emoji::class, (array) ($this->attributes['emoji'] ?? []), true);
     }
 
     /**
@@ -261,7 +261,7 @@ class MessageReaction extends Part
                 break;
             case Message::REACT_DELETE_ID:
             default:
-                if (! $userid = $this->user_id ?? $this->user->id) {
+                if (!$userid = $this->user_id ?? $this->user->id) {
                     return reject(new \RuntimeException('This reaction has no user id'));
                 }
                 $url = Endpoint::bind(Endpoint::USER_MESSAGE_REACTION, $this->channel_id, $this->message_id, $emoji, $userid);


### PR DESCRIPTION
When the Event::MESSAGE_REACTION_REMOVE_ALL event occurs, 
an exception occurs.
 
because `emoji` does not send it.