### PR TITLE
ExCollectionInterface

### DIFF
--- a/src/Discord/Helpers/Collection.php
+++ b/src/Discord/Helpers/Collection.php
@@ -17,7 +17,7 @@ namespace Discord\Helpers;
  * @since 5.0.0 No longer extends Laravel's BaseCollection
  * @since 4.0.0
  */
-class Collection implements CollectionInterface
+class Collection implements ExCollectionInterface
 {
     /**
      * The collection discriminator.

--- a/src/Discord/Helpers/CollectionTrait.php
+++ b/src/Discord/Helpers/CollectionTrait.php
@@ -407,7 +407,7 @@ trait CollectionTrait
      * @param ?int $length
      * @param bool $preserve_keys
      *
-     * @return CollectionInterface
+     * @return ExCollectionInterface
      */
     public function slice(int $offset, ?int $length = null, bool $preserve_keys = false)
     {
@@ -423,7 +423,7 @@ trait CollectionTrait
      *
      * @param callable|int|null $callback
      *
-     * @return CollectionInterface
+     * @return ExCollectionInterface
      */
     public function sort(callable|int|null $callback)
     {
@@ -445,7 +445,7 @@ trait CollectionTrait
      * @param CollectionInterface|array $array
      * @param ?callable                 $callback
      *
-     * @return CollectionInterface
+     * @return ExCollectionInterface
      */
     public function diff($items, ?callable $callback = null)
     {
@@ -469,7 +469,7 @@ trait CollectionTrait
      * @param CollectionInterface|array $array
      * @param ?callable                 $callback
      *
-     * @return CollectionInterface
+     * @return ExCollectionInterface
      */
     public function intersect($items, ?callable $callback = null)
     {
@@ -490,7 +490,7 @@ trait CollectionTrait
      * @param callable $callback
      * @param mixed    $arg
      *
-     * @return CollectionInterface
+     * @return ExCollectionInterface
      */
     public function walk(callable $callback, mixed $arg)
     {
@@ -507,7 +507,7 @@ trait CollectionTrait
      * @param callable $callback
      * @param ?mixed   $initial
      *
-     * @return CollectionInterface
+     * @return ExCollectionInterface
      */
     public function reduce(callable $callback, $initial = null)
     {
@@ -572,7 +572,6 @@ trait CollectionTrait
     {
         return $this->items;
     }
-
     /**
      * Converts the items into a new collection.
      *

--- a/src/Discord/Helpers/ExCollectionInterface.php
+++ b/src/Discord/Helpers/ExCollectionInterface.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is a part of the DiscordPHP project.
+ *
+ * Copyright (c) 2015-present David Cole <david.cole1340@gmail.com>
+ *
+ * This file is subject to the MIT license that is bundled
+ * with this source code in the LICENSE.md file.
+ */
+
+namespace Discord\Helpers;
+
+interface ExCollectionInterface extends CollectionInterface
+{
+    public function find_key(callable $callback);
+    public function any(callable $callback): bool;
+    public function all(callable $callback): bool;
+    public function splice(int $offset, ?int $length, mixed $replacement = []): self;
+    public function clear(): void;
+    public function slice(int $offset, ?int $length = null, bool $preserve_keys = false);
+    public function sort(callable|int|null $callback);
+    public function diff($items, ?callable $callback = null);
+    public function intersect($items, ?callable $callback = null);
+    public function walk(callable $callback, mixed $arg);
+    public function reduce(callable $callback, $initial = null);
+    public function unique(int $flags = SORT_STRING);
+    public function keys(): array;
+    public function values(): array;
+}

--- a/src/Discord/Helpers/ExCollectionInterface.php
+++ b/src/Discord/Helpers/ExCollectionInterface.php
@@ -13,6 +13,10 @@ namespace Discord\Helpers;
 
 interface ExCollectionInterface extends CollectionInterface
 {
+    public static function from(array $items = [], ?string $discrim = 'id', ?string $class = null);
+    public static function for(string $class, ?string $discrim = 'id');
+    public function shift();
+    public function search(mixed $needle, bool $strict = false): string|int|false;
     public function find_key(callable $callback);
     public function any(callable $callback): bool;
     public function all(callable $callback): bool;


### PR DESCRIPTION
This includes the newly introduced functions that were added as part of recent enhancements. We do not use these functions internally within the library, so rather than update the original interface to include them as requirements, it makes sense for end-users to utilize the ExCollectionInterface instead to take advantage of the full functionality.

For example:
```php
/**
 * Returns the highest role from a collection of roles.
 *
 * @param  Collection<Role> $roles The collection of roles.
 * 
 * @return ?Role
 */
function getHighestRole(Collection $roles): ?Role
{
    return $roles->reduce(fn($prev, $role) =>
        ($prev === null
            ? $role
            : ($this->comparePositionTo($role, $prev) > 0
                ? $role
                : $prev)))
        ->shift(); // Undefined method 'shift', because reduce returns CollectionInterface
}
```