### PR TITLE
Adds toCommand helper function to CommandBuilder

### DIFF
--- a/src/Discord/Builders/CommandBuilder.php
+++ b/src/Discord/Builders/CommandBuilder.php
@@ -11,6 +11,7 @@
 
 namespace Discord\Builders;
 
+use Discord\Discord;
 use Discord\Parts\Interactions\Command\Command;
 use Discord\Parts\Interactions\Command\Option;
 use JsonSerializable;
@@ -72,6 +73,17 @@ class CommandBuilder implements JsonSerializable
     public function getOptions(): ?array
     {
         return $this->options ?? null;
+    }
+
+    /**
+     * Converts the CommandBuilder object to a Command object.
+     *
+     * @param Discord
+     * @return Command
+     */
+    public function toCommand(Discord $discord): Command
+    {
+        return new Command($discord, $this->toArray(), false);
     }
 
     /**


### PR DESCRIPTION
We've previously recommended the previous flow for creating new commands using the command builder
```php
$discord->application->commands->save(
    $discord->application->commands->create($commandbuilder);
);
```
With this tweak, we can cut out an extra call to commands->create
```php
$discord->application->commands->save($commandbuilder->toCommand($discord));
```