### PR TITLE
PHP ^8.1.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "chat": "https://discord.gg/dphp"
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1.2",
         "nesbot/carbon": "^2.38 || ^3.0",
         "exan/pawl": "^0.4.4",
         "react/datagram": "^1.8",


### PR DESCRIPTION
Composer dependencies currently require a PHP version >= 8.1.2, but we're still indicating that we support ^8.0.