### PR TITLE
Fix non ephemeral acknowledge

### DIFF
--- a/src/Discord/Parts/Interactions/Interaction.php
+++ b/src/Discord/Parts/Interactions/Interaction.php
@@ -266,10 +266,13 @@ class Interaction extends Part
             return reject(new \LogicException('You can only acknowledge application command, message component, or modal submit interactions.'));
         }
 
-        return $this->respond([
-            'type' => InteractionResponseType::DEFERRED_CHANNEL_MESSAGE_WITH_SOURCE,
-            'data' => $ephemeral ? ['flags' => 64] : [],
-        ]);
+        $payload['type'] = InteractionResponseType::DEFERRED_CHANNEL_MESSAGE_WITH_SOURCE;
+
+        if ($ephemeral) {
+            $payload['data'] = ['flags' => 64];
+        }
+
+        return $this->respond($payload);
     }
 
     /**

--- a/src/Discord/Parts/Interactions/Interaction.php
+++ b/src/Discord/Parts/Interactions/Interaction.php
@@ -266,13 +266,10 @@ class Interaction extends Part
             return reject(new \LogicException('You can only acknowledge application command, message component, or modal submit interactions.'));
         }
 
-        $payload['type'] = InteractionResponseType::DEFERRED_CHANNEL_MESSAGE_WITH_SOURCE;
-
-        if ($ephemeral) {
-            $payload['data'] = ['flags' => 64];
-        }
-
-        return $this->respond($payload);
+        return $this->respond([
+            'type' => InteractionResponseType::DEFERRED_CHANNEL_MESSAGE_WITH_SOURCE,
+            'data' => $ephemeral ? ['flags' => 64] : null,
+        ]);
     }
 
     /**


### PR DESCRIPTION
Discord is no longer good with empty arrays...

This prevent errors for non ephemeral acknowledge:
![image](https://github.com/discord-php/DiscordPHP/assets/36747646/cbd030e4-f874-443a-905b-a2abb9c255bd)


