### PR TITLE
MessageBuilder::fromMessage

### DIFF
--- a/src/Discord/Builders/MessageBuilder.php
+++ b/src/Discord/Builders/MessageBuilder.php
@@ -16,6 +16,7 @@ use Discord\Builders\Components\Component;
 use Discord\Builders\Components\Contracts\ComponentV2;
 use Discord\Builders\Components\SelectMenu;
 use Discord\Exceptions\FileNotFoundException;
+use Discord\Helpers\ExCollectionInterface;
 use Discord\Helpers\Multipart;
 use Discord\Http\Exceptions\RequestFailedException;
 use Discord\Parts\Channel\Attachment;
@@ -156,6 +157,28 @@ class MessageBuilder implements JsonSerializable
     public static function new(): self
     {
         return new static();
+    }
+
+    public static function fromMessage(Message $message): self
+    {
+        return self::new()
+            ->setContent($message->content)
+            ->setNonce($message->nonce)
+            ->setUsername($message->author->username)
+            ->setAvatarUrl($message->author->avatar)
+            ->setTts($message->tts)
+            ->setEmbeds($message->embeds)
+            //setAllowedMentions($message->allowed_mentions)
+            ->setReplyTo($message->referenced_message)
+            //setForward($message->forward)
+            ->setComponents($message->components)
+            ->setStickers($message->sticker_items)
+            //setFiles($message->files)
+            ->addAttachment($message->attachments)
+            ->setPoll($message->poll)
+            ->setFlags($message->flags)
+            //->setEnforceNonce($message->enforce_nonce)
+            ;
     }
 
     /**
@@ -329,7 +352,7 @@ class MessageBuilder implements JsonSerializable
      *
      * @return $this
      */
-    public function setEmbeds(array $embeds): self
+    public function setEmbeds(ExCollectionInterface|array $embeds): self
     {
         $this->embeds = [];
 
@@ -478,7 +501,7 @@ class MessageBuilder implements JsonSerializable
      *
      * @return $this
      */
-    public function setComponents(array $components): self
+    public function setComponents(ExCollectionInterface|array $components): self
     {
         $this->components = [];
 
@@ -550,7 +573,7 @@ class MessageBuilder implements JsonSerializable
      *
      * @return $this
      */
-    public function setStickers(array $stickers): self
+    public function setStickers(ExCollectionInterface|array $stickers): self
     {
         $this->sticker_ids = [];
 


### PR DESCRIPTION
This pull request introduces enhancements to the `MessageBuilder` class in the `src/Discord/Builders/MessageBuilder.php` file, focusing on improved flexibility and functionality. Key updates include the addition of a new static method for creating a `MessageBuilder` from an existing `Message` object and the extension of several methods to accept both arrays and `ExCollectionInterface` for better compatibility.

### New functionality:
* Added a static method `fromMessage(Message $message): self` to create a `MessageBuilder` instance from an existing `Message` object, initializing it with the message's properties.

### Improved flexibility:
* Updated the `setEmbeds`,  `setComponents`, and `setStickers` methods to accept either an array or an `ExCollectionInterface`. 

### Dependency updates:
* Added `ExCollectionInterface` to the list of imports to support the updated methods.