### PR TITLE
Switch to fork of ratchet/pawl to fix php 8.4 deprecations

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Before you start using this Library, you **need** to know how PHP works, you nee
 
 ### Requirements
 
-- [PHP 8.0](https://php.net) or higher (latest version recommended)
+- [PHP 8.2](https://php.net) or higher (latest version recommended)
 	- x86 (32-bit) PHP requires [`ext-gmp`](https://www.php.net/manual/en/book.gmp.php) enabled.
 - [`ext-json`](https://www.php.net/manual/en/book.json.php)
 - [`ext-zlib`](https://www.php.net/manual/en/book.zlib.php)

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Before you start using this Library, you **need** to know how PHP works, you nee
 
 ### Requirements
 
-- [PHP 8.2](https://php.net) or higher (latest version recommended)
+- [PHP 8.0](https://php.net) or higher (latest version recommended)
 	- x86 (32-bit) PHP requires [`ext-gmp`](https://www.php.net/manual/en/book.gmp.php) enabled.
 - [`ext-json`](https://www.php.net/manual/en/book.json.php)
 - [`ext-zlib`](https://www.php.net/manual/en/book.zlib.php)

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "require": {
         "php": "^8.0",
         "nesbot/carbon": "^2.38 || ^3.0",
-        "exan/pawl": "^0.4.2",
+        "exan/pawl": "^0.4.3",
         "react/datagram": "^1.8",
         "symfony/options-resolver": "^5.1.11 || ^6.0 || ^7.0",
         "trafficcophp/bytebuffer": "^0.3",

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "require": {
         "php": "^8.0",
         "nesbot/carbon": "^2.38 || ^3.0",
-        "ratchet/pawl": "^0.4.1",
+        "exan/pawl": "^0.4.2",
         "react/datagram": "^1.8",
         "symfony/options-resolver": "^5.1.11 || ^6.0 || ^7.0",
         "trafficcophp/bytebuffer": "^0.3",

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "require": {
         "php": "^8.0",
         "nesbot/carbon": "^2.38 || ^3.0",
-        "exan/pawl": "^0.4.3",
+        "exan/pawl": "^0.4.4",
         "react/datagram": "^1.8",
         "symfony/options-resolver": "^5.1.11 || ^6.0 || ^7.0",
         "trafficcophp/bytebuffer": "^0.3",


### PR DESCRIPTION
Current set of dependencies require 8.2+, so updated the version in the readme.

Switch over to `exan/pawl` instead of `ratchet/pawl` as it hasn't been updated in years and uses deprecated php features. The only change in this fork is adding the dynamic attributes tags, and removing implicit nulls.

A peer dependency of `ratchet/pawl` does still use implicit nulls, but I haven't seen any warnings come thru so far. When someone runs into them, a similar action can be taken for that package.