### PR TITLE
Allow Symfony 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,10 +16,10 @@
     },
     "require": {
         "php": "^8.0",
-        "nesbot/carbon": "^2.38",
+        "nesbot/carbon": "^3.0",
         "ratchet/pawl": "^0.4.1",
         "react/datagram": "^1.8",
-        "symfony/options-resolver": "^5.1.11 || ^6.0",
+        "symfony/options-resolver": "^5.1.11 || ^6.0 || ^7.0",
         "trafficcophp/bytebuffer": "^0.3",
         "monolog/monolog": "^2.1.1 || ^3.0",
         "react/event-loop": "^1.2",


### PR DESCRIPTION
Hello :wave: 
I'm trying to use v10 on a Symfony 7 application and it can't work because DiscordPHP does not allow Symfony 7.

I checked: https://github.com/symfony/options-resolver/blob/7.0/CHANGELOG.md there were no modifications since 6.4 so we can safely update this component and make DiscordPHP compatible with Symfony 7.

Also, for `nestbot/carbon`, as seen https://carbon.nesbot.com/docs/#api-carbon-3, I don't see anything that would make it a blocker.

It's my first time contributing here, please feel free to tell me if I've done anything wrong :pray: 