### PR TITLE
Fix voice error 4020

### DIFF
--- a/src/Discord/Voice/VoiceClient.php
+++ b/src/Discord/Voice/VoiceClient.php
@@ -553,7 +553,7 @@ class VoiceClient extends EventEmitter
                     $sendHeartbeat = function () {
                         $this->send([
                             'op' => Op::VOICE_HEARTBEAT,
-                            'd' => microtime(true),
+                            'd' => (int) microtime(true),
                         ]);
                         $this->logger->debug('sending heartbeat');
                         $this->emit('ws-heartbeat', []);


### PR DESCRIPTION
Add type hint to 'd', preventing the heartbeat from being sent as a string, which is now rejected by Discord's voice websocket.