### PR TITLE
Fix Discord\Parts\Channel\Channel::sendMessage PHPDoc type hint

### DIFF
--- a/src/Discord/Parts/Channel/Channel.php
+++ b/src/Discord/Parts/Channel/Channel.php
@@ -98,7 +98,7 @@ use function React\Promise\resolve;
  * @property InviteRepository        $invites         Invites in the channel.
  * @property StageInstanceRepository $stage_instances Stage instances in the channel.
  *
- * @method ExtendedPromiseInterface<Message> sendMessage(MessageBuilder $builder)
+ * @method ExtendedPromiseInterface<Message> sendMessage(MessageBuilder|string $builder)
  */
 class Channel extends Part implements Stringable
 {


### PR DESCRIPTION
Otherwise PHPStan complains that "Parameter #1 $builder of method Discord\Parts\Channel\Channel::sendMessage() expects Discord\Builders\MessageBuilder, string given."