### PR TITLE
Update SelectMenu.php

### DIFF
--- a/src/Discord/Builders/Components/Button.php
+++ b/src/Discord/Builders/Components/Button.php
@@ -335,13 +335,7 @@ class Button extends Component
         $this->listener = function (Interaction $interaction) use ($callback, $oneOff) {
             if ($interaction->data->component_type == Component::TYPE_BUTTON && $interaction->data->custom_id == $this->custom_id) {
                 $response = $callback($interaction);
-                $ack = function () use ($interaction) {
-                    // attempt to acknowledge interaction if it has not already been responded to.
-                    try {
-                        $interaction->acknowledge();
-                    } catch (\Exception $e) {
-                    }
-                };
+                $ack = fn() => $interaction->isResponded() ?: $interaction->acknowledge();
 
                 if ($response instanceof PromiseInterface) {
                     $response->then($ack);

--- a/src/Discord/Builders/Components/SelectMenu.php
+++ b/src/Discord/Builders/Components/SelectMenu.php
@@ -361,11 +361,7 @@ abstract class SelectMenu extends Component
                     $response = $callback($interaction, $options);
                 }
 
-                $ack = static function () use ($interaction) {
-                    if(!$interaction->isResponded()){
-                        $interaction->acknowledge();
-                    }
-                };
+                $ack = fn() => $interaction->isResponded() ?: $interaction->acknowledge();
 
                 if ($response instanceof PromiseInterface) {
                     $response->then($ack);

--- a/src/Discord/Builders/Components/SelectMenu.php
+++ b/src/Discord/Builders/Components/SelectMenu.php
@@ -360,7 +360,6 @@ abstract class SelectMenu extends Component
 
                     $response = $callback($interaction, $options);
                 }
-
                 $ack = fn() => $interaction->isResponded() ?: $interaction->acknowledge();
 
                 if ($response instanceof PromiseInterface) {

--- a/src/Discord/Builders/Components/SelectMenu.php
+++ b/src/Discord/Builders/Components/SelectMenu.php
@@ -360,11 +360,10 @@ abstract class SelectMenu extends Component
 
                     $response = $callback($interaction, $options);
                 }
-                $ack = function () use ($interaction) {
-                    // attempt to acknowledge interaction if it has not already been responded to.
-                    try {
+
+                $ack = static function () use ($interaction) {
+                    if(!$interaction->isResponded()){
                         $interaction->acknowledge();
-                    } catch (\Exception $e) {
                     }
                 };
 


### PR DESCRIPTION
Just a small fix for auto-responding in a Select Menu interaction.

When I have an interaction that I have already responded in listener, `SelectMenu` code doesn't care about it, it calls `$ack` function anyway.

I do not change how it is called, but I think it should check if an interaction was responded before, before trying to `acknowledge` it.