### PR TITLE
fix: PollResults to correctly map to an array of PollAnswerCount

### DIFF
--- a/src/Discord/Parts/Channel/Poll/PollResults.php
+++ b/src/Discord/Parts/Channel/Poll/PollResults.php
@@ -22,7 +22,7 @@ use Discord\Parts\Part;
  *
  * @since 10.0.0
  *
- * @property boolean            $is_finalized   Whether the votes have been precisely counted
+ * @property boolean                       $is_finalized   Whether the votes have been precisely counted
  * @property Collection|PollAnswerCount[]  $answer_counts  The counts for each answer
  */
 class PollResults extends Part

--- a/src/Discord/Parts/Channel/Poll/PollResults.php
+++ b/src/Discord/Parts/Channel/Poll/PollResults.php
@@ -22,8 +22,8 @@ use Discord\Parts\Part;
  *
  * @since 10.0.0
  *
- * @property boolean                       $is_finalized   Whether the votes have been precisely counted
- * @property Collection|PollAnswerCount[]  $answer_counts  The counts for each answer
+ * @property boolean                                $is_finalized   Whether the votes have been precisely counted
+ * @property CollectionInterface|PollAnswerCount[]  $answer_counts  The counts for each answer
  */
 class PollResults extends Part
 {
@@ -38,7 +38,7 @@ class PollResults extends Part
     /**
      * Returns the answer counts attribute.
      *
-     * @return Collection A collection of poll answer counts.
+     * @return CollectionInterface<PollAnswerCount> A collection of poll answer counts.
      */
     protected function getAnswerCountsAttribute(): CollectionInterface
     {

--- a/src/Discord/Parts/Channel/Poll/PollResults.php
+++ b/src/Discord/Parts/Channel/Poll/PollResults.php
@@ -12,6 +12,7 @@
 namespace Discord\Parts\Channel\Poll;
 
 use Discord\Helpers\Collection;
+use Discord\Helpers\CollectionInterface;
 use Discord\Parts\Part;
 
 /**
@@ -22,7 +23,7 @@ use Discord\Parts\Part;
  * @since 10.0.0
  *
  * @property boolean            $is_finalized   Whether the votes have been precisely counted
- * @property PollAnswerCount[]  $answer_counts  The counts for each answer
+ * @property Collection|PollAnswerCount[]  $answer_counts  The counts for each answer
  */
 class PollResults extends Part
 {
@@ -37,16 +38,16 @@ class PollResults extends Part
     /**
      * Returns the answer counts attribute.
      *
-     * @return PollAnswerCount[]
+     * @return Collection A collection of poll answer counts.
      */
-    protected function getAnswerCountsAttribute(): array
+    protected function getAnswerCountsAttribute(): CollectionInterface
     {
-        $answerCounts = new Collection();
+        $answerCounts = Collection::for(PollAnswerCount::class);
 
         foreach ($this->attributes['answer_counts'] as $answerCount) {
-            $answerCounts->push($this->factory->create(PollAnswerCount::class, $answerCount, true));
+            $answerCounts->pushItem($this->factory->create(PollAnswerCount::class, $answerCount, true));
         }
 
-        return $answerCounts->toArray();
+        return $answerCounts;
     }
 }

--- a/src/Discord/Parts/Channel/Poll/PollResults.php
+++ b/src/Discord/Parts/Channel/Poll/PollResults.php
@@ -11,6 +11,7 @@
 
 namespace Discord\Parts\Channel\Poll;
 
+use Discord\Helpers\Collection;
 use Discord\Parts\Part;
 
 /**
@@ -36,10 +37,16 @@ class PollResults extends Part
     /**
      * Returns the answer counts attribute.
      *
-     * @return PollAnswerCount
+     * @return PollAnswerCount[]
      */
-    protected function getAnswerCountsAttribute(): PollAnswerCount
+    protected function getAnswerCountsAttribute(): array
     {
-        return $this->factory->part(PollAnswerCount::class, (array) $this->attributes['answer_counts'], true);
+        $answerCounts = new Collection();
+
+        foreach ($this->attributes['answer_counts'] as $answerCount) {
+            $answerCounts->push($this->factory->create(PollAnswerCount::class, $answerCount, true));
+        }
+
+        return $answerCounts->toArray();
     }
 }


### PR DESCRIPTION
While working on a small integration utilizing Channel Polls, I encountered an issue where retrieving the `answer_counts` unexpectedly returned a singular entity instead of an array of `PollAnswerCount` objects. This behavior was inconsistent with the expected structure and functionality.

This PR addresses the issue by ensuring that the `answer_counts` object is properly mapped into an array of `PollAnswerCount` objects, aligning with the intended design and improving data handling.

```
Discord\Parts\Channel\Poll\PollAnswerCount^ {#3876
  #http: Discord\Http\Http^ {#3813}
  #factory: Discord\Factory\Factory^ {#3064}
  #discord: Discord\Discord^ {#3856}
  +scriptData: null
  #fillable: array:3 [
    0 => "id"
    1 => "count"
    2 => "me_voted"
  ]
  #attributes: []
  #visible: []
  #hidden: []
  #repositories: []
  #repositories_cache: []
  +created: true
  id: null
  count: null
  me_voted: null
}
```