### PR TITLE
Make MessageBuilder constructable from json data

### DIFF
--- a/src/Discord/Builders/MessageBuilder.php
+++ b/src/Discord/Builders/MessageBuilder.php
@@ -149,13 +149,44 @@ class MessageBuilder implements JsonSerializable
     private $enforce_nonce;
 
     /**
+     * @param array|string|null $json Optional. An associative array or a JSON string containing property values to set on the instance.
+     *                                If a JSON string is provided, it will be decoded into an array.
+     *
+     * @throws \InvalidArgumentException If a JSON string is provided and it is invalid.
+     */
+    public function __construct(array|string|null $json = null)
+    {
+        if (empty($json)) {
+            return;
+        }
+        $this->fill($json);
+    }
+
+    /**
      * Creates a new message builder.
      *
+     * @param array|string|null $json Optional data to initialize the message builder.
      * @return static
      */
-    public static function new(): self
+    public static function new(array|string|null $json = null): self
     {
-        return new static();
+        return new static($json);
+    }
+
+    public function fill(array|string|null $json = null): void
+    {
+        if (is_string($json)) {
+            $json = json_decode($json, true);
+            if ($json === false) {
+                throw new \InvalidArgumentException('Invalid JSON string provided.');
+            }
+        }
+        /** @var array $json */
+        foreach ($json as $key => $value) {
+            if (property_exists($this, $key)) {
+                $this->{$key} = $value;
+            }
+        }
     }
 
     /**

--- a/src/Discord/Builders/MessageBuilder.php
+++ b/src/Discord/Builders/MessageBuilder.php
@@ -173,7 +173,7 @@ class MessageBuilder implements JsonSerializable
         return new static($json);
     }
 
-    public function fill(array|string|null $json = null): void
+    public function fill(array|string $json): void
     {
         if (is_string($json)) {
             $json = json_decode($json, true);

--- a/src/Discord/Builders/MessageBuilder.php
+++ b/src/Discord/Builders/MessageBuilder.php
@@ -173,7 +173,13 @@ class MessageBuilder implements JsonSerializable
         return new static($json);
     }
 
-    public function fill(array|string $json): void
+    /**
+     * Fills the parts properties from a json array.
+     *
+     * @param array $attributes An array of properties to build the part.
+     * @return $this
+     */
+    public function fill(array|string $json): self
     {
         if (is_string($json)) {
             $json = json_decode($json, true);
@@ -187,6 +193,7 @@ class MessageBuilder implements JsonSerializable
                 $this->{$key} = $value;
             }
         }
+        return $this;
     }
 
     /**

--- a/src/Discord/Builders/MessageBuilder.php
+++ b/src/Discord/Builders/MessageBuilder.php
@@ -165,7 +165,7 @@ class MessageBuilder implements JsonSerializable
     /**
      * Creates a new message builder.
      *
-     * @param array|string|null $json Optional data to initialize the message builder.
+     * @param array|string|null $json Optional data to initialize the builder.
      * @return static
      */
     public static function new(array|string|null $json = null): self
@@ -176,7 +176,7 @@ class MessageBuilder implements JsonSerializable
     /**
      * Fills the parts properties from a json array.
      *
-     * @param array $json An array of properties to build the part.
+     * @param array $json An array of properties to build the builder.
      * @return $this
      */
     public function fill(array|string $json): self

--- a/src/Discord/Builders/MessageBuilder.php
+++ b/src/Discord/Builders/MessageBuilder.php
@@ -176,7 +176,7 @@ class MessageBuilder implements JsonSerializable
     /**
      * Fills the parts properties from a json array.
      *
-     * @param array $attributes An array of properties to build the part.
+     * @param array $json An array of properties to build the part.
      * @return $this
      */
     public function fill(array|string $json): self


### PR DESCRIPTION
This pull request enhances the `MessageBuilder` class to support initialization with optional JSON data, improving flexibility and usability. The most important changes include adding a constructor to handle JSON input, updating the `new` method to pass optional data, and introducing a `fill` method for populating properties.

### Enhancements to `MessageBuilder` initialization:

* **Constructor added**: A new constructor allows initializing the `MessageBuilder` with an optional associative array or JSON string. If a JSON string is provided, it is decoded into an array, and an exception is thrown for invalid JSON.
* **`new` method updated**: The static `new` method now accepts optional JSON data and passes it to the constructor, enabling streamlined object creation with initial values.
* **`fill` method introduced**: A new `fill` method processes an array or JSON string to populate the class properties, ensuring compatibility with both formats and validating input.