### PR TITLE
Implement modularity Collection class with 

### DIFF
--- a/src/Discord/Builders/CommandAttributes.php
+++ b/src/Discord/Builders/CommandAttributes.php
@@ -29,7 +29,7 @@ use function Discord\poly_strlen;
  * @property ?string[]|null                            $name_localizations         Localization dictionary for the name field. Values follow the same restrictions as name.
  * @property ?string                                   $description                1-100 character description for CHAT_INPUT commands, empty string for USER and MESSAGE commands.
  * @property ?string[]|null                            $description_localizations  Localization dictionary for the description field. Values follow the same restrictions as description.
- * @property \Discord\Helpers\Collection|Option[]|null $options                    The parameters for the command, max 25. Only for Slash command (CHAT_INPUT).
+ * @property \Discord\Helpers\CollectionInterface|Option[]|null $options                    The parameters for the command, max 25. Only for Slash command (CHAT_INPUT).
  * @property ?string                                   $default_member_permissions Set of permissions represented as a bit set.
  * @property bool|null                                 $dm_permission              Indicates whether the command is available in DMs with the app, only for globally-scoped commands. By default, commands are visible.
  * @property ?bool                                     $default_permission         Whether the command is enabled by default when the app is added to a guild. SOON DEPRECATED.

--- a/src/Discord/Builders/Components/SelectMenu.php
+++ b/src/Discord/Builders/Components/SelectMenu.php
@@ -12,7 +12,7 @@
 namespace Discord\Builders\Components;
 
 use Discord\Discord;
-use Discord\Helpers\Collection;
+use Discord\Helpers\CollectionInterface;
 use Discord\Parts\Interactions\Interaction;
 use Discord\WebSockets\Event;
 use React\Promise\PromiseInterface;
@@ -350,7 +350,7 @@ abstract class SelectMenu extends Component
                 if (empty($this->options)) {
                     $response = $callback($interaction);
                 } else {
-                    $options = Collection::for(Option::class, null);
+                    $options = ($this->discord->getCollectionClass())::for(Option::class, null);
 
                     foreach ($this->options as $option) {
                         if (in_array($option->getValue(), $interaction->data->values)) {

--- a/src/Discord/Helpers/RegisteredCommand.php
+++ b/src/Discord/Helpers/RegisteredCommand.php
@@ -90,7 +90,7 @@ class RegisteredCommand
      */
     public function execute(array $options, Interaction $interaction): bool
     {
-        $params = Collection::for(Option::class, 'name');
+        $params = ($this->discord->getCollectionClass())::for(Option::class, 'name');
 
         foreach ($options as $option) {
             if (isset($this->subCommands[$option->name])) {

--- a/src/Discord/Parts/Channel/Channel.php
+++ b/src/Discord/Parts/Channel/Channel.php
@@ -14,7 +14,7 @@ namespace Discord\Parts\Channel;
 use Carbon\Carbon;
 use Discord\Builders\MessageBuilder;
 use Discord\Exceptions\InvalidOverwriteException;
-use Discord\Helpers\Collection;
+use Discord\Helpers\CollectionInterface;
 use Discord\Parts\Embed\Embed;
 use Discord\Parts\Guild\Guild;
 use Discord\Parts\Guild\Role;
@@ -70,7 +70,7 @@ use function React\Promise\resolve;
  * @property      int|null            $bitrate                            The bitrate of the channel. Only for voice channels.
  * @property      int|null            $user_limit                         The user limit of the channel. Max 99 for voice channels and 10000 for stage channels (0 refers to no limit).
  * @property      int|null            $rate_limit_per_user                Amount of seconds a user has to wait before sending a new message (slow mode).
- * @property      Collection|User[]   $recipients                         A collection of all the recipients in the channel. Only for DM or group channels.
+ * @property      CollectionInterface|User[]   $recipients                A collection of all the recipients in the channel. Only for DM or group channels.
  * @property-read User|null           $recipient                          The first recipient of the channel. Only for DM or group channels.
  * @property-read string|null         $recipient_id                       The ID of the recipient of the channel, if it is a DM channel.
  * @property      ?string|null        $icon                               Icon hash.
@@ -84,7 +84,7 @@ use function React\Promise\resolve;
  * @property      int|null            $default_auto_archive_duration      Default duration for newly created threads, in minutes, to automatically archive the thread after recent activity, can be set to: 60, 1440, 4320, 10080.
  * @property      string|null         $permissions                        Computed permissions for the invoking user in the channel, including overwrites, only included when part of the resolved data received on an application command interaction.
  * @property      int|null            $flags                              Channel flags combined as a bitfield.
- * @property      Collection|Tag[]    $available_tags                     Set of tags that can be used in a forum channel, limited to 20.
+ * @property      CollectionInterface|Tag[]    $available_tags            Set of tags that can be used in a forum channel, limited to 20.
  * @property      ?Reaction|null      $default_reaction_emoji             Emoji to show in the add reaction button on a thread in a forum channel.
  * @property      int|null            $default_thread_rate_limit_per_user The initial rate_limit_per_user to set on newly created threads in a forum channel. this field is copied to the thread at creation time and does not live update.
  * @property      ?int|null           $default_sort_order                 The default sort order type used to order posts in forum channels.
@@ -251,11 +251,11 @@ class Channel extends Part implements Stringable
     /**
      * Gets the recipients attribute.
      *
-     * @return Collection A collection of recipients.
+     * @return CollectionInterface A collection of recipients.
      */
-    protected function getRecipientsAttribute(): Collection
+    protected function getRecipientsAttribute(): CollectionInterface
     {
-        $recipients = Collection::for(User::class);
+        $recipients = ($this->discord->getCollectionClass())::for(User::class);
 
         foreach ($this->attributes['recipients'] ?? [] as $recipient) {
             $recipients->pushItem($this->discord->users->get('id', $recipient->id) ?: $this->factory->part(User::class, (array) $recipient, true));
@@ -295,13 +295,13 @@ class Channel extends Part implements Stringable
      *
      * @link https://discord.com/developers/docs/resources/channel#get-pinned-messages
      *
-     * @return PromiseInterface<Collection<Message[]>>
+     * @return PromiseInterface<CollectionInterface<Message[]>>
      */
     public function getPinnedMessages(): PromiseInterface
     {
         return $this->http->get(Endpoint::bind(Endpoint::CHANNEL_PINS, $this->id))
         ->then(function ($responses) {
-            $messages = Collection::for(Message::class);
+            $messages = ($this->discord->getCollectionClass())::for(Message::class);
 
             foreach ($responses as $response) {
                 $messages->pushItem($this->messages->get('id', $response->id) ?: $this->messages->create($response, true));
@@ -736,7 +736,7 @@ class Channel extends Part implements Stringable
      *                                Or also missing `connect` permission for text in voice.
      * @throws \RangeException
      *
-     * @return PromiseInterface<Collection<Message[]>>
+     * @return PromiseInterface<CollectionInterface<Message[]>>
      * @todo Make it in a trait along with Thread
      */
     public function getMessageHistory(array $options = []): PromiseInterface
@@ -781,7 +781,7 @@ class Channel extends Part implements Stringable
         }
 
         return $this->http->get($endpoint)->then(function ($responses) {
-            $messages = Collection::for(Message::class);
+            $messages = ($this->discord->getCollectionClass())::for(Message::class);
 
             foreach ($responses as $response) {
                 $messages->pushItem($this->messages->get('id', $response->id) ?: $this->messages->create($response, true));
@@ -925,13 +925,13 @@ class Channel extends Part implements Stringable
     /**
      * Gets the available tags attribute.
      *
-     * @return Collection|Tag[] Available forum tags.
+     * @return CollectionInterface|Tag[] Available forum tags.
      *
      * @since 7.4.0
      */
-    protected function getAvailableTagsAttribute(): Collection
+    protected function getAvailableTagsAttribute(): CollectionInterface
     {
-        $available_tags = Collection::for(Tag::class);
+        $available_tags = ($this->discord->getCollectionClass())::for(Tag::class);
 
         foreach ($this->attributes['available_tags'] ?? [] as $available_tag) {
             $available_tags->pushItem($this->createOf(Tag::class, $available_tag));
@@ -1267,12 +1267,13 @@ class Channel extends Part implements Stringable
      * @param int      $options['time']  Time in milliseconds until the collector finishes or false.
      * @param int      $options['limit'] The amount of messages allowed or false.
      *
-     * @return PromiseInterface<Collection<Message[]>>
+     * @return PromiseInterface<CollectionInterface<Message[]>>
      */
     public function createMessageCollector(callable $filter, array $options = []): PromiseInterface
     {
         $deferred = new Deferred();
-        $messages = new Collection([], null, null);
+        /** @var CollectionInterface $messages An instance of the collection class implementing CollectionInterface.*/
+        $messages = new ($this->discord->getCollectionClass())([], null, null);
         $timer = null;
 
         $options = array_merge([

--- a/src/Discord/Parts/Channel/Message.php
+++ b/src/Discord/Parts/Channel/Message.php
@@ -13,7 +13,7 @@ namespace Discord\Parts\Channel;
 
 use Carbon\Carbon;
 use Discord\Builders\MessageBuilder;
-use Discord\Helpers\Collection;
+use Discord\Helpers\CollectionInterface;
 use Discord\Parts\Channel\Poll;
 use Discord\Parts\Embed\Embed;
 use Discord\Parts\Guild\Emoji;
@@ -45,39 +45,39 @@ use function React\Promise\reject;
  *
  * @since 2.0.0
  *
- * @property      string                      $id                     The unique identifier of the message.
- * @property      string                      $channel_id             The unique identifier of the channel that the message was sent in.
- * @property-read Channel|Thread              $channel                The channel that the message was sent in.
- * @property      User|null                   $author                 The author of the message. Will be a webhook if sent from one.
- * @property-read string|null                 $user_id                The user id of the author.
- * @property      string                      $content                The content of the message if it is a normal message.
- * @property      Carbon                      $timestamp              A timestamp of when the message was sent.
- * @property      Carbon|null                 $edited_timestamp       A timestamp of when the message was edited, or null.
- * @property      bool                        $tts                    Whether the message was sent as a text-to-speech message.
- * @property      bool                        $mention_everyone       Whether the message contained an @everyone mention.
- * @property      Collection|User[]           $mentions               A collection of the users mentioned in the message.
- * @property      Collection|Role[]           $mention_roles          A collection of roles that were mentioned in the message.
- * @property      Collection|Channel[]        $mention_channels       Collection of mentioned channels.
- * @property      Collection|Attachment[]     $attachments            Collection of attachment objects.
- * @property      Collection|Embed[]          $embeds                 A collection of embed objects.
- * @property      ReactionRepository          $reactions              Collection of reactions on the message.
- * @property      string|null                 $nonce                  A randomly generated string that provides verification for the client. Not required.
- * @property      bool                        $pinned                 Whether the message is pinned to the channel.
- * @property      string|null                 $webhook_id             ID of the webhook that made the message, if any.
- * @property      int                         $type                   The type of message.
- * @property      object|null                 $activity               Current message activity. Requires rich presence.
- * @property      object|null                 $application            Application of message. Requires rich presence.
- * @property      string|null                 $application_id         If the message is a response to an Interaction, this is the id of the interaction's application.
- * @property      object|null                 $message_reference      Message that is referenced by this message.
- * @property      int|null                    $flags                  Message flags.
- * @property      Message|null                $referenced_message     The message that is referenced in a reply.
- * @property      MessageInteraction|null     $interaction            Sent if the message is a response to an Interaction.
- * @property      Thread|null                 $thread                 The thread that was started from this message, includes thread member object.
- * @property      Collection|Component[]|null $components             Sent if the message contains components like buttons, action rows, or other interactive components.
- * @property      Collection|Sticker[]|null   $sticker_items          Stickers attached to the message.
- * @property      int|null                    $position               A generally increasing integer (there may be gaps or duplicates) that represents the approximate position of the message in a thread, it can be used to estimate the relative position of the message in a thread in company with `total_message_sent` on parent thread.
- * @property      object|null                 $role_subscription_data Data of the role subscription purchase or renewal that prompted this `ROLE_SUBSCRIPTION_PURCHASE` message.
- * @property      Poll|null                   $poll                   The poll attached to the message.
+ * @property      string                                $id                     The unique identifier of the message.
+ * @property      string                                $channel_id             The unique identifier of the channel that the message was sent in.
+ * @property-read Channel|Thread                        $channel                The channel that the message was sent in.
+ * @property      User|null                             $author                 The author of the message. Will be a webhook if sent from one.
+ * @property-read string|null                           $user_id                The user id of the author.
+ * @property      string                                $content                The content of the message if it is a normal message.
+ * @property      Carbon                                $timestamp              A timestamp of when the message was sent.
+ * @property      Carbon|null                           $edited_timestamp       A timestamp of when the message was edited, or null.
+ * @property      bool                                  $tts                    Whether the message was sent as a text-to-speech message.
+ * @property      bool                                  $mention_everyone       Whether the message contained an @everyone mention.
+ * @property      CollectionInterface|User[]            $mentions               A collection of the users mentioned in the message.
+ * @property      CollectionInterface|Role[]            $mention_roles          A collection of roles that were mentioned in the message.
+ * @property      CollectionInterface|Channel[]         $mention_channels       Collection of mentioned channels.
+ * @property      CollectionInterface|Attachment[]      $attachments            Collection of attachment objects.
+ * @property      CollectionInterface|Embed[]           $embeds                 A collection of embed objects.
+ * @property      ReactionRepository                    $reactions              Collection of reactions on the message.
+ * @property      string|null                           $nonce                  A randomly generated string that provides verification for the client. Not required.
+ * @property      bool                                  $pinned                 Whether the message is pinned to the channel.
+ * @property      string|null                           $webhook_id             ID of the webhook that made the message, if any.
+ * @property      int                                   $type                   The type of message.
+ * @property      object|null                           $activity               Current message activity. Requires rich presence.
+ * @property      object|null                           $application            Application of message. Requires rich presence.
+ * @property      string|null                           $application_id         If the message is a response to an Interaction, this is the id of the interaction's application.
+ * @property      object|null                           $message_reference      Message that is referenced by this message.
+ * @property      int|null                              $flags                  Message flags.
+ * @property      Message|null                          $referenced_message     The message that is referenced in a reply.
+ * @property      MessageInteraction|null               $interaction            Sent if the message is a response to an Interaction.
+ * @property      Thread|null                           $thread                 The thread that was started from this message, includes thread member object.
+ * @property      CollectionInterface|Component[]|null  $components             Sent if the message contains components like buttons, action rows, or other interactive components.
+ * @property      CollectionInterface|Sticker[]|null    $sticker_items          Stickers attached to the message.
+ * @property      int|null                              $position               A generally increasing integer (there may be gaps or duplicates) that represents the approximate position of the message in a thread, it can be used to estimate the relative position of the message in a thread in company with `total_message_sent` on parent thread.
+ * @property      object|null                           $role_subscription_data Data of the role subscription purchase or renewal that prompted this `ROLE_SUBSCRIPTION_PURCHASE` message.
+ * @property      Poll|null                             $poll                   The poll attached to the message.
  *
  * @property-read bool $crossposted                            Message has been crossposted.
  * @property-read bool $is_crosspost                           Message is a crosspost from another channel.
@@ -334,11 +334,11 @@ class Message extends Part
     /**
      * Gets the mention_channels attribute.
      *
-     * @return Collection|Channel[]
+     * @return CollectionInterface|Channel[]
      */
-    protected function getMentionChannelsAttribute(): Collection
+    protected function getMentionChannelsAttribute(): CollectionInterface
     {
-        $collection = Collection::for(Channel::class);
+        $collection = ($this->discord->getCollectionClass())::for(Channel::class);
 
         if (preg_match_all('/<#([0-9]*)>/', $this->content, $matches)) {
             foreach ($matches[1] as $channelId) {
@@ -358,11 +358,11 @@ class Message extends Part
     /**
      * Returns any attached files.
      *
-     * @return Collection|Attachment[] Attachment objects.
+     * @return CollectionInterface|Attachment[] Attachment objects.
      */
-    protected function getAttachmentsAttribute(): Collection
+    protected function getAttachmentsAttribute(): CollectionInterface
     {
-        $attachments = Collection::for(Attachment::class);
+        $attachments = ($this->discord->getCollectionClass())::for(Attachment::class);
 
         foreach ($this->attributes['attachments'] ?? [] as $attachment) {
             $attachments->pushItem($this->createOf(Attachment::class, $attachment));
@@ -490,11 +490,12 @@ class Message extends Part
     /**
      * Returns the mention_roles attribute.
      *
-     * @return Collection<?Role> The roles that were mentioned. null role only contains the ID in the collection.
+     * @return CollectionInterface<?Role> The roles that were mentioned. null role only contains the ID in the collection.
      */
-    protected function getMentionRolesAttribute(): Collection
+    protected function getMentionRolesAttribute(): CollectionInterface
     {
-        $roles = new Collection();
+        /** @var CollectionInterface $roles An instance of the collection class implementing CollectionInterface.*/
+        $roles = new ($this->discord->getCollectionClass())();
 
         if (empty($this->attributes['mention_roles'])) {
             return $roles;
@@ -514,11 +515,11 @@ class Message extends Part
     /**
      * Returns the mention attribute.
      *
-     * @return Collection|User[] The users that were mentioned.
+     * @return CollectionInterface|User[] The users that were mentioned.
      */
-    protected function getMentionsAttribute(): Collection
+    protected function getMentionsAttribute(): CollectionInterface
     {
-        $users = Collection::for(User::class);
+        $users = ($this->discord->getCollectionClass())::for(User::class);
 
         foreach ($this->attributes['mentions'] ?? [] as $mention) {
             $users->pushItem($this->discord->users->get('id', $mention->id) ?: $this->factory->part(User::class, (array) $mention, true));
@@ -581,11 +582,12 @@ class Message extends Part
     /**
      * Returns the embed attribute.
      *
-     * @return Collection<Embed> A collection of embeds.
+     * @return CollectionInterface<Embed> A collection of embeds.
      */
-    protected function getEmbedsAttribute(): Collection
+    protected function getEmbedsAttribute(): CollectionInterface
     {
-        $embeds = new Collection([], null);
+        /** @var CollectionInterface $embeds An instance of the collection class implementing CollectionInterface.*/
+        $embeds = new ($this->discord->getCollectionClass())([], null);
 
         foreach ($this->attributes['embeds'] ?? [] as $embed) {
             $embeds->pushItem($this->createOf(Embed::class, $embed));
@@ -681,15 +683,15 @@ class Message extends Part
     /**
      * Returns the components attribute.
      *
-     * @return Collection|Component[]|null
+     * @return CollectionInterface|Component[]|null
      */
-    protected function getComponentsAttribute(): ?Collection
+    protected function getComponentsAttribute(): ?CollectionInterface
     {
         if (! isset($this->attributes['components'])) {
             return null;
         }
 
-        $components = Collection::for(Component::class, null);
+        $components = ($this->discord->getCollectionClass())::for(Component::class, null);
 
         foreach ($this->attributes['components'] as $component) {
             $components->pushItem($this->createOf(Component::class, $component));
@@ -701,15 +703,15 @@ class Message extends Part
     /**
      * Returns the sticker_items attribute.
      *
-     * @return Collection|Sticker[]|null Partial stickers.
+     * @return CollectionInterface|Sticker[]|null Partial stickers.
      */
-    protected function getStickerItemsAttribute(): ?Collection
+    protected function getStickerItemsAttribute(): ?CollectionInterface
     {
         if (! isset($this->attributes['sticker_items']) && ! in_array($this->type, [self::TYPE_DEFAULT, self::TYPE_REPLY])) {
             return null;
         }
 
-        $sticker_items = Collection::for(Sticker::class);
+        $sticker_items = ($this->discord->getCollectionClass())::for(Sticker::class);
 
         foreach ($this->attributes['sticker_items'] ?? [] as $sticker) {
             $sticker_items->pushItem($this->factory->part(Sticker::class, (array) $sticker, true));
@@ -1077,12 +1079,13 @@ class Message extends Part
      * @param int      $options['time']  Time in milliseconds until the collector finishes or false.
      * @param int      $options['limit'] The amount of reactions allowed or false.
      *
-     * @return PromiseInterface<Collection<MessageReaction>>
+     * @return PromiseInterface<CollectionInterface<MessageReaction>>
      */
     public function createReactionCollector(callable $filter, array $options = []): PromiseInterface
     {
         $deferred = new Deferred();
-        $reactions = new Collection([], null, null);
+        /** @var CollectionInterface $reactions An instance of the collection class implementing CollectionInterface.*/
+        $reactions = new ($this->discord->getCollectionClass())([], null, null);
         $timer = null;
 
         $options = array_merge([

--- a/src/Discord/Parts/Channel/Poll.php
+++ b/src/Discord/Parts/Channel/Poll.php
@@ -12,7 +12,7 @@
 namespace Discord\Parts\Channel;
 
 use Carbon\Carbon;
-use Discord\Helpers\Collection;
+use Discord\Helpers\CollectionInterface;
 use Discord\Http\Endpoint;
 use Discord\Parts\Channel\Poll\PollAnswer;
 use Discord\Parts\Channel\Poll\PollMedia;

--- a/src/Discord/Parts/Channel/Poll/PollAnswer.php
+++ b/src/Discord/Parts/Channel/Poll/PollAnswer.php
@@ -11,7 +11,7 @@
 
 namespace Discord\Parts\Channel\Poll;
 
-use Discord\Helpers\Collection;
+use Discord\Helpers\CollectionInterface;
 use Discord\Http\Endpoint;
 use Discord\Parts\Channel\Channel;
 use Discord\Parts\Channel\Message;
@@ -140,7 +140,7 @@ class PollAnswer extends Part
      *
      * @throws \OutOfRangeException
      *
-     * @return PromiseInterface<Collection|User[]>
+     * @return PromiseInterface<CollectionInterface|User[]>
      */
     public function getVoters(array $options = []): PromiseInterface
     {
@@ -162,7 +162,7 @@ class PollAnswer extends Part
 
         return $this->http->get($query)
             ->then(function ($response) {
-                $users = Collection::for(User::class);
+                $users = ($this->discord->getCollectionClass())::for(User::class);
 
                 foreach ($response->users ?? [] as $user) {
                     if (! $part = $this->discord->users->get('id', $user->id)) {

--- a/src/Discord/Parts/Channel/Reaction.php
+++ b/src/Discord/Parts/Channel/Reaction.php
@@ -11,7 +11,7 @@
 
 namespace Discord\Parts\Channel;
 
-use Discord\Helpers\Collection;
+use Discord\Helpers\CollectionInterface;
 use Discord\Http\Endpoint;
 use Discord\Parts\Guild\Emoji;
 use Discord\Parts\Guild\Guild;
@@ -139,7 +139,7 @@ class Reaction extends Part
      *
      * @link https://discord.com/developers/docs/resources/channel#get-reactions
      *
-     * @return PromiseInterface<Collection|User[]>
+     * @return PromiseInterface<CollectionInterface|User[]>
      */
     public function getUsers(array $options = []): PromiseInterface
     {
@@ -161,7 +161,7 @@ class Reaction extends Part
 
         return $this->http->get($query)
         ->then(function ($response) {
-            $users = Collection::for(User::class);
+            $users = ($this->discord->getCollectionClass())::for(User::class);
 
             foreach ((array) $response as $user) {
                 if (! $part = $this->discord->users->get('id', $user->id)) {
@@ -182,11 +182,11 @@ class Reaction extends Part
      *
      * @see Message::getUsers()
      *
-     * @return PromiseInterface<Collection|User[]>
+     * @return PromiseInterface<CollectionInterface|User[]>
      */
     public function getAllUsers(): PromiseInterface
     {
-        $response = Collection::for(User::class);
+        $response = ($this->discord->getCollectionClass())::for(User::class);
         $getUsers = function ($after = null) use (&$getUsers, $response) {
             $options = ['limit' => 100];
             if ($after != null) {

--- a/src/Discord/Parts/Embed/Embed.php
+++ b/src/Discord/Parts/Embed/Embed.php
@@ -12,7 +12,7 @@
 namespace Discord\Parts\Embed;
 
 use Carbon\Carbon;
-use Discord\Helpers\Collection;
+use Discord\Helpers\CollectionInterface;
 use Discord\Parts\Channel\Attachment;
 use Discord\Parts\Part;
 use function Discord\poly_strlen;
@@ -36,7 +36,7 @@ use function Discord\poly_strlen;
  * @property-read Video|null         $video       The video of the embed.
  * @property-read object|null        $provider    The provider of the embed.
  * @property      Author|null        $author      The author of the embed.
- * @property      Collection|Field[] $fields      A collection of embed fields.
+ * @property      CollectionInterface|Field[] $fields      A collection of embed fields.
  */
 class Embed extends Part
 {
@@ -135,11 +135,11 @@ class Embed extends Part
     /**
      * Gets the fields attribute.
      *
-     * @return Collection|Field[]
+     * @return CollectionInterfaceInterface|Field[]
      */
-    protected function getFieldsAttribute(): Collection
+    protected function getFieldsAttribute(): CollectionInterface
     {
-        $fields = Collection::for(Field::class, null);
+        $fields = ($this->discord->getCollectionClass())::for(Field::class, null);
 
         if (! array_key_exists('fields', $this->attributes)) {
             return $fields;

--- a/src/Discord/Parts/Guild/AuditLog/AuditLog.php
+++ b/src/Discord/Parts/Guild/AuditLog/AuditLog.php
@@ -11,7 +11,7 @@
 
 namespace Discord\Parts\Guild\AuditLog;
 
-use Discord\Helpers\Collection;
+use Discord\Helpers\CollectionInterface;
 use Discord\Parts\Channel\Webhook;
 use Discord\Parts\Guild\AutoModeration\Rule;
 use Discord\Parts\Guild\Guild;
@@ -30,14 +30,14 @@ use ReflectionClass;
  *
  * @since 5.1.0
  *
- * @property Collection|Command[]        $application_commands   List of application commands referenced in the audit log.
- * @property Collection|Entry[]          $audit_log_entries      List of audit log entries.
- * @property Collection|Rule[]           $auto_moderation_rules  List of auto moderation rules referenced in the audit log.
- * @property Collection|ScheduledEvent[] $guild_scheduled_events List of guild scheduled events referenced in the audit log.
- * @property Collection|Integration[]    $integrations           List of partial integration objects.
- * @property Collection|Thread[]         $threads                List of threads referenced in the audit log.
- * @property Collection|User[]           $users                  List of users referenced in the audit log.
- * @property Collection|Webhook[]        $webhooks               List of webhooks referenced in the audit log.
+ * @property CollectionInterface|Command[]        $application_commands   List of application commands referenced in the audit log.
+ * @property CollectionInterface|Entry[]          $audit_log_entries      List of audit log entries.
+ * @property CollectionInterface|Rule[]           $auto_moderation_rules  List of auto moderation rules referenced in the audit log.
+ * @property CollectionInterface|ScheduledEvent[] $guild_scheduled_events List of guild scheduled events referenced in the audit log.
+ * @property CollectionInterface|Integration[]    $integrations           List of partial integration objects.
+ * @property CollectionInterface|Thread[]         $threads                List of threads referenced in the audit log.
+ * @property CollectionInterface|User[]           $users                  List of users referenced in the audit log.
+ * @property CollectionInterface|Webhook[]        $webhooks               List of webhooks referenced in the audit log.
  *
  * @property      string     $guild_id
  * @property-read Guild|null $guild
@@ -74,11 +74,11 @@ class AuditLog extends Part
     /**
      * Returns a collection of application commands found in the audit log.
      *
-     * @return Collection|Command[]
+     * @return CollectionInterfaceInterface|Command[]
      */
-    protected function getApplicationCommandsAttribute(): Collection
+    protected function getApplicationCommandsAttribute(): CollectionInterface
     {
-        $collection = Collection::for(Command::class);
+        $collection = ($this->discord->getCollectionClass())::for(Command::class);
 
         foreach ($this->attributes['application_commands'] ?? [] as $application_commands) {
             $collection->pushItem($this->factory->part(Command::class, (array) $application_commands, true));
@@ -90,11 +90,11 @@ class AuditLog extends Part
     /**
      * Returns a collection of audit log entries.
      *
-     * @return Collection|Entry[]
+     * @return CollectionInterfaceInterface|Entry[]
      */
-    protected function getAuditLogEntriesAttribute(): Collection
+    protected function getAuditLogEntriesAttribute(): CollectionInterface
     {
-        $collection = Collection::for(Entry::class);
+        $collection = ($this->discord->getCollectionClass())::for(Entry::class);
 
         foreach ($this->attributes['audit_log_entries'] ?? [] as $entry) {
             $collection->pushItem($this->createOf(Entry::class, $entry));
@@ -106,11 +106,11 @@ class AuditLog extends Part
     /**
      * Returns a collection of auto moderation rules found in the audit log.
      *
-     * @return Collection|Rule[]
+     * @return CollectionInterfaceInterface|Rule[]
      */
-    protected function getAutoModerationRulesAttribute(): Collection
+    protected function getAutoModerationRulesAttribute(): CollectionInterface
     {
-        $collection = Collection::for(Rule::class);
+        $collection = ($this->discord->getCollectionClass())::for(Rule::class);
 
         foreach ($this->attributes['auto_moderation_rules'] ?? [] as $rule) {
             $collection->pushItem($this->factory->part(Rule::class, (array) $rule, true));
@@ -122,11 +122,11 @@ class AuditLog extends Part
     /**
      * Returns a collection of guild scheduled events found in the audit log.
      *
-     * @return Collection|ScheduledEvent[]
+     * @return CollectionInterfaceInterface|ScheduledEvent[]
      */
-    protected function getGuildScheduledEventsAttribute(): Collection
+    protected function getGuildScheduledEventsAttribute(): CollectionInterface
     {
-        $collection = Collection::for(ScheduledEvent::class);
+        $collection = ($this->discord->getCollectionClass())::for(ScheduledEvent::class);
 
         foreach ($this->attributes['guild_scheduled_events'] ?? [] as $scheduled_event) {
             $collection->pushItem($this->factory->part(ScheduledEvent::class, (array) $scheduled_event, true));
@@ -140,11 +140,11 @@ class AuditLog extends Part
      *
      * @link https://discord.com/developers/docs/resources/audit-log#audit-log-object-example-partial-integration-object
      *
-     * @return Collection|Integration[]
+     * @return CollectionInterfaceInterface|Integration[]
      */
-    protected function getIntegrationsAttribute(): Collection
+    protected function getIntegrationsAttribute(): CollectionInterface
     {
-        $collection = Collection::for(Integration::class);
+        $collection = ($this->discord->getCollectionClass())::for(Integration::class);
 
         foreach ($this->attributes['integrations'] ?? [] as $integration) {
             $collection->pushItem($this->factory->part(Integration::class, (array) $integration, true));
@@ -156,11 +156,11 @@ class AuditLog extends Part
     /**
      * Returns a collection of threads found in the audit log.
      *
-     * @return Collection|Thread[]
+     * @return CollectionInterfaceInterface|Thread[]
      */
-    protected function getThreadsAttribute(): Collection
+    protected function getThreadsAttribute(): CollectionInterface
     {
-        $collection = Collection::for(Thread::class);
+        $collection = ($this->discord->getCollectionClass())::for(Thread::class);
 
         foreach ($this->attributes['threads'] ?? [] as $thread) {
             $collection->pushItem($this->factory->part(Thread::class, (array) $thread, true));
@@ -172,11 +172,11 @@ class AuditLog extends Part
     /**
      * Returns a collection of users found in the audit log.
      *
-     * @return Collection|User[]
+     * @return CollectionInterfaceInterface|User[]
      */
-    protected function getUsersAttribute(): Collection
+    protected function getUsersAttribute(): CollectionInterface
     {
-        $collection = Collection::for(User::class);
+        $collection = ($this->discord->getCollectionClass())::for(User::class);
 
         foreach ($this->attributes['users'] ?? [] as $user) {
             $collection->pushItem($this->discord->users->get('id', $user->id) ?: $this->factory->part(User::class, (array) $user, true));
@@ -188,11 +188,11 @@ class AuditLog extends Part
     /**
      * Returns a collection of webhooks found in the audit log.
      *
-     * @return Collection|Webhook[]
+     * @return CollectionInterfaceInterface|Webhook[]
      */
-    protected function getWebhooksAttribute(): Collection
+    protected function getWebhooksAttribute(): CollectionInterface
     {
-        $collection = Collection::for(Webhook::class);
+        $collection = ($this->discord->getCollectionClass())::for(Webhook::class);
 
         foreach ($this->attributes['webhooks'] ?? [] as $webhook) {
             $collection->pushItem($this->factory->part(Webhook::class, (array) $webhook, true));
@@ -208,9 +208,9 @@ class AuditLog extends Part
      *
      * @throws \InvalidArgumentException
      *
-     * @return Collection|Entry[]
+     * @return CollectionInterfaceInterface|Entry[]
      */
-    public function searchByType(int $action_type): Collection
+    public function searchByType(int $action_type): CollectionInterface
     {
         $types = array_values((new ReflectionClass(Entry::class))->getConstants());
 

--- a/src/Discord/Parts/Guild/AuditLog/Entry.php
+++ b/src/Discord/Parts/Guild/AuditLog/Entry.php
@@ -11,7 +11,7 @@
 
 namespace Discord\Parts\Guild\AuditLog;
 
-use Discord\Helpers\Collection;
+use Discord\Helpers\CollectionInterface;
 use Discord\Parts\Part;
 use Discord\Parts\User\User;
 
@@ -121,11 +121,11 @@ class Entry extends Part
      *
      * @link https://discord.com/developers/docs/resources/audit-log#audit-log-change-object
      *
-     * @return Collection
+     * @return CollectionInterface
      */
-    protected function getChangesAttribute(): Collection
+    protected function getChangesAttribute(): CollectionInterface
     {
-        return new Collection($this->attributes['changes'] ?? [], 'key', null);
+        return new ($this->discord->getCollectionClass())($this->attributes['changes'] ?? [], 'key', null);
     }
 
     /**

--- a/src/Discord/Parts/Guild/AutoModeration/Rule.php
+++ b/src/Discord/Parts/Guild/AutoModeration/Rule.php
@@ -11,7 +11,7 @@
 
 namespace Discord\Parts\Guild\AutoModeration;
 
-use Discord\Helpers\Collection;
+use Discord\Helpers\CollectionInterface;
 use Discord\Parts\Channel\Channel;
 use Discord\Parts\Guild\Guild;
 use Discord\Parts\Guild\Role;
@@ -39,10 +39,10 @@ use Discord\Parts\User\User;
  * @property      int                   $event_type       The rule event type.
  * @property      int                   $trigger_type     The rule trigger type.
  * @property      object                $trigger_metadata The rule trigger metadata (may contain `keyword_filter`, `regex_patterns`, `presets`, `allow_list`, `mention_total_limit` and `mention_raid_protection_enabled`).
- * @property      Collection|Action[]   $actions          The actions which will execute when the rule is triggered.
+ * @property      CollectionInterface|Action[]   $actions          The actions which will execute when the rule is triggered.
  * @property      bool                  $enabled          Whether the rule is enabled.
- * @property      Collection|?Role[]    $exempt_roles     The role ids that should not be affected by the rule (Maximum of 20).
- * @property      Collection|?Channel[] $exempt_channels  The channel ids that should not be affected by the rule (Maximum of 50).
+ * @property      CollectionInterface|?Role[]    $exempt_roles     The role ids that should not be affected by the rule (Maximum of 20).
+ * @property      CollectionInterface|?Channel[] $exempt_channels  The channel ids that should not be affected by the rule (Maximum of 50).
  */
 class Rule extends Part
 {
@@ -98,11 +98,11 @@ class Rule extends Part
     /**
      * Returns the actions attribute.
      *
-     * @return Collection|Action[] A collection of actions.
+     * @return CollectionInterfaceInterface|Action[] A collection of actions.
      */
-    protected function getActionsAttribute(): Collection
+    protected function getActionsAttribute(): CollectionInterface
     {
-        $actions = Collection::for(Action::class, null);
+        $actions = ($this->discord->getCollectionClass())::for(Action::class, null);
 
         foreach ($this->attributes['actions'] as $action) {
             $actions->pushItem($this->createOf(Action::class, $action));
@@ -114,11 +114,11 @@ class Rule extends Part
     /**
      * Returns the exempt roles attribute.
      *
-     * @return Collection|?Role[] A collection of roles exempt from the rule.
+     * @return CollectionInterfaceInterface|?Role[] A collection of roles exempt from the rule.
      */
-    protected function getExemptRolesAttribute(): Collection
+    protected function getExemptRolesAttribute(): CollectionInterface
     {
-        $roles = new Collection();
+        $roles = new ($this->discord->getCollectionClass())();
 
         if (empty($this->attributes['exempt_roles'])) {
             return $roles;
@@ -138,11 +138,11 @@ class Rule extends Part
     /**
      * Returns the exempt channels attribute.
      *
-     * @return Collection|?Channel[] A collection of channels exempt from the rule.
+     * @return CollectionInterfaceInterface|?Channel[] A collection of channels exempt from the rule.
      */
-    protected function getExemptChannelsAttribute(): Collection
+    protected function getExemptChannelsAttribute(): CollectionInterface
     {
-        $channels = new Collection();
+        $channels = new ($this->discord->getCollectionClass())();
 
         if (empty($this->attributes['exempt_channels'])) {
             return $channels;

--- a/src/Discord/Parts/Guild/CommandPermissions.php
+++ b/src/Discord/Parts/Guild/CommandPermissions.php
@@ -12,7 +12,7 @@
 namespace Discord\Parts\Guild;
 
 use Discord\Helpers\BigInt;
-use Discord\Helpers\Collection;
+use Discord\Helpers\CollectionInterface;
 use Discord\Parts\Interactions\Command\Permission;
 use Discord\Parts\Part;
 
@@ -28,7 +28,7 @@ use Discord\Parts\Part;
  * @property      string                  $application_id The id of the application the command belongs to.
  * @property      string                  $guild_id       The id of the guild.
  * @property-read Guild|null              $guild
- * @property      Collection|Permission[] $permissions    The permissions for the command in the guild.
+ * @property      CollectionInterface|Permission[] $permissions    The permissions for the command in the guild.
  */
 class CommandPermissions extends Part
 {
@@ -55,11 +55,11 @@ class CommandPermissions extends Part
     /**
      * Gets the permissions attribute.
      *
-     * @return Collection|Permission[] A collection of permissions.
+     * @return CollectionInterfaceInterface|Permission[] A collection of permissions.
      */
-    protected function getPermissionsAttribute(): Collection
+    protected function getPermissionsAttribute(): CollectionInterface
     {
-        $permissions = Collection::for(Permission::class);
+        $permissions = ($this->discord->getCollectionClass())::for(Permission::class);
 
         foreach ($this->attributes['permissions'] ?? [] as $permission) {
             $permissions->pushItem($this->factory->part(Permission::class, (array) $permission, true));

--- a/src/Discord/Parts/Guild/Emoji.php
+++ b/src/Discord/Parts/Guild/Emoji.php
@@ -11,7 +11,7 @@
 
 namespace Discord\Parts\Guild;
 
-use Discord\Helpers\Collection;
+use Discord\Helpers\CollectionInterface;
 use Discord\Parts\Part;
 use Discord\Parts\User\User;
 use Stringable;
@@ -25,7 +25,7 @@ use Stringable;
  *
  * @property ?string           $id             The identifier for the emoji.
  * @property string            $name           The name of the emoji.
- * @property Collection|Role[] $roles          The roles that are allowed to use the emoji.
+ * @property CollectionInterface|Role[] $roles          The roles that are allowed to use the emoji.
  * @property User|null         $user           User that created this emoji.
  * @property bool|null         $require_colons Whether the emoji requires colons to be triggered.
  * @property bool|null         $managed        Whether this emoji is managed by a role.
@@ -67,11 +67,12 @@ class Emoji extends Part implements Stringable
     /**
      * Returns the roles attribute.
      *
-     * @return Collection<?Role> A collection of roles for the emoji.
+     * @return CollectionInterface<?Role> A collection of roles for the emoji.
      */
-    protected function getRolesAttribute(): Collection
+    protected function getRolesAttribute(): CollectionInterface
     {
-        $roles = new Collection();
+        /** @var CollectionInterface $roles An instance of the collection class implementing CollectionInterface.*/
+        $roles = new ($this->discord->getCollectionClass())();
 
         if (empty($this->attributes['roles'])) {
             return $roles;

--- a/src/Discord/Parts/Guild/Guild.php
+++ b/src/Discord/Parts/Guild/Guild.php
@@ -13,7 +13,7 @@ namespace Discord\Parts\Guild;
 
 use Carbon\Carbon;
 use Discord\Exceptions\FileNotFoundException;
-use Discord\Helpers\Collection;
+use Discord\Helpers\CollectionInterface;
 use Discord\Helpers\Multipart;
 use Discord\Http\Endpoint;
 use Discord\Http\Exceptions\NoPermissionsException;
@@ -305,7 +305,7 @@ class Guild extends Part
     /**
      * An array of valid regions.
      *
-     * @var Collection|null
+     * @var CollectionInterface|null
      */
     protected $regions;
 
@@ -423,7 +423,7 @@ class Guild extends Part
      *
      * @throws NoPermissionsException Missing manage_guild permission.
      *
-     * @return PromiseInterface<Collection|Invite[]>
+     * @return PromiseInterface<CollectionInterface|Invite[]>
      */
     public function getInvites(): PromiseInterface
     {
@@ -433,7 +433,7 @@ class Guild extends Part
         }
 
         return $this->http->get(Endpoint::bind(Endpoint::GUILD_INVITES, $this->id))->then(function ($response) {
-            $invites = Collection::for(Invite::class, 'code');
+            $invites = ($this->discord->getCollectionClass())::for(Invite::class, 'code');
 
             foreach ($response as $invite) {
                 $invite = $this->factory->part(Invite::class, (array) $invite, true);
@@ -568,11 +568,11 @@ class Guild extends Part
      *
      * @deprecated 10.0.0 Use `$channel->stage_instances`
      *
-     * @return Collection|StageInstance[]
+     * @return CollectionInterfaceInterface|StageInstance[]
      */
-    protected function getStageInstancesAttribute(): Collection
+    protected function getStageInstancesAttribute(): CollectionInterface
     {
-        $stage_instances = Collection::for(StageInstance::class);
+        $stage_instances = ($this->discord->getCollectionClass())::for(StageInstance::class);
 
         if ($channels = $this->channels) {
             /** @var Channel */
@@ -753,7 +753,7 @@ class Guild extends Part
         }
 
         return $this->http->get('voice/regions')->then(function ($regions) {
-            $regions = new Collection($regions);
+            $regions = new ($this->discord->getCollectionClass())($regions);
 
             $this->regions = $regions;
 
@@ -1155,7 +1155,7 @@ class Guild extends Part
      * @param string|null $options['query'] Query string to match username(s) and nickname(s) against
      * @param int|null    $options['limit'] How many entries are returned (default 1, minimum 1, maximum 1000)
      *
-     * @return PromiseInterface<Collection|Member[]>
+     * @return PromiseInterface<CollectionInterface|Member[]>
      */
     public function searchMembers(array $options): PromiseInterface
     {
@@ -1176,7 +1176,7 @@ class Guild extends Part
         $endpoint->addQuery('limit', $options['limit']);
 
         return $this->http->get($endpoint)->then(function ($responses) {
-            $members = Collection::for(Member::class);
+            $members = ($this->discord->getCollectionClass())::for(Member::class);
 
             foreach ($responses as $response) {
                 if (! $member = $this->members->get('id', $response->user->id)) {

--- a/src/Discord/Parts/Guild/ScheduledEvent.php
+++ b/src/Discord/Parts/Guild/ScheduledEvent.php
@@ -12,7 +12,7 @@
 namespace Discord\Parts\Guild;
 
 use Carbon\Carbon;
-use Discord\Helpers\Collection;
+use Discord\Helpers\CollectionInterface;
 use Discord\Http\Endpoint;
 use Discord\Parts\Channel\Channel;
 use Discord\Parts\Part;
@@ -97,7 +97,7 @@ class ScheduledEvent extends Part
      *
      * @throws \RangeException
      *
-     * @return PromiseInterface<Collection<User>>
+     * @return PromiseInterface<CollectionInterface<User>>
      */
     public function getUsers(array $options): PromiseInterface
     {
@@ -126,7 +126,7 @@ class ScheduledEvent extends Part
         }
 
         return $this->http->get($endpoint)->then(function ($responses) {
-            $users = new Collection();
+            $users = new ($this->discord->getCollectionClass())();
 
             $guild = $this->guild;
 

--- a/src/Discord/Parts/Guild/WelcomeScreen.php
+++ b/src/Discord/Parts/Guild/WelcomeScreen.php
@@ -11,7 +11,7 @@
 
 namespace Discord\Parts\Guild;
 
-use Discord\Helpers\Collection;
+use Discord\Helpers\CollectionInterface;
 use Discord\Parts\Part;
 
 /**
@@ -22,7 +22,7 @@ use Discord\Parts\Part;
  * @since 7.0.0
  *
  * @property ?string                     $description      The server description shown in the welcome screen.
- * @property Collection|WelcomeChannel[] $welcome_channels The channels shown in the welcome screen, up to 5.
+ * @property CollectionInterface|WelcomeChannel[] $welcome_channels The channels shown in the welcome screen, up to 5.
  */
 class WelcomeScreen extends Part
 {
@@ -37,11 +37,11 @@ class WelcomeScreen extends Part
     /**
      * Returns the Welcome Channels of the Welcome Screen.
      *
-     * @return Collection|WelcomeChannel[] The channels of welcome screen.
+     * @return CollectionInterfaceInterface|WelcomeChannel[] The channels of welcome screen.
      */
-    protected function getWelcomeChannelsAttribute(): Collection
+    protected function getWelcomeChannelsAttribute(): CollectionInterface
     {
-        $collection = Collection::for(WelcomeChannel::class, null);
+        $collection = ($this->discord->getCollectionClass())::for(WelcomeChannel::class, null);
 
         foreach ($this->attributes['welcome_channels'] ?? [] as $welcome_channel) {
             $collection->pushItem($this->createOf(WelcomeChannel::class, $welcome_channel));

--- a/src/Discord/Parts/Interactions/Command/Command.php
+++ b/src/Discord/Parts/Interactions/Command/Command.php
@@ -11,7 +11,7 @@
 
 namespace Discord\Parts\Interactions\Command;
 
-use Discord\Helpers\Collection;
+use Discord\Helpers\CollectionInterface;
 use Discord\Parts\Guild\Guild;
 use Discord\Parts\Part;
 use Stringable;
@@ -79,15 +79,15 @@ class Command extends Part implements Stringable
     /**
      * Gets the options attribute.
      *
-     * @return Collection|Option[]|null A collection of options.
+     * @return CollectionInterfaceInterface|Option[]|null A collection of options.
      */
-    protected function getOptionsAttribute(): ?Collection
+    protected function getOptionsAttribute(): ?CollectionInterface
     {
         if (! isset($this->attributes['options']) && (isset($this->type) && $this->type != self::CHAT_INPUT)) {
             return null;
         }
 
-        $options = Collection::for(Option::class, null);
+        $options = ($this->discord->getCollectionClass())::for(Option::class, null);
 
         foreach ($this->attributes['options'] ?? [] as $option) {
             $options->pushItem($this->createOf(Option::class, $option));

--- a/src/Discord/Parts/Interactions/Command/Option.php
+++ b/src/Discord/Parts/Interactions/Command/Option.php
@@ -11,7 +11,7 @@
 
 namespace Discord\Parts\Interactions\Command;
 
-use Discord\Helpers\Collection;
+use Discord\Helpers\CollectionInterface;
 use Discord\Parts\Part;
 
 use function Discord\poly_strlen;
@@ -29,8 +29,8 @@ use function Discord\poly_strlen;
  * @property string                   $description               1-100 character description.
  * @property ?string[]|null           $description_localizations Localization dictionary for the description field. Values follow the same restrictions as description.
  * @property bool|null                $required                  If the parameter is required or optional--default false.
- * @property Collection|Choice[]|null $choices                   Choices for STRING, INTEGER, and NUMBER types for the user to pick from, max 25. Only for slash commands.
- * @property Collection|Option[]      $options                   Sub-options if applicable.
+ * @property CollectionInterface|Choice[]|null $choices                   Choices for STRING, INTEGER, and NUMBER types for the user to pick from, max 25. Only for slash commands.
+ * @property CollectionInterface|Option[]      $options                   Sub-options if applicable.
  * @property array|null               $channel_types             If the option is a channel type, the channels shown will be restricted to these types.
  * @property int|float|null           $min_value                 If the option is an INTEGER or NUMBER type, the minimum value permitted.
  * @property int|float|null           $max_value                 If the option is an INTEGER or NUMBER type, the maximum value permitted.
@@ -75,15 +75,15 @@ class Option extends Part
     /**
      * Gets the choices attribute.
      *
-     * @return Collection|Choice[]|null A collection of choices.
+     * @return CollectionInterfaceInterface|Choice[]|null A collection of choices.
      */
-    protected function getChoicesAttribute(): ?Collection
+    protected function getChoicesAttribute(): ?CollectionInterface
     {
         if (! isset($this->attributes['choices']) && ! in_array($this->type, [self::STRING, self::INTEGER, self::NUMBER])) {
             return null;
         }
 
-        $choices = Collection::for(Choice::class, null);
+        $choices = ($this->discord->getCollectionClass())::for(Choice::class, null);
 
         foreach ($this->attributes['choices'] ?? [] as $choice) {
             $choices->pushItem($this->createOf(Choice::class, $choice));
@@ -95,11 +95,11 @@ class Option extends Part
     /**
      * Gets the options attribute.
      *
-     * @return Collection|Option[] A collection of options.
+     * @return CollectionInterfaceInterface|Option[] A collection of options.
      */
-    protected function getOptionsAttribute(): Collection
+    protected function getOptionsAttribute(): CollectionInterface
     {
-        $options = Collection::for(Option::class, null);
+        $options = ($this->discord->getCollectionClass())::for(Option::class, null);
 
         foreach ($this->attributes['options'] ?? [] as $option) {
             $options->pushItem($this->createOf(Option::class, $option));

--- a/src/Discord/Parts/Interactions/Interaction.php
+++ b/src/Discord/Parts/Interactions/Interaction.php
@@ -13,7 +13,7 @@ namespace Discord\Parts\Interactions;
 
 use Discord\Builders\Components\Component;
 use Discord\Builders\MessageBuilder;
-use Discord\Helpers\Collection;
+use Discord\Helpers\CollectionInterface;
 use Discord\Helpers\Multipart;
 use Discord\Http\Endpoint;
 use Discord\Parts\Channel\Channel;
@@ -610,7 +610,7 @@ class Interaction extends Part
             if ($submit) {
                 $listener = function (Interaction $interaction) use ($custom_id, $submit, &$listener) {
                     if ($interaction->type == self::TYPE_MODAL_SUBMIT && $interaction->data->custom_id == $custom_id) {
-                        $components = Collection::for(RequestComponent::class, 'custom_id');
+                        $components = ($this->discord->getCollectionClass())::for(RequestComponent::class, 'custom_id');
                         foreach ($interaction->data->components as $actionrow) {
                             if ($actionrow->type == Component::TYPE_ACTION_ROW) {
                                 foreach ($actionrow->components as $component) {

--- a/src/Discord/Parts/Interactions/Request/Component.php
+++ b/src/Discord/Parts/Interactions/Request/Component.php
@@ -12,7 +12,7 @@
 namespace Discord\Parts\Interactions\Request;
 
 use Discord\Builders\Components\Component as ComponentBuilder;
-use Discord\Helpers\Collection;
+use Discord\Helpers\CollectionInterface;
 use Discord\Parts\Guild\Emoji;
 use Discord\Parts\Part;
 
@@ -36,7 +36,7 @@ use Discord\Parts\Part;
  * @property string|null                 $placeholder Custom placeholder text if nothing is selected; max 150 characters. (Select Menus, Text Inputs)
  * @property int|null                    $min_values  The minimum number of items that must be chosen; default 1, min 0, max 25. (Select Menus)
  * @property int|null                    $max_values  The maximum number of items that can be chosen; default 1, max 25. (Select Menus)
- * @property Collection|Component[]|null $components  A list of child components. (Action Rows)
+ * @property CollectionInterface|Component[]|null $components  A list of child components. (Action Rows)
  * @property int|null                    $min_length  Minimum input length for a text input. (Text Inputs)
  * @property int|null                    $max_length  Maximum input length for a text input. (Text Inputs)
  * @property bool|null                   $required    Whether this component is required to be filled; defaults to `true` (Text Inputs)
@@ -69,15 +69,15 @@ class Component extends Part
     /**
      * Gets the sub-components of the component.
      *
-     * @return Collection|Component[]|null $components
+     * @return CollectionInterfaceInterface|Component[]|null $components
      */
-    protected function getComponentsAttribute(): ?Collection
+    protected function getComponentsAttribute(): ?CollectionInterface
     {
         if (! isset($this->attributes['components']) && $this->type != ComponentBuilder::TYPE_ACTION_ROW) {
             return null;
         }
 
-        $components = Collection::for(Component::class, null);
+        $components = ($this->discord->getCollectionClass())::for(Component::class, null);
 
         foreach ($this->attributes['components'] ?? [] as $component) {
             $components->pushItem($this->createOf(Component::class, $component));

--- a/src/Discord/Parts/Interactions/Request/InteractionData.php
+++ b/src/Discord/Parts/Interactions/Request/InteractionData.php
@@ -11,7 +11,7 @@
 
 namespace Discord\Parts\Interactions\Request;
 
-use Discord\Helpers\Collection;
+use Discord\Helpers\CollectionInterface;
 use Discord\Parts\Interactions\Command\Command;
 use Discord\Parts\Part;
 
@@ -26,13 +26,13 @@ use Discord\Parts\Part;
  * @property string                      $name           Name of the invoked command.
  * @property int                         $type           The type of the invoked command.
  * @property Resolved|null               $resolved       Resolved users, members, roles and channels that are relevant.
- * @property Collection|Option[]|null    $options        Parameters and values from the user.
+ * @property CollectionInterface|Option[]|null    $options        Parameters and values from the user.
  * @property string|null                 $guild_id       ID of the guild internally passed from Interaction or ID of the guild the command belongs to.
  * @property string|null                 $target_id      ID the of user or message targeted by a user or message command.
  * @property string|null                 $custom_id      Custom ID the component was created for. (Only for Message Component & Modal)
  * @property int|null                    $component_type Type of the component. (Only for Message Component)
  * @property string[]|null               $values         Values selected in a select menu. (Only for Message Component)
- * @property Collection|Component[]|null $components     The values submitted by the user. (Only for Modal)
+ * @property CollectionInterface|Component[]|null $components     The values submitted by the user. (Only for Modal)
  */
 class InteractionData extends Part
 {
@@ -58,15 +58,15 @@ class InteractionData extends Part
     /**
      * Gets the options of the interaction.
      *
-     * @return Collection|Option[]|null $options
+     * @return CollectionInterfaceInterface|Option[]|null $options
      */
-    protected function getOptionsAttribute(): ?Collection
+    protected function getOptionsAttribute(): ?CollectionInterface
     {
         if (! isset($this->attributes['options']) && $this->type != Command::CHAT_INPUT) {
             return null;
         }
 
-        $options = Collection::for(Option::class, 'name');
+        $options = ($this->discord->getCollectionClass())::for(Option::class, 'name');
 
         foreach ($this->attributes['options'] ?? [] as $option) {
             $options->pushItem($this->createOf(Option::class, $option));
@@ -78,15 +78,15 @@ class InteractionData extends Part
     /**
      * Gets the components of the interaction.
      *
-     * @return Collection|Component[]|null $components
+     * @return CollectionInterfaceInterface|Component[]|null $components
      */
-    protected function getComponentsAttribute(): ?Collection
+    protected function getComponentsAttribute(): ?CollectionInterface
     {
         if (! isset($this->attributes['components'])) {
             return null;
         }
 
-        $components = Collection::for(Component::class, null);
+        $components = ($this->discord->getCollectionClass())::for(Component::class, null);
 
         foreach ($this->attributes['components'] as $component) {
             $components->pushItem($this->createOf(Component::class, $component));

--- a/src/Discord/Parts/Interactions/Request/Option.php
+++ b/src/Discord/Parts/Interactions/Request/Option.php
@@ -11,7 +11,7 @@
 
 namespace Discord\Parts\Interactions\Request;
 
-use Discord\Helpers\Collection;
+use Discord\Helpers\CollectionInterface;
 use Discord\Parts\Interactions\Command\Option as CommandOption;
 use Discord\Parts\Part;
 
@@ -25,7 +25,7 @@ use Discord\Parts\Part;
  * @property string                     $name    Name of the parameter.
  * @property int                        $type    Type of the option.
  * @property string|int|float|bool|null $value   Value of the option resulting from user input.
- * @property Collection|Option[]|null   $options Present if this option is a group or subcommand.
+ * @property CollectionInterface|Option[]|null   $options Present if this option is a group or subcommand.
  * @property bool|null                  $focused `true` if this option is the currently focused option for autocomplete.
  */
 class Option extends Part
@@ -44,15 +44,15 @@ class Option extends Part
     /**
      * Gets the options of the interaction.
      *
-     * @return Collection|Option[]|null $options
+     * @return CollectionInterfaceInterface|Option[]|null $options
      */
-    protected function getOptionsAttribute(): ?Collection
+    protected function getOptionsAttribute(): ?CollectionInterface
     {
         if (! isset($this->attributes['options']) && ! in_array($this->type, [CommandOption::SUB_COMMAND, CommandOption::SUB_COMMAND_GROUP])) {
             return null;
         }
 
-        $options = Collection::for(Option::class, 'name');
+        $options = ($this->discord->getCollectionClass())::for(Option::class, 'name');
 
         foreach ($this->attributes['options'] ?? [] as $option) {
             $options->pushItem($this->createOf(Option::class, $option));

--- a/src/Discord/Parts/Interactions/Request/Resolved.php
+++ b/src/Discord/Parts/Interactions/Request/Resolved.php
@@ -11,7 +11,7 @@
 
 namespace Discord\Parts\Interactions\Request;
 
-use Discord\Helpers\Collection;
+use Discord\Helpers\CollectionInterface;
 use Discord\Parts\Channel\Attachment;
 use Discord\Parts\Channel\Channel;
 use Discord\Parts\Channel\Message;
@@ -28,12 +28,12 @@ use Discord\Parts\User\User;
  *
  * @since 7.0.0
  *
- * @property Collection|User[]|null             $users       The ids and User objects.
- * @property Collection|Member[]|null           $members     The ids and partial Member objects.
- * @property Collection|Role[]|null             $roles       The ids and Role objects.
- * @property Collection|Channel[]|Thread[]|null $channels    The ids and partial Channel objects.
- * @property Collection|Message[]|null          $messages    The ids and partial Message objects.
- * @property Collection|Attachment[]|null       $attachments The ids and partial Attachment objects.
+ * @property CollectionInterface|User[]|null             $users       The ids and User objects.
+ * @property CollectionInterface|Member[]|null           $members     The ids and partial Member objects.
+ * @property CollectionInterface|Role[]|null             $roles       The ids and Role objects.
+ * @property CollectionInterface|Channel[]|Thread[]|null $channels    The ids and partial Channel objects.
+ * @property CollectionInterface|Message[]|null          $messages    The ids and partial Message objects.
+ * @property CollectionInterface|Attachment[]|null       $attachments The ids and partial Attachment objects.
  *
  * @property string|null $guild_id ID of the guild internally passed from Interaction.
  */
@@ -62,15 +62,15 @@ class Resolved extends Part
     /**
      * Returns a collection of resolved users.
      *
-     * @return Collection|User[]|null Map of Snowflakes to user objects
+     * @return CollectionInterfaceInterface|User[]|null Map of Snowflakes to user objects
      */
-    protected function getUsersAttribute(): ?Collection
+    protected function getUsersAttribute(): ?CollectionInterface
     {
         if (! isset($this->attributes['users'])) {
             return null;
         }
 
-        $collection = Collection::for(User::class);
+        $collection = ($this->discord->getCollectionClass())::for(User::class);
 
         foreach ($this->attributes['users'] as $snowflake => $user) {
             $collection->pushItem($this->discord->users->get('id', $snowflake) ?: $this->factory->part(User::class, (array) $user, true));
@@ -84,15 +84,15 @@ class Resolved extends Part
      *
      * Partial Member objects are missing user, deaf and mute fields
      *
-     * @return Collection|Member[]|null Map of Snowflakes to partial member objects
+     * @return CollectionInterfaceInterface|Member[]|null Map of Snowflakes to partial member objects
      */
-    protected function getMembersAttribute(): ?Collection
+    protected function getMembersAttribute(): ?CollectionInterface
     {
         if (! isset($this->attributes['members'])) {
             return null;
         }
 
-        $collection = Collection::for(Member::class);
+        $collection = ($this->discord->getCollectionClass())::for(Member::class);
 
         foreach ($this->attributes['members'] as $snowflake => $member) {
             if ($guild = $this->discord->guilds->get('id', $this->guild_id)) {
@@ -113,15 +113,15 @@ class Resolved extends Part
     /**
      * Returns a collection of resolved roles.
      *
-     * @return Collection|Role[]|null Map of Snowflakes to role objects
+     * @return CollectionInterfaceInterface|Role[]|null Map of Snowflakes to role objects
      */
-    protected function getRolesAttribute(): ?Collection
+    protected function getRolesAttribute(): ?CollectionInterface
     {
         if (! isset($this->attributes['roles'])) {
             return null;
         }
 
-        $collection = Collection::for(Role::class);
+        $collection = ($this->discord->getCollectionClass())::for(Role::class);
 
         foreach ($this->attributes['roles'] as $snowflake => $role) {
             if ($guild = $this->discord->guilds->get('id', $this->guild_id)) {
@@ -143,15 +143,15 @@ class Resolved extends Part
      *
      * Partial Channel objects only have id, name, type and permissions fields. Threads will also have thread_metadata and parent_id fields.
      *
-     * @return Collection|Channel[]|Thread[]|null Map of Snowflakes to partial channel objects
+     * @return CollectionInterfaceInterface|Channel[]|Thread[]|null Map of Snowflakes to partial channel objects
      */
-    protected function getChannelsAttribute(): ?Collection
+    protected function getChannelsAttribute(): ?CollectionInterface
     {
         if (! isset($this->attributes['channels'])) {
             return null;
         }
 
-        $collection = new Collection();
+        $collection = new ($this->discord->getCollectionClass())();
 
         foreach ($this->attributes['channels'] as $snowflake => $channel) {
             if ($guild = $this->discord->guilds->get('id', $this->guild_id)) {
@@ -175,15 +175,15 @@ class Resolved extends Part
     /**
      * Returns a collection of resolved messages.
      *
-     * @return Collection|Message[]|null Map of Snowflakes to partial messages objects
+     * @return CollectionInterfaceInterface|Message[]|null Map of Snowflakes to partial messages objects
      */
-    protected function getMessagesAttribute(): ?Collection
+    protected function getMessagesAttribute(): ?CollectionInterface
     {
         if (! isset($this->attributes['messages'])) {
             return null;
         }
 
-        $collection = Collection::for(Message::class);
+        $collection = ($this->discord->getCollectionClass())::for(Message::class);
 
         foreach ($this->attributes['messages'] as $snowflake => $message) {
             if ($guild = $this->discord->guilds->get('id', $this->guild_id)) {
@@ -201,15 +201,15 @@ class Resolved extends Part
     /**
      * Returns a collection of resolved attachments.
      *
-     * @return Collection|Attachment[]|null Map of Snowflakes to attachments objects
+     * @return CollectionInterfaceInterface|Attachment[]|null Map of Snowflakes to attachments objects
      */
-    protected function getAttachmentsAttribute(): ?Collection
+    protected function getAttachmentsAttribute(): ?CollectionInterface
     {
         if (! isset($this->attributes['attachments'])) {
             return null;
         }
 
-        $attachments = Collection::for(Attachment::class);
+        $attachments = ($this->discord->getCollectionClass())::for(Attachment::class);
 
         foreach ($this->attributes['attachments'] as $attachment) {
             $attachments->pushItem($this->factory->part(Attachment::class, (array) $attachment, true));

--- a/src/Discord/Parts/Thread/Thread.php
+++ b/src/Discord/Parts/Thread/Thread.php
@@ -13,7 +13,7 @@ namespace Discord\Parts\Thread;
 
 use Carbon\Carbon;
 use Discord\Builders\MessageBuilder;
-use Discord\Helpers\Collection;
+use Discord\Helpers\CollectionInterface;
 use Discord\Http\Endpoint;
 use Discord\Http\Exceptions\NoPermissionsException;
 use Discord\Parts\Channel\Channel;
@@ -462,7 +462,7 @@ class Thread extends Part implements Stringable
      *
      * @link https://discord.com/developers/docs/resources/channel#get-pinned-messages
      *
-     * @return PromiseInterface<Collection<Message[]>>
+     * @return PromiseInterface<CollectionInterface<Message[]>>
      *
      * @todo Make it in a trait along with Channel
      */
@@ -470,7 +470,7 @@ class Thread extends Part implements Stringable
     {
         return $this->http->get(Endpoint::bind(Endpoint::CHANNEL_PINS, $this->id))
             ->then(function ($responses) {
-                $messages = Collection::for(Message::class);
+                $messages = ($this->discord->getCollectionClass())::for(Message::class);
 
                 foreach ($responses as $response) {
                     $messages->pushItem($this->messages->get('id', $response->id) ?: $this->messages->create($response, true));
@@ -546,7 +546,7 @@ class Thread extends Part implements Stringable
      * @param string|Message|null $options['after']  Get messages after this message ID.
      * @param int|null            $options['limit']  Max number of messages to return (1-100). Defaults to 50.
      *
-     * @return PromiseInterface<Collection<Message[]>>
+     * @return PromiseInterface<CollectionInterface<Message[]>>
      *
      * @todo Make it in a trait along with Channel
      */
@@ -586,7 +586,7 @@ class Thread extends Part implements Stringable
         }
 
         return $this->http->get($endpoint)->then(function ($responses) {
-            $messages = Collection::for(Message::class);
+            $messages = ($this->discord->getCollectionClass())::for(Message::class);
 
             foreach ($responses as $response) {
                 if (! $message = $this->messages->get('id', $response->id)) {
@@ -770,14 +770,14 @@ class Thread extends Part implements Stringable
      * @param int      $options ['time']  Time in milliseconds until the collector finishes or false.
      * @param int      $options ['limit'] The amount of messages allowed or false.
      *
-     * @return PromiseInterface<Collection<Message[]>>
+     * @return PromiseInterface<CollectionInterface<Message[]>>
      *
      * @todo Make it in a trait along with Channel
      */
     public function createMessageCollector(callable $filter, array $options = []): PromiseInterface
     {
         $deferred = new Deferred();
-        $messages = new Collection([], null, null);
+        $messages = new ($this->discord->getCollectionClass())([], null, null);
         $timer = null;
 
         $options = array_merge([

--- a/src/Discord/Parts/User/Member.php
+++ b/src/Discord/Parts/User/Member.php
@@ -14,7 +14,7 @@ namespace Discord\Parts\User;
 use Carbon\Carbon;
 use Discord\Builders\MessageBuilder;
 use Discord\Helpers\BigInt;
-use Discord\Helpers\Collection;
+use Discord\Helpers\CollectionInterface;
 use Discord\Http\Endpoint;
 use Discord\Http\Exceptions\NoPermissionsException;
 use Discord\Parts\Channel\Channel;
@@ -46,7 +46,7 @@ use function React\Promise\reject;
  * @property-read string              $displayname                  The nickname or display name with optional discriminator of the member.
  * @property      ?string|null        $avatar                       The avatar URL of the member or null if member has no guild avatar.
  * @property      ?string|null        $avatar_hash                  The avatar hash of the member or null if member has no guild avatar.
- * @property      Collection|Role[]   $roles                        A collection of Roles that the member has.
+ * @property      CollectionInterface|Role[]   $roles                        A collection of Roles that the member has.
  * @property      Carbon|null         $joined_at                    A timestamp of when the member joined the guild.
  * @property      Carbon|null         $premium_since                When the user started boosting the server.
  * @property      bool                $deaf                         Whether the member is deaf.
@@ -61,7 +61,7 @@ use function React\Promise\reject;
  * @property      string                $id            The unique identifier of the member.
  * @property      string                $status        The status of the member.
  * @property-read Activity              $game          The game the member is playing.
- * @property      Collection|Activity[] $activities    User's current activities.
+ * @property      CollectionInterface|Activity[] $activities    User's current activities.
  * @property      object                $client_status Current client status.
  *
  * @method PromiseInterface<Message> sendMessage(MessageBuilder $builder)
@@ -609,11 +609,11 @@ class Member extends Part implements Stringable
     /**
      * Gets the activities attribute.
      *
-     * @return Collection|Activity[]
+     * @return CollectionInterfaceInterface|Activity[]
      */
-    protected function getActivitiesAttribute(): Collection
+    protected function getActivitiesAttribute(): CollectionInterface
     {
-        $activities = Collection::for(Activity::class, null);
+        $activities = ($this->discord->getCollectionClass())::for(Activity::class, null);
 
         foreach ($this->attributes['activities'] ?? [] as $activity) {
             $activities->pushItem($this->createOf(Activity::class, $activity));
@@ -685,11 +685,11 @@ class Member extends Part implements Stringable
     /**
      * Returns the roles attribute.
      *
-     * @return Collection<?Role> A collection of roles the member is in. null role only contains ID in the collection.
+     * @return CollectionInterfaceInterface<?Role> A collection of roles the member is in. null role only contains ID in the collection.
      */
-    protected function getRolesAttribute(): Collection
+    protected function getRolesAttribute(): CollectionInterface
     {
-        $roles = new Collection();
+        $roles = new ($this->discord->getCollectionClass())();
 
         if (empty($this->attributes['roles'])) {
             return $roles;

--- a/src/Discord/Parts/WebSockets/PresenceUpdate.php
+++ b/src/Discord/Parts/WebSockets/PresenceUpdate.php
@@ -11,7 +11,7 @@
 
 namespace Discord\Parts\WebSockets;
 
-use Discord\Helpers\Collection;
+use Discord\Helpers\CollectionInterface;
 use Discord\Parts\Guild\Guild;
 use Discord\Parts\Guild\Role;
 use Discord\Parts\Part;
@@ -32,7 +32,7 @@ use Discord\Parts\User\User;
  * @property      string                $guild_id       The unique identifier of the guild that the presence update affects.
  * @property-read Guild|null            $guild          The guild that the presence update affects.
  * @property      string                $status         The updated status of the user.
- * @property      Collection|Activity[] $activities     The activities of the user.
+ * @property      CollectionInterface|Activity[] $activities     The activities of the user.
  * @property-read Activity              $game           The updated game of the user.
  * @property      object                $client_status  Status of the client.
  * @property      string|null           $desktop_status Status of the user on their desktop client. Null if they are not active on desktop.
@@ -40,7 +40,7 @@ use Discord\Parts\User\User;
  * @property      string|null           $web_status     Status of the user on their web client. Null if they are not active on web.
  *
  * @property-read Member            $member The member that the presence update affects.
- * @property-read Collection|Role[] $roles  Roles that the user has in the guild.
+ * @property-read CollectionInterface|Role[] $roles  Roles that the user has in the guild.
  */
 class PresenceUpdate extends Part
 {
@@ -93,11 +93,11 @@ class PresenceUpdate extends Part
     /**
      * Gets the activities attribute.
      *
-     * @return Collection|Activity[]
+     * @return CollectionInterfaceInterface|Activity[]
      */
-    protected function getActivitiesAttribute(): Collection
+    protected function getActivitiesAttribute(): CollectionInterface
     {
-        $collection = Collection::for(Activity::class, null);
+        $collection = ($this->discord->getCollectionClass())::for(Activity::class, null);
 
         foreach ($this->attributes['activities'] ?? [] as $activity) {
             $collection->pushItem($this->factory->part(Activity::class, (array) $activity, true));
@@ -163,14 +163,14 @@ class PresenceUpdate extends Part
     /**
      * Returns the users roles.
      *
-     * @return Collection|Role[]
+     * @return CollectionInterfaceInterface|Role[]
      */
-    protected function getRolesAttribute(): Collection
+    protected function getRolesAttribute(): CollectionInterface
     {
         if ($member = $this->member) {
             return $member->roles;
         }
 
-        return Collection::for(Role::class);
+        return ($this->discord->getCollectionClass())::for(Role::class);
     }
 }

--- a/src/Discord/Repository/AbstractRepository.php
+++ b/src/Discord/Repository/AbstractRepository.php
@@ -14,7 +14,8 @@ namespace Discord\Repository;
 use Discord\Discord;
 use Discord\Factory\Factory;
 use Discord\Helpers\CacheWrapper;
-use Discord\Helpers\Collection;
+use Discord\Helpers\CollectionInterface;
+use Discord\Helpers\CollectionTrait;
 use Discord\Helpers\LegacyCacheWrapper;
 use Discord\Http\Endpoint;
 use Discord\Http\Http;
@@ -38,8 +39,9 @@ use function React\Promise\resolve;
  * @property      string       $discrim The discriminator.
  * @property-read CacheWrapper $cache   The react/cache wrapper.
  */
-abstract class AbstractRepository extends Collection
+abstract class AbstractRepository implements CollectionInterface
 {
+    use CollectionTrait;
     /**
      * The discriminator.
      *
@@ -553,16 +555,16 @@ abstract class AbstractRepository extends Collection
     }
 
     /**
-     * Runs a filter callback over the repository and returns a new collection
+     * Runs a filter callback over the repository and returns a new ($this->discord->getCollectionClass())
      * based on the response of the callback.
      *
      * @param callable $callback
      *
-     * @return Collection
+     * @return CollectionInterface
      */
-    public function filter(callable $callback): Collection
+    public function filter(callable $callback): CollectionInterface
     {
-        $collection = new Collection([], $this->discrim, $this->class);
+        $collection = new ($this->discord->getCollectionClass())([], $this->discrim, $this->class);
 
         foreach ($this->items as $offset => $item) {
             if ($item instanceof WeakReference) {

--- a/src/Discord/Repository/Channel/ThreadRepository.php
+++ b/src/Discord/Repository/Channel/ThreadRepository.php
@@ -11,7 +11,7 @@
 
 namespace Discord\Repository\Channel;
 
-use Discord\Helpers\Collection;
+use Discord\Helpers\CollectionInterface;
 use Discord\Http\Endpoint;
 use Discord\Parts\Thread\Thread;
 use Discord\Repository\AbstractRepository;
@@ -87,7 +87,7 @@ class ThreadRepository extends AbstractRepository
      *
      * @link https://discord.com/developers/docs/resources/channel#list-active-threads
      *
-     * @return PromiseInterface<Collection<Thread[]>>
+     * @return PromiseInterface<CollectionInterface<Thread[]>>
      */
     public function active(): PromiseInterface
     {
@@ -109,7 +109,7 @@ class ThreadRepository extends AbstractRepository
      *
      * @throws \InvalidArgumentException
      *
-     * @return PromiseInterface<Collection<Thread[]>>
+     * @return PromiseInterface<CollectionInterface<Thread[]>>
      */
     public function archived(bool $private = false, bool $joined = false, ?int $limit = null, $before = null): PromiseInterface
     {
@@ -150,11 +150,11 @@ class ThreadRepository extends AbstractRepository
      *
      * @param object $response
      *
-     * @return Collection|Thread[]
+     * @return CollectionInterfaceInterface|Thread[]
      */
-    private function handleThreadPaginationResponse(object $response): Collection
+    private function handleThreadPaginationResponse(object $response): CollectionInterface
     {
-        $collection = Collection::for(Thread::class);
+        $collection = ($this->discord->getCollectionClass())::for(Thread::class);
 
         foreach ($response->threads as $thread) {
             /** @var Thread */

--- a/src/Discord/Voice/VoiceClient.php
+++ b/src/Discord/Voice/VoiceClient.php
@@ -16,7 +16,7 @@ use Discord\Exceptions\FileNotFoundException;
 use Discord\Exceptions\LibSodiumNotFoundException;
 use Discord\Exceptions\OutdatedDCAException;
 use Discord\Helpers\Buffer as RealBuffer;
-use Discord\Helpers\Collection;
+use Discord\Helpers\CollectionInterface;
 use Discord\Parts\Channel\Channel;
 use Discord\WebSockets\Op;
 use Evenement\EventEmitter;
@@ -371,7 +371,7 @@ class VoiceClient extends EventEmitter
         $this->deaf = $data['deaf'];
         $this->mute = $data['mute'];
         $this->endpoint = str_replace([':80', ':443'], '', $data['endpoint']);
-        $this->speakingStatus = new Collection([], 'ssrc');
+        $this->speakingStatus = new ($this->discord->getCollectionClass())([], 'ssrc');
         $this->dnsConfig = $data['dnsConfig'];
     }
 
@@ -1341,7 +1341,7 @@ class VoiceClient extends EventEmitter
         $this->sentLoginFrame = false;
         $this->startTime = null;
         $this->streamTime = 0;
-        $this->speakingStatus = new Collection([], 'ssrc');
+        $this->speakingStatus = new ($this->discord->getCollectionClass())([], 'ssrc');
 
         $this->emit('close');
     }

--- a/src/Discord/WebSockets/Events/GuildEmojisUpdate.php
+++ b/src/Discord/WebSockets/Events/GuildEmojisUpdate.php
@@ -11,7 +11,7 @@
 
 namespace Discord\WebSockets\Events;
 
-use Discord\Helpers\Collection;
+use Discord\Helpers\CollectionInterface;
 use Discord\WebSockets\Event;
 use Discord\Parts\Guild\Emoji;
 use Discord\Parts\Guild\Guild;
@@ -28,8 +28,8 @@ class GuildEmojisUpdate extends Event
      */
     public function handle($data)
     {
-        $oldEmojis = Collection::for(Emoji::class);
-        $emojiParts = Collection::for(Emoji::class);
+        $oldEmojis = ($this->discord->getCollectionClass())::for(Emoji::class);
+        $emojiParts = ($this->discord->getCollectionClass())::for(Emoji::class);
 
         /** @var ?Guild */
         if ($guild = yield $this->discord->guilds->cacheGet($data->guild_id)) {

--- a/src/Discord/WebSockets/Events/GuildStickersUpdate.php
+++ b/src/Discord/WebSockets/Events/GuildStickersUpdate.php
@@ -11,7 +11,7 @@
 
 namespace Discord\WebSockets\Events;
 
-use Discord\Helpers\Collection;
+use Discord\Helpers\CollectionInterface;
 use Discord\WebSockets\Event;
 use Discord\Parts\Guild\Guild;
 use Discord\Parts\Guild\Sticker;
@@ -28,8 +28,8 @@ class GuildStickersUpdate extends Event
      */
     public function handle($data)
     {
-        $oldStickers = Collection::for(Sticker::class);
-        $stickerParts = Collection::for(Sticker::class);
+        $oldStickers = ($this->discord->getCollectionClass())::for(Sticker::class);
+        $stickerParts = ($this->discord->getCollectionClass())::for(Sticker::class);
 
         /** @var ?Guild */
         if ($guild = yield $this->discord->guilds->cacheGet($data->guild_id)) {

--- a/src/Discord/WebSockets/Events/MessageDeleteBulk.php
+++ b/src/Discord/WebSockets/Events/MessageDeleteBulk.php
@@ -11,7 +11,7 @@
 
 namespace Discord\WebSockets\Events;
 
-use Discord\Helpers\Collection;
+use Discord\Helpers\CollectionInterface;
 use Discord\WebSockets\Event;
 
 /**
@@ -26,7 +26,7 @@ class MessageDeleteBulk extends Event
      */
     public function handle($data)
     {
-        $resolved = new Collection();
+        $resolved = new ($this->discord->getCollectionClass())();
 
         foreach ($data->ids as $id) {
             $event = new MessageDelete($this->discord);

--- a/src/Discord/WebSockets/Events/ThreadListSync.php
+++ b/src/Discord/WebSockets/Events/ThreadListSync.php
@@ -11,7 +11,7 @@
 
 namespace Discord\WebSockets\Events;
 
-use Discord\Helpers\Collection;
+use Discord\Helpers\CollectionInterface;
 use Discord\Parts\Channel\Channel;
 use Discord\Parts\Guild\Guild;
 use Discord\Parts\Thread\Thread;
@@ -26,7 +26,7 @@ class ThreadListSync extends Event
 {
     public function handle($data)
     {
-        $threadParts = Collection::for(Thread::class);
+        $threadParts = ($this->discord->getCollectionClass())::for(Thread::class);
 
         /** @var ?Guild */
         if ($guild = yield $this->discord->guilds->cacheGet($data->guild_id)) {

--- a/tests/Parts/Channel/ChannelTest.php
+++ b/tests/Parts/Channel/ChannelTest.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 use Discord\Builders\MessageBuilder;
 use Discord\Discord;
-use Discord\Helpers\Collection;
+use Discord\Helpers\CollectionInterface;
 use Discord\Parts\Channel\Channel;
 use Discord\Parts\Channel\Message;
 use Discord\Parts\Channel\Invite;

--- a/tests/Parts/Channel/Message/EmptyMessageTest.php
+++ b/tests/Parts/Channel/Message/EmptyMessageTest.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 use Carbon\Carbon;
 use Discord\Discord;
-use Discord\Helpers\Collection;
+use Discord\Helpers\CollectionInterface;
 use Discord\Parts\Channel\Channel;
 use Discord\Parts\Channel\Message;
 use Discord\Parts\Embed\Embed;


### PR DESCRIPTION
The main singleton object now includes a new `getCollectionClass` method to centralize the collection class logic. Parts of the library that previously used the hardcoded Collection class now dynamically retrieve the appropriate class via the getCollectionClass method.