### PR TITLE
Permissions Change for Pruning

### DIFF
--- a/src/Discord/Parts/Guild/Guild.php
+++ b/src/Discord/Parts/Guild/Guild.php
@@ -1225,7 +1225,7 @@ class Guild extends Part
         $options = $resolver->resolve($options);
 
         $botperms = $this->getBotPermissions();
-        if ($botperms && (! $botperms->kick_members || ! $botperms->manage_guild)) {
+        if ($botperms && ! ($botperms->kick_members && $botperms->manage_guild)) {
             return reject(new NoPermissionsException("You do not have permission to get prune count in the guild {$this->id}."));
         }
 

--- a/src/Discord/Parts/Guild/Guild.php
+++ b/src/Discord/Parts/Guild/Guild.php
@@ -1225,7 +1225,7 @@ class Guild extends Part
         $options = $resolver->resolve($options);
 
         $botperms = $this->getBotPermissions();
-        if ($botperms && ! $botperms->kick_members) {
+        if ($botperms && (! $botperms->kick_members || ! $botperms->manage_guild)) {
             return reject(new NoPermissionsException("You do not have permission to get prune count in the guild {$this->id}."));
         }
 
@@ -1283,7 +1283,7 @@ class Guild extends Part
         $options = $resolver->resolve($options);
 
         $botperms = $this->getBotPermissions();
-        if ($botperms && ! $botperms->kick_members) {
+        if ($botperms && (! $botperms->kick_members || ! $botperms->manage_guild)) {
             return reject(new NoPermissionsException("You do not have permission to prune members in the guild {$this->id}."));
         }
 

--- a/src/Discord/Parts/Guild/Guild.php
+++ b/src/Discord/Parts/Guild/Guild.php
@@ -1283,7 +1283,7 @@ class Guild extends Part
         $options = $resolver->resolve($options);
 
         $botperms = $this->getBotPermissions();
-        if ($botperms && (! $botperms->kick_members || ! $botperms->manage_guild)) {
+        if ($botperms && ! ($botperms->kick_members && $botperms->manage_guild)) {
             return reject(new NoPermissionsException("You do not have permission to prune members in the guild {$this->id}."));
         }
 


### PR DESCRIPTION
Starting on March 15, 2024, the Get Guild Prune Count and Begin Guild Prune endpoints will require the MANAGE_GUILD permission alongside the existing KICK_MEMBERS permission.