### PR TITLE
✨ Add `sort` method to Collections

### DIFF
--- a/src/Discord/Helpers/CollectionInterface.php
+++ b/src/Discord/Helpers/CollectionInterface.php
@@ -33,7 +33,7 @@ interface CollectionInterface extends ArrayAccess, JsonSerializable, IteratorAgg
     public function filter(callable $callback);
     public function find(callable $callback);
     public function clear(): void;
-    public function sort(callable $callback): static;
+    public function sort(callable|int|null $callback): static;
     public function map(callable $callback);
     public function merge($collection): self;
     public function toArray();

--- a/src/Discord/Helpers/CollectionInterface.php
+++ b/src/Discord/Helpers/CollectionInterface.php
@@ -33,7 +33,7 @@ interface CollectionInterface extends ArrayAccess, JsonSerializable, IteratorAgg
     public function filter(callable $callback);
     public function find(callable $callback);
     public function clear(): void;
-    public function sort(callable|int|null $callback): static;
+    public function sort(callable|int|null $callback);
     public function map(callable $callback);
     public function merge($collection): self;
     public function toArray();

--- a/src/Discord/Helpers/CollectionInterface.php
+++ b/src/Discord/Helpers/CollectionInterface.php
@@ -33,7 +33,7 @@ interface CollectionInterface extends ArrayAccess, JsonSerializable, IteratorAgg
     public function filter(callable $callback);
     public function find(callable $callback);
     public function clear(): void;
-    public function uasort(callable $callback): true;
+    public function sort(callable $callback): true;
     public function map(callable $callback);
     public function merge($collection): self;
     public function toArray();

--- a/src/Discord/Helpers/CollectionInterface.php
+++ b/src/Discord/Helpers/CollectionInterface.php
@@ -33,7 +33,7 @@ interface CollectionInterface extends ArrayAccess, JsonSerializable, IteratorAgg
     public function filter(callable $callback);
     public function find(callable $callback);
     public function clear(): void;
-    public function sort(callable $callback): true;
+    public function sort(callable $callback): static;
     public function map(callable $callback);
     public function merge($collection): self;
     public function toArray();

--- a/src/Discord/Helpers/CollectionInterface.php
+++ b/src/Discord/Helpers/CollectionInterface.php
@@ -33,6 +33,7 @@ interface CollectionInterface extends ArrayAccess, JsonSerializable, IteratorAgg
     public function filter(callable $callback);
     public function find(callable $callback);
     public function clear(): void;
+    public function uasort(callable $callback): true;
     public function map(callable $callback);
     public function merge($collection): self;
     public function toArray();

--- a/src/Discord/Helpers/CollectionTrait.php
+++ b/src/Discord/Helpers/CollectionTrait.php
@@ -295,6 +295,11 @@ trait CollectionTrait
         $this->items = [];
     }
 
+    public function uasort(callable $callback): true
+    {
+        return uasort($this->items, $callback);
+    }
+
     /**
      * Runs a callback over the collection and creates a new static.
      *

--- a/src/Discord/Helpers/CollectionTrait.php
+++ b/src/Discord/Helpers/CollectionTrait.php
@@ -295,9 +295,22 @@ trait CollectionTrait
         $this->items = [];
     }
 
-    public function uasort(callable $callback): true
+    /**
+     * Sort through each item with a callback.
+     *
+     * @param callable|int|null $callback
+     *
+     * @return static
+     */
+    public function sort(callable|int|null $callback): static
     {
-        return uasort($this->items, $callback);
+        $items = $this->items;
+
+        $callback && is_callable($callback)
+            ? uasort($items, $callback)
+            : asort($items, $callback ?? SORT_REGULAR);
+
+        return new static($items, $this->discrim, $this->class);
     }
 
     /**


### PR DESCRIPTION
This pull request introduces a new sorting functionality to the `CollectionInterface` and `CollectionTrait` in the `src/Discord/Helpers` directory. The most important changes include the addition of a `sort` method, which allows sorting of collection items using a callback or predefined sorting order.

New sorting functionality:

* [`src/Discord/Helpers/CollectionInterface.php`](diffhunk://#diff-e03abf0b08dbf335e90b013afb96b1b6aff3d0b55a391ea2bbc140a53878e644R36): Added the `sort` method declaration to the interface, allowing collections to be sorted using a callback or an integer sorting flag.
* [`src/Discord/Helpers/CollectionTrait.php`](diffhunk://#diff-58ec4730828594c785b2e9eb266da740546bd89607b20bc1b73ce2f526045b05R298-R315): Implemented the `sort` method, which sorts the items in the collection using a provided callback or a default sorting order if no callback is provided.