### PR TITLE
Log Promise rejections in command client

### DIFF
--- a/src/Discord/DiscordCommandClient.php
+++ b/src/Discord/DiscordCommandClient.php
@@ -14,6 +14,7 @@ namespace Discord;
 use Discord\CommandClient\Command;
 use Discord\Parts\Embed\Embed;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use React\Promise\PromiseInterface;
 
 /**
  * Provides an easy way to have triggerable message based commands.
@@ -96,7 +97,13 @@ class DiscordCommandClient extends Discord
                     $result = $command->handle($message, $args);
 
                     if (is_string($result)) {
-                        $message->reply($result);
+                        $result = $message->reply($result);
+                    }
+
+                    if ($result instanceof PromiseInterface) {
+                        $result->then(null, function (\Throwable $e) {
+                            $this->logger->warning($e->getTraceAsString());
+                        });
                     }
                 }
             });


### PR DESCRIPTION
This very banal change allows discord command clients to report `Promise` rejections with log level "warning" rather than just failing silently. I think it's much better than nothing because unhandled `Promise`s couldn't fall back anywhere so these logging has to be compared to "oops, too bad" silent failure.

Probably something similar should be done (or at least preferred) for other DiscordPHP utilities that feed into the event loop; most notably the Discord class itself. But again, I think it's better than nothing.