### PR TITLE
Container::setAccentColor mixed parameter enhancement

### DIFF
--- a/src/Discord/Builders/Components/Container.php
+++ b/src/Discord/Builders/Components/Container.php
@@ -60,6 +60,36 @@ class Container extends Component implements Contracts\ComponentV2
     }
 
     /**
+     * Resolves a color to an integer.
+     *
+     * @param array|int|string $color
+     *
+     * @throws \InvalidArgumentException `$color` cannot be resolved
+     *
+     * @return int
+     */
+    protected static function resolveColor($color): int
+    {
+        if (is_numeric($color)) {
+            $color = (int) $color;
+        }
+
+        if (is_int($color)) {
+            return $color;
+        }
+
+        if (! is_array($color)) {
+            return hexdec((str_replace('#', '', (string) $color)));
+        }
+
+        if (count($color) < 1) {
+            throw new \InvalidArgumentException('Color "'.var_export($color, true).'" is not resolvable');
+        }
+
+        return (($color[0] << 16) + (($color[1] ?? 0) << 8) + ($color[2] ?? 0));
+    }
+
+    /**
      * Adds a component to the container.
      *
      * @param ActionRow|Section|TextDisplay|MediaGallery|File|Separator $component Component to add.

--- a/src/Discord/Builders/Components/Container.php
+++ b/src/Discord/Builders/Components/Container.php
@@ -145,12 +145,16 @@ class Container extends Component implements Contracts\ComponentV2
     /**
      * Sets the accent color for the container.
      *
-     * @param int|null $color Color code for the container.
+     * @param mixed $color Color code for the container.
      *
      * @return $this
      */
-    public function setAccentColor(?int $color): self
+    public function setAccentColor($color): self
     {
+        if ($color !== null) {
+            $color = self::resolveColor($color);
+        }
+
         $this->accent_color = $color;
 
         return $this;


### PR DESCRIPTION
This pull request introduces a utility function to handle color resolution and updates the `setAccentColor` method to support more flexible input types for color codes. These changes enhance the functionality and usability of the `Container` class in the `Discord\Builders\Components` namespace.

### Enhancements to color handling:

* [`src/Discord/Builders/Components/Container.php`](diffhunk://#diff-f94de5508e6be0f5411e4c7b2664a98801357446c46d7c639d6acf26897f9374R62-R91): Added the `resolveColor` method to convert various color formats (array, integer, string) into an integer representation. This method also includes validation to ensure unsupported formats throw an exception.
* [`src/Discord/Builders/Components/Container.php`](diffhunk://#diff-f94de5508e6be0f5411e4c7b2664a98801357446c46d7c639d6acf26897f9374L118-R157): Updated the `setAccentColor` method to accept mixed input types (`array`, `int`, `string`) by utilizing the new `resolveColor` method, improving flexibility in setting the accent color.