### PR TITLE
CommandAttributes options should be CollectionInterface

### DIFF
--- a/src/Discord/Builders/CommandAttributes.php
+++ b/src/Discord/Builders/CommandAttributes.php
@@ -11,6 +11,8 @@
 
 namespace Discord\Builders;
 
+use Discord\Helpers\Collection;
+use Discord\Helpers\CollectionInterface;
 use Discord\Parts\Interactions\Command\Command;
 use Discord\Parts\Interactions\Command\Option;
 
@@ -24,17 +26,17 @@ use function Discord\poly_strlen;
  *
  * @since 7.1.0
  *
- * @property int                                                $type                       The type of the command, defaults 1 if not set.
- * @property string                                             $name                       1-32 character name of the command.
- * @property ?string[]|null                                     $name_localizations         Localization dictionary for the name field. Values follow the same restrictions as name.
- * @property ?string                                            $description                1-100 character description for CHAT_INPUT commands, empty string for USER and MESSAGE commands.
- * @property ?string[]|null                                     $description_localizations  Localization dictionary for the description field. Values follow the same restrictions as description.
- * @property \Discord\Helpers\CollectionInterface|Option[]|null $options                    The parameters for the command, max 25. Only for Slash command (CHAT_INPUT).
- * @property ?string                                            $default_member_permissions Set of permissions represented as a bit set.
- * @property bool|null                                          $dm_permission              Indicates whether the command is available in DMs with the app, only for globally-scoped commands. By default, commands are visible.
- * @property ?bool                                              $default_permission         Whether the command is enabled by default when the app is added to a guild. SOON DEPRECATED.
- * @property ?int                                               $guild_id                   The optional guild ID this command is for. If not set, the command is global.
- * @property bool|null                                          $nsfw                       Indicates whether the command is age-restricted, defaults to `false`.
+ * @property int                               $type                       The type of the command, defaults 1 if not set.
+ * @property string                            $name                       1-32 character name of the command.
+ * @property ?string[]|null                    $name_localizations         Localization dictionary for the name field. Values follow the same restrictions as name.
+ * @property ?string                           $description                1-100 character description for CHAT_INPUT commands, empty string for USER and MESSAGE commands.
+ * @property ?string[]|null                    $description_localizations  Localization dictionary for the description field. Values follow the same restrictions as description.
+ * @property CollectionInterface|Option[]|null $options                    The parameters for the command, max 25. Only for Slash command (CHAT_INPUT).
+ * @property ?string                           $default_member_permissions Set of permissions represented as a bit set.
+ * @property bool|null                         $dm_permission              Indicates whether the command is available in DMs with the app, only for globally-scoped commands. By default, commands are visible.
+ * @property ?bool                             $default_permission         Whether the command is enabled by default when the app is added to a guild. SOON DEPRECATED.
+ * @property ?int                              $guild_id                   The optional guild ID this command is for. If not set, the command is global.
+ * @property bool|null                         $nsfw                       Indicates whether the command is age-restricted, defaults to `false`.
  */
 trait CommandAttributes
 {
@@ -257,7 +259,7 @@ trait CommandAttributes
             throw new \OverflowException('Command can only have a maximum of 25 options.');
         }
 
-        $this->options ??= [];
+        $this->options ??= Collection::for(Option::class, 'name');
 
         $this->options[] = $option;
 
@@ -293,7 +295,7 @@ trait CommandAttributes
      */
     public function clearOptions(): self
     {
-        $this->options = [];
+        $this->options = Collection::for(Option::class, 'name');
 
         return $this;
     }


### PR DESCRIPTION
This pull request includes changes to the `CommandAttributes` class in the `src/Discord/Builders` directory to improve the handling of command options by utilizing the `Collection` class. The most important changes include the addition of new imports, updates to property annotations, and modifications to methods for adding and removing options.

Updates to imports and property annotations:

* [`src/Discord/Builders/CommandAttributes.php`](diffhunk://#diff-3eb7dfcca1697e681b65575963ad32d6a46c7adca75b23f77fce4ac890a60025R14-R15): Added imports for `Collection` and `CollectionInterface`.
* [`src/Discord/Builders/CommandAttributes.php`](diffhunk://#diff-3eb7dfcca1697e681b65575963ad32d6a46c7adca75b23f77fce4ac890a60025L32-R34): Updated the `options` property annotation to use `CollectionInterface` instead of the fully qualified name.

Modifications to methods:

* [`src/Discord/Builders/CommandAttributes.php`](diffhunk://#diff-3eb7dfcca1697e681b65575963ad32d6a46c7adca75b23f77fce4ac890a60025L260-R262): Updated the `addOption` method to initialize `options` using `Collection::for` with `Option::class` and 'name'.
* [`src/Discord/Builders/CommandAttributes.php`](diffhunk://#diff-3eb7dfcca1697e681b65575963ad32d6a46c7adca75b23f77fce4ac890a60025L296-R298): Updated the `clearOptions` method to reset `options` using `Collection::for` with `Option::class` and 'name'.