### PR TITLE
Enhancement to addRole and removeRole methods for Member class

### DIFF
--- a/src/Discord/Parts/User/Member.php
+++ b/src/Discord/Parts/User/Member.php
@@ -288,11 +288,11 @@ class Member extends Part implements Stringable
                     return $this;
                 })
             : $this->http->put(Endpoint::bind(Endpoint::GUILD_MEMBER_ROLE, $this->guild_id, $this->id, $role), null, $headers)
-            ->then(function () use ($role) {
-                if (! in_array($role, $this->attributes['roles'])) {
-                    $this->attributes['roles'][] = $role;
-                }
-            });
+                ->then(function () use ($role) {
+                    if (! in_array($role, $this->attributes['roles'])) {
+                        $this->attributes['roles'][] = $role;
+                    }
+                });
     }
 
     /**

--- a/src/Discord/Parts/User/Member.php
+++ b/src/Discord/Parts/User/Member.php
@@ -281,7 +281,7 @@ class Member extends Part implements Stringable
         }
 
         return $patch
-            ? $this->http->patch(Endpoint::bind(Endpoint::GUILD_MEMBER, $this->guild_id, $this->id), ['roles' => array_merge($this->attributes['roles'], [$role])], $headers)
+            ? $this->http->patch(Endpoint::bind(Endpoint::GUILD_MEMBER, $this->guild_id, $this->id), ['roles' => array_unique(array_merge($this->attributes['roles'], [$role]))], $headers)
                 ->then(function ($response) {
                     $this->attributes['roles'] = $response->roles;
 

--- a/src/Discord/Parts/User/Member.php
+++ b/src/Discord/Parts/User/Member.php
@@ -249,14 +249,14 @@ class Member extends Part implements Stringable
      *
      * @param Role|string $role   The role to add to the member.
      * @param string|null $reason Reason for Audit Log.
-     * @param bool|null   $set    Whether to set the roles using PATCH instead of PUT and return the updated member part on resolved promise.
+     * @param bool|null   $patch    Whether to set the roles using PATCH instead of PUT and return the updated member part on resolved promise.
      *
      * @throws \RuntimeException
      * @throws NoPermissionsException Missing manage_roles permission.
      *
      * @return ExtendedPromiseInterface|ExtendedPromiseInterface<static>
      */
-    public function addRole($role, ?string $reason = null, ?bool $set = false): ExtendedPromiseInterface
+    public function addRole($role, ?string $reason = null, ?bool $patch = false): ExtendedPromiseInterface
     {
         if ($role instanceof Role) {
             $role = $role->id;
@@ -280,7 +280,7 @@ class Member extends Part implements Stringable
             $headers['X-Audit-Log-Reason'] = $reason;
         }
 
-        return $set
+        return $patch
             ? $this->http->patch(Endpoint::bind(Endpoint::GUILD_MEMBER, $this->guild_id, $this->id), ['roles' => array_merge($this->attributes['roles'], [$role])], $headers)
                 ->then(function ($response) {
                     $this->attributes['roles'] = $response->roles;
@@ -302,13 +302,13 @@ class Member extends Part implements Stringable
      *
      * @param Role|string $role   The role to remove from the member.
      * @param string|null $reason Reason for Audit Log.
-     * @param bool|null   $set    Whether to set the roles using PATCH instead of DELETE and return the updated member part on resolved promise.
+     * @param bool|null   $patch    Whether to set the roles using PATCH instead of DELETE and return the updated member part on resolved promise.
      *
      * @throws NoPermissionsException Missing manage_roles permission.
      *
      * @return ExtendedPromiseInterface|ExtendedPromiseInterface<static>
      */
-    public function removeRole($role, ?string $reason = null, ?bool $set = false): ExtendedPromiseInterface
+    public function removeRole($role, ?string $reason = null, ?bool $patch = false): ExtendedPromiseInterface
     {
         if ($role instanceof Role) {
             $role = $role->id;
@@ -327,7 +327,7 @@ class Member extends Part implements Stringable
             $headers['X-Audit-Log-Reason'] = $reason;
         }
 
-        return $set
+        return $patch
             ? $this->http->patch(Endpoint::bind(Endpoint::GUILD_MEMBER, $this->guild_id, $this->id), ['roles' => array_diff($this->attributes['roles'], [$role])], $headers)
                 ->then(function ($response) {
                     $this->attributes['roles'] = $response->roles;

--- a/src/Discord/Parts/User/Member.php
+++ b/src/Discord/Parts/User/Member.php
@@ -256,7 +256,7 @@ class Member extends Part implements Stringable
      *
      * @return ExtendedPromiseInterface|ExtendedPromiseInterface<static>
      */
-    public function addRole($role, ?string $reason = null, ?bool $patch = false): ExtendedPromiseInterface
+    public function addRole($role, ?string $reason = null, bool $patch = false): ExtendedPromiseInterface
     {
         if ($role instanceof Role) {
             $role = $role->id;
@@ -308,7 +308,7 @@ class Member extends Part implements Stringable
      *
      * @return ExtendedPromiseInterface|ExtendedPromiseInterface<static>
      */
-    public function removeRole($role, ?string $reason = null, ?bool $patch = false): ExtendedPromiseInterface
+    public function removeRole($role, ?string $reason = null, bool $patch = false): ExtendedPromiseInterface
     {
         if ($role instanceof Role) {
             $role = $role->id;

--- a/src/Discord/Parts/User/Member.php
+++ b/src/Discord/Parts/User/Member.php
@@ -249,7 +249,7 @@ class Member extends Part implements Stringable
      *
      * @param Role|string $role   The role to add to the member.
      * @param string|null $reason Reason for Audit Log.
-     * @param bool|null   $patch    Whether to set the roles using PATCH instead of PUT and return the updated member part on resolved promise.
+     * @param bool|null   $patch  Whether to set the roles using PATCH instead of PUT and return the updated member part on resolved promise.
      *
      * @throws \RuntimeException
      * @throws NoPermissionsException Missing manage_roles permission.
@@ -302,7 +302,7 @@ class Member extends Part implements Stringable
      *
      * @param Role|string $role   The role to remove from the member.
      * @param string|null $reason Reason for Audit Log.
-     * @param bool|null   $patch    Whether to set the roles using PATCH instead of DELETE and return the updated member part on resolved promise.
+     * @param bool|null   $patch  Whether to set the roles using PATCH instead of DELETE and return the updated member part on resolved promise.
      *
      * @throws NoPermissionsException Missing manage_roles permission.
      *


### PR DESCRIPTION
This improvement aims to optimize the Member class methods, specifically addRole and removeRole, making them more versatile and aligned with expected behavior, thereby enhancing the overall usability of the library. Currently, due to their use of PUT and DELETE endpoints, these methods do not return an updated member part. The proposed change introduces the ability to pass true as the third parameter, enabling the use of array_merge or array_diff operations and facilitating the return of an updated member part by calling the PATCH endpoint instead.

This enhancement grants additional functionality by allowing the methods to return a resolved member, thereby enhancing the library’s capabilities without compromising its existing structure. Doing so would also add better support for chaining of promises in this context.

It's important to note that chaining multiple addRole or removeRole promises together will always be slower and result in additional API calls where it would otherwise be better to make a single call to setRoles. This change is not intended to replace or undermine the intended usage of setRole, but reduce the amount of code required for a user of the library to effectively utilize these functions.