### PR TITLE
Collection enhancements

### DIFF
--- a/src/Discord/Helpers/CollectionInterface.php
+++ b/src/Discord/Helpers/CollectionInterface.php
@@ -46,7 +46,7 @@ interface CollectionInterface extends ArrayAccess, JsonSerializable, IteratorAgg
     public function values(): array;
     public function diff($items, ?callable $callback);
     public function intersect($items, ?callable $callback);
-    public function unique(int $flags = SORT_STRING)
+    public function unique(int $flags = SORT_STRING);
     public function offsetExists($offset): bool;
     #[\ReturnTypeWillChange]
     public function offsetGet($offset);

--- a/src/Discord/Helpers/CollectionInterface.php
+++ b/src/Discord/Helpers/CollectionInterface.php
@@ -55,7 +55,7 @@ interface CollectionInterface extends ArrayAccess, JsonSerializable, IteratorAgg
     public function serialize(int $flags = 0, ?int $depth = 512): string;
     public function __serialize(): array;
     public function unserialize(string $serialized): void;
-    public function __unserialize(array $data): void;
+    public function __unserialize($data): void;
     public function jsonSerialize(): array;
     public function getIterator(): Traversable;
     public function __debugInfo(): array;

--- a/src/Discord/Helpers/CollectionInterface.php
+++ b/src/Discord/Helpers/CollectionInterface.php
@@ -23,7 +23,7 @@ interface CollectionInterface extends ArrayAccess, JsonSerializable, IteratorAgg
     public function set($offset, $value);
     public function pull($key, $default = null);
     public function shift();
-    public function fill(array $items): self;
+    public function fill($items): self;
     public function push(...$items): self;
     public function pushItem($item): self;
     public function count(): int;

--- a/src/Discord/Helpers/CollectionInterface.php
+++ b/src/Discord/Helpers/CollectionInterface.php
@@ -45,6 +45,7 @@ interface CollectionInterface extends ArrayAccess, JsonSerializable, IteratorAgg
     public function keys(): array;
     public function values(): array;
     public function diff($items, ?callable $callback);
+    public function intersect($items, ?callable $callback);
     public function offsetExists($offset): bool;
     #[\ReturnTypeWillChange]
     public function offsetGet($offset);

--- a/src/Discord/Helpers/CollectionInterface.php
+++ b/src/Discord/Helpers/CollectionInterface.php
@@ -42,6 +42,7 @@ interface CollectionInterface extends ArrayAccess, JsonSerializable, IteratorAgg
     public function toArray();
     public function keys(): array;
     public function values(): array;
+    public function diff(): array;
     public function offsetExists($offset): bool;
     #[\ReturnTypeWillChange]
     public function offsetGet($offset);

--- a/src/Discord/Helpers/CollectionInterface.php
+++ b/src/Discord/Helpers/CollectionInterface.php
@@ -44,7 +44,7 @@ interface CollectionInterface extends ArrayAccess, JsonSerializable, IteratorAgg
     public function collect();
     public function keys(): array;
     public function values(): array;
-    public function diff(): array;
+    public function diff($items, ?callable $callback);
     public function offsetExists($offset): bool;
     #[\ReturnTypeWillChange]
     public function offsetGet($offset);

--- a/src/Discord/Helpers/CollectionInterface.php
+++ b/src/Discord/Helpers/CollectionInterface.php
@@ -46,6 +46,7 @@ interface CollectionInterface extends ArrayAccess, JsonSerializable, IteratorAgg
     public function values(): array;
     public function diff($items, ?callable $callback);
     public function intersect($items, ?callable $callback);
+    public function unique(int $flags = SORT_STRING)
     public function offsetExists($offset): bool;
     #[\ReturnTypeWillChange]
     public function offsetGet($offset);

--- a/src/Discord/Helpers/CollectionInterface.php
+++ b/src/Discord/Helpers/CollectionInterface.php
@@ -22,6 +22,7 @@ interface CollectionInterface extends ArrayAccess, JsonSerializable, IteratorAgg
     public function get(string $discrim, $key);
     public function set($offset, $value);
     public function pull($key, $default = null);
+    public function shift();
     public function fill(array $items): self;
     public function push(...$items): self;
     public function pushItem($item): self;

--- a/src/Discord/Helpers/CollectionInterface.php
+++ b/src/Discord/Helpers/CollectionInterface.php
@@ -41,6 +41,7 @@ interface CollectionInterface extends ArrayAccess, JsonSerializable, IteratorAgg
     public function map(callable $callback);
     public function merge($collection): self;
     public function toArray();
+    public function collect();
     public function keys(): array;
     public function values(): array;
     public function diff(): array;

--- a/src/Discord/Helpers/CollectionInterface.php
+++ b/src/Discord/Helpers/CollectionInterface.php
@@ -38,6 +38,8 @@ interface CollectionInterface extends ArrayAccess, JsonSerializable, IteratorAgg
     public function map(callable $callback);
     public function merge($collection): self;
     public function toArray();
+    public function keys(): array;
+    public function values(): array;
     public function offsetExists($offset): bool;
     #[\ReturnTypeWillChange]
     public function offsetGet($offset);

--- a/src/Discord/Helpers/CollectionInterface.php
+++ b/src/Discord/Helpers/CollectionInterface.php
@@ -35,6 +35,7 @@ interface CollectionInterface extends ArrayAccess, JsonSerializable, IteratorAgg
     public function clear(): void;
     public function slice(int $offset, ?int $length, bool $preserve_keys = false);
     public function sort(callable|int|null $callback);
+    public function reduce(callable $callback, $initial = null);
     public function map(callable $callback);
     public function merge($collection): self;
     public function toArray();

--- a/src/Discord/Helpers/CollectionInterface.php
+++ b/src/Discord/Helpers/CollectionInterface.php
@@ -35,6 +35,7 @@ interface CollectionInterface extends ArrayAccess, JsonSerializable, IteratorAgg
     public function clear(): void;
     public function slice(int $offset, ?int $length, bool $preserve_keys = false);
     public function sort(callable|int|null $callback);
+    public function walk(callable $callback, mixed $arg);
     public function reduce(callable $callback, $initial = null);
     public function map(callable $callback);
     public function merge($collection): self;

--- a/src/Discord/Helpers/CollectionTrait.php
+++ b/src/Discord/Helpers/CollectionTrait.php
@@ -467,7 +467,11 @@ trait CollectionTrait
      */
     public function merge($collection): self
     {
-        $this->items = array_merge($this->items, $collection->toArray());
+        $items = $collection instanceof CollectionInterface
+            ? $collection->toArray()
+            : $collection;
+
+        $this->items = array_merge($this->items, $items);
 
         return $this;
     }

--- a/src/Discord/Helpers/CollectionTrait.php
+++ b/src/Discord/Helpers/CollectionTrait.php
@@ -18,7 +18,7 @@ trait CollectionTrait
      *
      * @param array       $items
      * @param ?string     $discrim
-     * @param string|null $class
+     * @param ?string     $class
      */
     public function __construct(array $items = [], ?string $discrim = 'id', ?string $class = null)
     {
@@ -32,7 +32,7 @@ trait CollectionTrait
      *
      * @param array       $items
      * @param ?string     $discrim
-     * @param string|null $class
+     * @param ?string     $class
      *
      * @return static
      */
@@ -298,8 +298,8 @@ trait CollectionTrait
     /**
      * Slices the collection.
      *
-     * @param int $offset
-     * @param null|int $length
+     * @param int  $offset
+     * @param ?int $length
      * @param bool $preserve_keys
      *
      * @return CollectionInterface
@@ -327,6 +327,32 @@ trait CollectionTrait
         $callback && is_callable($callback)
             ? uasort($items, $callback)
             : asort($items, $callback ?? SORT_REGULAR);
+
+        return new Collection($items, $this->discrim, $this->class);
+    }
+
+    /**
+     * Computes the difference between the current collection and the given array.
+     *
+     * If a callback is provided and is callable, it uses `array_udiff_assoc` to compute the difference.
+     * Otherwise, it uses `array_diff`.
+     *
+     * @param CollectionInterface|array $array
+     * @param ?callable         $callback
+     *
+     * @return CollectionInterface
+     */
+    public function diff($array, ?callable $callback)
+    {
+        $array = $array instanceof CollectionInterface
+            ? $array->toArray()
+            : $array;
+
+        $items = $this->items;
+
+        $callback && is_callable($callback)
+            ? array_udiff_assoc($items, $array, $callback)
+            : array_diff($items, $array);
 
         return new Collection($items, $this->discrim, $this->class);
     }

--- a/src/Discord/Helpers/CollectionTrait.php
+++ b/src/Discord/Helpers/CollectionTrait.php
@@ -342,19 +342,35 @@ trait CollectionTrait
      *
      * @return CollectionInterface
      */
-    public function diff($array, ?callable $callback)
+    public function diff($items, ?callable $callback)
     {
-        $array = $array instanceof CollectionInterface
-            ? $array->toArray()
-            : $array;
+        $items = $items instanceof CollectionInterface
+            ? $items->toArray()
+            : $items;
 
-        $items = $this->items;
+        $diff = $callback && is_callable($callback)
+            ? array_udiff_assoc($this->items, $items, $callback)
+            : array_diff($this->items, $items);
 
-        $callback && is_callable($callback)
-            ? array_udiff_assoc($items, $array, $callback)
-            : array_diff($items, $array);
+        return new Collection($diff, $this->discrim, $this->class);
+    }
 
-        return new Collection($items, $this->discrim, $this->class);
+    /**
+     * Gets the intersection of the items.
+     *
+     * @param CollectionInterface|array $array
+     *
+     * @return CollectionInterface
+     */
+    public function intersect($items)
+    {
+        $items = $items instanceof CollectionInterface
+            ? $items->toArray()
+            : $items;
+
+        $diff = array_intersect($this->items, $items);
+
+        return new Collection($diff, $this->discrim, $this->class);
     }
 
     /**

--- a/src/Discord/Helpers/CollectionTrait.php
+++ b/src/Discord/Helpers/CollectionTrait.php
@@ -146,6 +146,7 @@ trait CollectionTrait
         if (! is_array($items)) {
             throw new \InvalidArgumentException('The fill method only accepts arrays or CollectionInterface instances.');
         }
+
         foreach ($items as $item) {
             $this->pushItem($item);
         }
@@ -606,10 +607,17 @@ trait CollectionTrait
     /**
      * Unserializes the collection.
      *
-     * @param array $data
+     * @param CollectionInterface|array $data
      */
-    public function __unserialize(array $data): void
+    public function __unserialize($data): void
     {
+        if ($data instanceof CollectionInterface) {
+            $data = $data->toArray();
+        }
+        if (! is_array($data)) {
+            throw new \InvalidArgumentException('The __unserialize method only accepts arrays or CollectionInterface instances.');
+        }
+
         $this->items = $data;
     }
 

--- a/src/Discord/Helpers/CollectionTrait.php
+++ b/src/Discord/Helpers/CollectionTrait.php
@@ -332,6 +332,23 @@ trait CollectionTrait
     }
 
     /**
+     * Applies the given callback function to each item in the collection.
+     *
+     * @param callable $callback
+     * @param mixed    $arg
+     *
+     * @return CollectionInterface
+     */
+    public function walk(callable $callback, mixed $arg)
+    {
+        $items = $this->items;
+
+        array_walk($items, $callback, $arg);
+
+        return new Collection($items, $this->discrim, $this->class);
+    }
+
+    /**
      * Reduces the collection to a single value using a callback function.
      *
      * @param callable $callback

--- a/src/Discord/Helpers/CollectionTrait.php
+++ b/src/Discord/Helpers/CollectionTrait.php
@@ -332,6 +332,23 @@ trait CollectionTrait
     }
 
     /**
+     * Reduces the collection to a single value using a callback function.
+     *
+     * @param callable $callback
+     * @param ?mixed   $initial
+     *
+     * @return CollectionInterface
+     */
+    public function reduce(callable $callback, $initial = null)
+    {
+        $items = $this->items;
+
+        $items = array_reduce($items, $callback, $initial);
+
+        return new Collection($items, $this->discrim, $this->class);
+    }
+
+    /**
      * Runs a callback over the collection and creates a new static.
      *
      * @param callable $callback

--- a/src/Discord/Helpers/CollectionTrait.php
+++ b/src/Discord/Helpers/CollectionTrait.php
@@ -114,6 +114,24 @@ trait CollectionTrait
     }
 
     /**
+     * Shifts an item from the collection.
+     *
+     * @return mixed
+     */
+    public function shift()
+    {
+        if (empty($this->items)) {
+            return null;
+        }
+
+        reset($this->items);
+        $key = key($this->items);
+        $value = array_shift($this->items);
+
+        return [$key => $value];
+    }
+
+    /**
      * Fills an array of items into the collection.
      *
      * @param array $items

--- a/src/Discord/Helpers/CollectionTrait.php
+++ b/src/Discord/Helpers/CollectionTrait.php
@@ -483,6 +483,16 @@ trait CollectionTrait
     }
 
     /**
+     * Converts the items into a new collection.
+     *
+     * @return CollectionInterface
+     */
+    public function collect()
+    {
+        return new Collection($this->items, $this->discrim, $this->class);
+    }
+
+    /**
      * @since 11.0.0
      *
      * Get the keys of the items.

--- a/src/Discord/Helpers/CollectionTrait.php
+++ b/src/Discord/Helpers/CollectionTrait.php
@@ -383,6 +383,16 @@ trait CollectionTrait
     }
 
     /**
+     * Get the values of the items.
+     *
+     * @return array
+     */
+    public function values(): array
+    {
+        return array_values($this->items);
+    }
+
+    /**
      * If the collection has an offset.
      *
      * @param mixed $offset

--- a/src/Discord/Helpers/CollectionTrait.php
+++ b/src/Discord/Helpers/CollectionTrait.php
@@ -134,12 +134,18 @@ trait CollectionTrait
     /**
      * Fills an array of items into the collection.
      *
-     * @param array $items
+     * @param CollectionInterface|array $items
      *
      * @return self
      */
-    public function fill(array $items): self
+    public function fill($items): self
     {
+        if ($items instanceof CollectionInterface) {
+            $items = $items->toArray();
+        }
+        if (! is_array($items)) {
+            throw new \InvalidArgumentException('The fill method only accepts arrays or CollectionInterface instances.');
+        }
         foreach ($items as $item) {
             $this->pushItem($item);
         }

--- a/src/Discord/Helpers/CollectionTrait.php
+++ b/src/Discord/Helpers/CollectionTrait.php
@@ -332,13 +332,13 @@ trait CollectionTrait
     }
 
     /**
-     * Computes the difference between the current collection and the given array.
+     * Gets the difference between the items.
      *
      * If a callback is provided and is callable, it uses `array_udiff_assoc` to compute the difference.
      * Otherwise, it uses `array_diff`.
      *
      * @param CollectionInterface|array $array
-     * @param ?callable         $callback
+     * @param ?callable                 $callback
      *
      * @return CollectionInterface
      */
@@ -358,17 +358,23 @@ trait CollectionTrait
     /**
      * Gets the intersection of the items.
      *
+     * If a callback is provided and is callable, it uses `array_uintersect_assoc` to compute the intersection.
+     * Otherwise, it uses `array_intersect`.
+     *
      * @param CollectionInterface|array $array
+     * @param ?callable                 $callback
      *
      * @return CollectionInterface
      */
-    public function intersect($items)
+    public function intersect($items, ?callable $callback)
     {
         $items = $items instanceof CollectionInterface
             ? $items->toArray()
             : $items;
 
-        $diff = array_intersect($this->items, $items);
+        $diff = $callback && is_callable($callback)
+            ? array_uintersect_assoc($this->items, $items, $callback)
+            : array_intersect($this->items, $items);
 
         return new Collection($diff, $this->discrim, $this->class);
     }

--- a/src/Discord/Helpers/CollectionTrait.php
+++ b/src/Discord/Helpers/CollectionTrait.php
@@ -429,6 +429,18 @@ trait CollectionTrait
     }
 
     /**
+     * Returns unique items.
+     *
+     * @param int   $flags
+     *
+     * @return CollectionInterface
+     */
+    public function unique(int $flags = SORT_STRING)
+    {
+        return new Collection(array_unique($this->items, $flags), $this->discrim, $this->class);
+    }
+
+    /**
      * Merges another collection into this collection.
      *
      * @param $collection
@@ -522,6 +534,9 @@ trait CollectionTrait
 
     /**
      * Returns the string representation of the collection.
+     *
+     * @param int  $flags
+     * @param ?int $depth
      *
      * @return string
      */

--- a/src/Discord/Parts/Channel/Channel.php
+++ b/src/Discord/Parts/Channel/Channel.php
@@ -253,7 +253,7 @@ class Channel extends Part implements Stringable
      *
      * @return Collection A collection of recipients.
      */
-    protected function getRecipientsAttribute(): Collection
+    protected function getRecipientsAttribute(): CollectionInterface
     {
         $recipients = Collection::for(User::class);
 
@@ -999,7 +999,7 @@ class Channel extends Part implements Stringable
      *
      * @since 7.4.0
      */
-    protected function getAvailableTagsAttribute(): Collection
+    protected function getAvailableTagsAttribute(): CollectionInterface
     {
         $available_tags = Collection::for(Tag::class);
 

--- a/src/Discord/Parts/Channel/Message.php
+++ b/src/Discord/Parts/Channel/Message.php
@@ -336,7 +336,7 @@ class Message extends Part
      *
      * @return Collection|Channel[]
      */
-    protected function getMentionChannelsAttribute(): Collection
+    protected function getMentionChannelsAttribute(): CollectionInterface
     {
         $collection = Collection::for(Channel::class);
 
@@ -360,7 +360,7 @@ class Message extends Part
      *
      * @return Collection|Attachment[] Attachment objects.
      */
-    protected function getAttachmentsAttribute(): Collection
+    protected function getAttachmentsAttribute(): CollectionInterface
     {
         $attachments = Collection::for(Attachment::class);
 
@@ -492,7 +492,7 @@ class Message extends Part
      *
      * @return Collection<?Role> The roles that were mentioned. null role only contains the ID in the collection.
      */
-    protected function getMentionRolesAttribute(): Collection
+    protected function getMentionRolesAttribute(): CollectionInterface
     {
         $roles = new Collection();
 
@@ -516,7 +516,7 @@ class Message extends Part
      *
      * @return Collection|User[] The users that were mentioned.
      */
-    protected function getMentionsAttribute(): Collection
+    protected function getMentionsAttribute(): CollectionInterface
     {
         $users = Collection::for(User::class);
 
@@ -583,7 +583,7 @@ class Message extends Part
      *
      * @return Collection<Embed> A collection of embeds.
      */
-    protected function getEmbedsAttribute(): Collection
+    protected function getEmbedsAttribute(): CollectionInterface
     {
         $embeds = new Collection([], null);
 

--- a/src/Discord/Parts/Embed/Embed.php
+++ b/src/Discord/Parts/Embed/Embed.php
@@ -137,7 +137,7 @@ class Embed extends Part
      *
      * @return Collection|Field[]
      */
-    protected function getFieldsAttribute(): Collection
+    protected function getFieldsAttribute(): CollectionInterface
     {
         $fields = Collection::for(Field::class, null);
 

--- a/src/Discord/Parts/Guild/AuditLog/AuditLog.php
+++ b/src/Discord/Parts/Guild/AuditLog/AuditLog.php
@@ -76,7 +76,7 @@ class AuditLog extends Part
      *
      * @return Collection|Command[]
      */
-    protected function getApplicationCommandsAttribute(): Collection
+    protected function getApplicationCommandsAttribute(): CollectionInterface
     {
         $collection = Collection::for(Command::class);
 
@@ -92,7 +92,7 @@ class AuditLog extends Part
      *
      * @return Collection|Entry[]
      */
-    protected function getAuditLogEntriesAttribute(): Collection
+    protected function getAuditLogEntriesAttribute(): CollectionInterface
     {
         $collection = Collection::for(Entry::class);
 
@@ -108,7 +108,7 @@ class AuditLog extends Part
      *
      * @return Collection|Rule[]
      */
-    protected function getAutoModerationRulesAttribute(): Collection
+    protected function getAutoModerationRulesAttribute(): CollectionInterface
     {
         $collection = Collection::for(Rule::class);
 
@@ -124,7 +124,7 @@ class AuditLog extends Part
      *
      * @return Collection|ScheduledEvent[]
      */
-    protected function getGuildScheduledEventsAttribute(): Collection
+    protected function getGuildScheduledEventsAttribute(): CollectionInterface
     {
         $collection = Collection::for(ScheduledEvent::class);
 
@@ -142,7 +142,7 @@ class AuditLog extends Part
      *
      * @return Collection|Integration[]
      */
-    protected function getIntegrationsAttribute(): Collection
+    protected function getIntegrationsAttribute(): CollectionInterface
     {
         $collection = Collection::for(Integration::class);
 
@@ -158,7 +158,7 @@ class AuditLog extends Part
      *
      * @return Collection|Thread[]
      */
-    protected function getThreadsAttribute(): Collection
+    protected function getThreadsAttribute(): CollectionInterface
     {
         $collection = Collection::for(Thread::class);
 
@@ -174,7 +174,7 @@ class AuditLog extends Part
      *
      * @return Collection|User[]
      */
-    protected function getUsersAttribute(): Collection
+    protected function getUsersAttribute(): CollectionInterface
     {
         $collection = Collection::for(User::class);
 
@@ -190,7 +190,7 @@ class AuditLog extends Part
      *
      * @return Collection|Webhook[]
      */
-    protected function getWebhooksAttribute(): Collection
+    protected function getWebhooksAttribute(): CollectionInterface
     {
         $collection = Collection::for(Webhook::class);
 
@@ -210,7 +210,7 @@ class AuditLog extends Part
      *
      * @return Collection|Entry[]
      */
-    public function searchByType(int $action_type): Collection
+    public function searchByType(int $action_type): CollectionInterface
     {
         $types = array_values((new ReflectionClass(Entry::class))->getConstants());
 

--- a/src/Discord/Parts/Guild/AuditLog/Entry.php
+++ b/src/Discord/Parts/Guild/AuditLog/Entry.php
@@ -123,7 +123,7 @@ class Entry extends Part
      *
      * @return Collection
      */
-    protected function getChangesAttribute(): Collection
+    protected function getChangesAttribute(): CollectionInterface
     {
         return new Collection($this->attributes['changes'] ?? [], 'key', null);
     }

--- a/src/Discord/Parts/Guild/AutoModeration/Rule.php
+++ b/src/Discord/Parts/Guild/AutoModeration/Rule.php
@@ -100,7 +100,7 @@ class Rule extends Part
      *
      * @return Collection|Action[] A collection of actions.
      */
-    protected function getActionsAttribute(): Collection
+    protected function getActionsAttribute(): CollectionInterface
     {
         $actions = Collection::for(Action::class, null);
 
@@ -116,7 +116,7 @@ class Rule extends Part
      *
      * @return Collection|?Role[] A collection of roles exempt from the rule.
      */
-    protected function getExemptRolesAttribute(): Collection
+    protected function getExemptRolesAttribute(): CollectionInterface
     {
         $roles = new Collection();
 
@@ -140,7 +140,7 @@ class Rule extends Part
      *
      * @return Collection|?Channel[] A collection of channels exempt from the rule.
      */
-    protected function getExemptChannelsAttribute(): Collection
+    protected function getExemptChannelsAttribute(): CollectionInterface
     {
         $channels = new Collection();
 

--- a/src/Discord/Parts/Guild/CommandPermissions.php
+++ b/src/Discord/Parts/Guild/CommandPermissions.php
@@ -57,7 +57,7 @@ class CommandPermissions extends Part
      *
      * @return Collection|Permission[] A collection of permissions.
      */
-    protected function getPermissionsAttribute(): Collection
+    protected function getPermissionsAttribute(): CollectionInterface
     {
         $permissions = Collection::for(Permission::class);
 

--- a/src/Discord/Parts/Guild/Emoji.php
+++ b/src/Discord/Parts/Guild/Emoji.php
@@ -69,7 +69,7 @@ class Emoji extends Part implements Stringable
      *
      * @return Collection<?Role> A collection of roles for the emoji.
      */
-    protected function getRolesAttribute(): Collection
+    protected function getRolesAttribute(): CollectionInterface
     {
         $roles = new Collection();
 

--- a/src/Discord/Parts/Guild/Guild.php
+++ b/src/Discord/Parts/Guild/Guild.php
@@ -581,7 +581,7 @@ class Guild extends Part
      *
      * @return Collection|StageInstance[]
      */
-    protected function getStageInstancesAttribute(): Collection
+    protected function getStageInstancesAttribute(): CollectionInterface
     {
         $stage_instances = Collection::for(StageInstance::class);
 

--- a/src/Discord/Parts/Guild/Guild.php
+++ b/src/Discord/Parts/Guild/Guild.php
@@ -14,6 +14,7 @@ namespace Discord\Parts\Guild;
 use Carbon\Carbon;
 use Discord\Exceptions\FileNotFoundException;
 use Discord\Helpers\Collection;
+use Discord\Helpers\CollectionInterface;
 use Discord\Helpers\Multipart;
 use Discord\Http\Endpoint;
 use Discord\Http\Exceptions\NoPermissionsException;
@@ -335,12 +336,22 @@ class Guild extends Part
     /**
      * Sets the roles attribute.
      *
-     * @param ?array $roles
+     * @param CollectionInterface|array|null $roles
      */
-    protected function setRolesAttribute(?array $roles): void
+    protected function setRolesAttribute($roles): void
     {
+        if ($roles instanceof CollectionInterface) {
+            $roles = $roles->toArray();
+        }
+        if ($roles === null) {
+            $roles = [];
+        }
+        if (! is_array($roles)) {
+            throw new \InvalidArgumentException('Roles must be an array or CollectionInterface.');
+        }
+
         $rolesDiscrim = $this->roles->discrim;
-        foreach ($roles ?? [] as $role) {
+        foreach ($roles as $role) {
             $role = (array) $role;
             /** @var ?Role */
             if ($rolePart = $this->roles->offsetGet($role[$rolesDiscrim])) {
@@ -1106,16 +1117,23 @@ class Guild extends Part
      *
      * @link https://discord.com/developers/docs/resources/guild#modify-guild-role-positions
      *
-     * @param array $roles Associative array where the LHS key is the position,
-     *                     and the RHS value is a `Role` object or a string ID,
-     *                     e.g. `[1 => 'role_id_1', 3 => 'role_id_3']`.
+     * @param CollectionInterface|array $roles  Associative array where the LHS key is the position,
+     *                                              and the RHS value is a `Role` object or a string ID,
+     *                                              e.g. `[1 => 'role_id_1', 3 => 'role_id_3']`.
      *
      * @throws NoPermissionsException Missing manage_roles permission.
      *
      * @return PromiseInterface<self>
      */
-    public function updateRolePositions(array $roles): PromiseInterface
+    public function updateRolePositions($roles): PromiseInterface
     {
+        if ($roles instanceof CollectionInterface) {
+            $roles = $roles->toArray();
+        }
+        if (! is_array($roles)) {
+            return reject(new \InvalidArgumentException('Roles must be an array of Role instances or Role IDs.'));
+        }
+
         $botperms = $this->getBotPermissions();
         if ($botperms && ! $botperms->manage_roles) {
             return reject(new NoPermissionsException("You do not have permission to update role positions in the guild {$this->id}."));

--- a/src/Discord/Parts/Guild/WelcomeScreen.php
+++ b/src/Discord/Parts/Guild/WelcomeScreen.php
@@ -39,7 +39,7 @@ class WelcomeScreen extends Part
      *
      * @return Collection|WelcomeChannel[] The channels of welcome screen.
      */
-    protected function getWelcomeChannelsAttribute(): Collection
+    protected function getWelcomeChannelsAttribute(): CollectionInterface
     {
         $collection = Collection::for(WelcomeChannel::class, null);
 

--- a/src/Discord/Parts/Interactions/Command/Option.php
+++ b/src/Discord/Parts/Interactions/Command/Option.php
@@ -97,7 +97,7 @@ class Option extends Part
      *
      * @return Collection|Option[] A collection of options.
      */
-    protected function getOptionsAttribute(): Collection
+    protected function getOptionsAttribute(): CollectionInterface
     {
         $options = Collection::for(Option::class, null);
 

--- a/src/Discord/Parts/User/Member.php
+++ b/src/Discord/Parts/User/Member.php
@@ -15,6 +15,7 @@ use Carbon\Carbon;
 use Discord\Builders\MessageBuilder;
 use Discord\Helpers\BigInt;
 use Discord\Helpers\Collection;
+use Discord\Helpers\CollectionInterface;
 use Discord\Http\Endpoint;
 use Discord\Http\Exceptions\NoPermissionsException;
 use Discord\Parts\Channel\Channel;
@@ -331,15 +332,22 @@ class Member extends Part implements Stringable
      *
      * @link https://discord.com/developers/docs/resources/guild#modify-guild-member
      *
-     * @param Role[]|string[] $roles  The roles to set to the member.
-     * @param string|null     $reason Reason for Audit Log.
+     * @param CollectionInterface|Role[]|string[] $roles  The roles to set to the member.
+     * @param string|null                         $reason Reason for Audit Log.
      *
      * @throws NoPermissionsException Missing manage_roles permission.
      *
      * @return PromiseInterface<self>
      */
-    public function setRoles(array $roles, ?string $reason = null): PromiseInterface
+    public function setRoles($roles, ?string $reason = null): PromiseInterface
     {
+        if ($roles instanceof CollectionInterface) {
+            $roles = $roles->toArray();
+        }
+        if (! is_array($roles)) {
+            return reject(new \InvalidArgumentException('Roles must be an array of Role instances or Role IDs.'));
+        }
+
         foreach ($roles as $i => $role) {
             if ($role instanceof Role) {
                 $roles[$i] = $role->id;

--- a/src/Discord/Parts/User/Member.php
+++ b/src/Discord/Parts/User/Member.php
@@ -619,7 +619,7 @@ class Member extends Part implements Stringable
      *
      * @return Collection|Activity[]
      */
-    protected function getActivitiesAttribute(): Collection
+    protected function getActivitiesAttribute(): CollectionInterface
     {
         $activities = Collection::for(Activity::class, null);
 
@@ -695,7 +695,7 @@ class Member extends Part implements Stringable
      *
      * @return Collection<?Role> A collection of roles the member is in. null role only contains ID in the collection.
      */
-    protected function getRolesAttribute(): Collection
+    protected function getRolesAttribute(): CollectionInterface
     {
         $roles = new Collection();
 

--- a/src/Discord/Parts/WebSockets/PresenceUpdate.php
+++ b/src/Discord/Parts/WebSockets/PresenceUpdate.php
@@ -95,7 +95,7 @@ class PresenceUpdate extends Part
      *
      * @return Collection|Activity[]
      */
-    protected function getActivitiesAttribute(): Collection
+    protected function getActivitiesAttribute(): CollectionInterface
     {
         $collection = Collection::for(Activity::class, null);
 
@@ -165,7 +165,7 @@ class PresenceUpdate extends Part
      *
      * @return Collection|Role[]
      */
-    protected function getRolesAttribute(): Collection
+    protected function getRolesAttribute(): CollectionInterface
     {
         if ($member = $this->member) {
             return $member->roles;

--- a/src/Discord/Repository/AbstractRepositoryInterface.php
+++ b/src/Discord/Repository/AbstractRepositoryInterface.php
@@ -40,6 +40,7 @@ interface AbstractRepositoryInterface extends CollectionInterface
     public function clear(): void;
     public function toArray(): array;
     public function keys(): array;
+    public function values(): array;
     public function offsetExists($offset): bool;
     #[\ReturnTypeWillChange]
     public function offsetGet($offset);

--- a/src/Discord/Repository/AbstractRepositoryTrait.php
+++ b/src/Discord/Repository/AbstractRepositoryTrait.php
@@ -670,6 +670,16 @@ trait AbstractRepositoryTrait
     }
 
     /**
+     * Get the values of the items.
+     *
+     * @return array
+     */
+    public function values(): array
+    {
+        return array_values($this->items);
+    }
+
+    /**
      * If the repository has an offset.
      *
      * @deprecated 10.0.0 Use async `$repository->cache->has()`

--- a/src/Discord/Repository/Channel/ThreadRepository.php
+++ b/src/Discord/Repository/Channel/ThreadRepository.php
@@ -152,7 +152,7 @@ class ThreadRepository extends AbstractRepository
      *
      * @return Collection|Thread[]
      */
-    private function handleThreadPaginationResponse(object $response): Collection
+    private function handleThreadPaginationResponse(object $response): CollectionInterface
     {
         $collection = Collection::for(Thread::class);
 


### PR DESCRIPTION
This pull request includes several changes to the `CollectionInterface` and `CollectionTrait` in the `Discord/Helpers` directory, as well as updates to various attributes in the `Channel`, `Message`, `Embed`, and `AuditLog` classes. The primary focus is on enhancing the functionality of the collection interface and traits, and updating the return types of attributes to use `CollectionInterface` instead of `Collection`.

### Collection Interface Enhancements:
* Added new methods `shift()`, `walk(callable $callback, mixed $arg)`, `reduce(callable $callback, $initial = null)`, `collect()`, `keys()`, `values()`, `diff($items, ?callable $callback)`, `intersect($items, ?callable $callback)`, and `unique(int $flags = SORT_STRING)` to `CollectionInterface`. [[1]](diffhunk://#diff-e03abf0b08dbf335e90b013afb96b1b6aff3d0b55a391ea2bbc140a53878e644L25-R26) [[2]](diffhunk://#diff-e03abf0b08dbf335e90b013afb96b1b6aff3d0b55a391ea2bbc140a53878e644R39-R49) [[3]](diffhunk://#diff-e03abf0b08dbf335e90b013afb96b1b6aff3d0b55a391ea2bbc140a53878e644L49-R58)

### Collection Trait Enhancements:
* Implemented the `shift()` method to remove and return the first item of the collection.
* Updated the `fill()` method to accept both arrays and `CollectionInterface` instances.
* Added methods `diff()`, `intersect()`, `walk()`, `reduce()`, `unique()`, `collect()`, `keys()`, and `values()` to the `CollectionTrait`. [[1]](diffhunk://#diff-58ec4730828594c785b2e9eb266da740546bd89607b20bc1b73ce2f526045b05L302-R327) [[2]](diffhunk://#diff-58ec4730828594c785b2e9eb266da740546bd89607b20bc1b73ce2f526045b05R359-R440) [[3]](diffhunk://#diff-58ec4730828594c785b2e9eb266da740546bd89607b20bc1b73ce2f526045b05R456-R467) [[4]](diffhunk://#diff-58ec4730828594c785b2e9eb266da740546bd89607b20bc1b73ce2f526045b05L358-R481) [[5]](diffhunk://#diff-58ec4730828594c785b2e9eb266da740546bd89607b20bc1b73ce2f526045b05R496-R505) [[6]](diffhunk://#diff-58ec4730828594c785b2e9eb266da740546bd89607b20bc1b73ce2f526045b05R518-R527)
* Modified the `__unserialize()` method to accept both arrays and `CollectionInterface` instances.

### Attribute Return Type Updates:
* Updated the return type of various attributes from `Collection` to `CollectionInterface` in `Channel`, `Message`, `Embed`, and `AuditLog` classes. [[1]](diffhunk://#diff-347cb634bd9dfce6baf790e117c398ae2c78812c67bfbbce182b3a32b4e1313fL256-R256) [[2]](diffhunk://#diff-347cb634bd9dfce6baf790e117c398ae2c78812c67bfbbce182b3a32b4e1313fL1002-R1002) [[3]](diffhunk://#diff-3bc0952a87e08969969124672b2539443f4afa2fa67b5fdcddd94944c88eb1ddL339-R339) [[4]](diffhunk://#diff-3bc0952a87e08969969124672b2539443f4afa2fa67b5fdcddd94944c88eb1ddL363-R363) [[5]](diffhunk://#diff-3bc0952a87e08969969124672b2539443f4afa2fa67b5fdcddd94944c88eb1ddL495-R495) [[6]](diffhunk://#diff-3bc0952a87e08969969124672b2539443f4afa2fa67b5fdcddd94944c88eb1ddL519-R519) [[7]](diffhunk://#diff-3bc0952a87e08969969124672b2539443f4afa2fa67b5fdcddd94944c88eb1ddL586-R586) [[8]](diffhunk://#diff-825742194655a73fc909ddb6516b4e978a4cc174f34ec0dca6de332516ecefbcL140-R140) [[9]](diffhunk://#diff-d0fed80500fee0122ece5e27b77f473bfcf34868699007bd7ca8376018be1859L79-R79) [[10]](diffhunk://#diff-d0fed80500fee0122ece5e27b77f473bfcf34868699007bd7ca8376018be1859L95-R95) [[11]](diffhunk://#diff-d0fed80500fee0122ece5e27b77f473bfcf34868699007bd7ca8376018be1859L111-R111) [[12]](diffhunk://#diff-d0fed80500fee0122ece5e27b77f473bfcf34868699007bd7ca8376018be1859L127-R127) [[13]](diffhunk://#diff-d0fed80500fee0122ece5e27b77f473bfcf34868699007bd7ca8376018be1859L145-R145) [[14]](diffhunk://#diff-d0fed80500fee0122ece5e27b77f473bfcf34868699007bd7ca8376018be1859L161-R161) [[15]](diffhunk://#diff-d0fed80500fee0122ece5e27b77f473bfcf34868699007bd7ca8376018be1859L177-R177) [[16]](diffhunk://#diff-d0fed80500fee0122ece5e27b77f473bfcf34868699007bd7ca8376018be1859L193-R193)