### PR TITLE
Automatically wrap SelectMenus in ActionRow

### DIFF
--- a/src/Discord/Builders/Components/ActionRow.php
+++ b/src/Discord/Builders/Components/ActionRow.php
@@ -57,6 +57,14 @@ class ActionRow extends Component
             throw new \InvalidArgumentException('You cannot add another `ActionRow` to this action row.');
         }
 
+        if ($component instanceof SelectMenu) {
+            foreach ($this->components as $existingComponent) {
+                if ($existingComponent instanceof SelectMenu) {
+                    throw new \InvalidArgumentException('You cannot add more than one select menu to an action row.');
+                }
+            }
+        }
+
         if (count($this->components) >= 5) {
             throw new \OverflowException('You can only have 5 components per action row.');
         }

--- a/src/Discord/Builders/Components/Container.php
+++ b/src/Discord/Builders/Components/Container.php
@@ -88,7 +88,6 @@ class Container extends Component implements Contracts\ComponentV2
      * @param ActionRow|SelectMenu|Section|TextDisplay|MediaGallery|File|Separator $component Component to add.
      *
      * @throws \InvalidArgumentException Component is not a valid type.
-     * @throws \OverflowException        Container exceeds 10 components.
      *
      * @return $this
      */

--- a/src/Discord/Builders/Components/Container.php
+++ b/src/Discord/Builders/Components/Container.php
@@ -85,7 +85,7 @@ class Container extends Component implements Contracts\ComponentV2
     /**
      * Adds a component to the container.
      *
-     * @param ActionRow|Section|TextDisplay|MediaGallery|File|Separator $component Component to add.
+     * @param ActionRow|SelectMenu|Section|TextDisplay|MediaGallery|File|Separator $component Component to add.
      *
      * @throws \InvalidArgumentException Component is not a valid type.
      * @throws \OverflowException        Container exceeds 10 components.
@@ -94,16 +94,13 @@ class Container extends Component implements Contracts\ComponentV2
      */
     public function addComponent(Component $component): self
     {
-        /*
-         * This is correct per Discord's documentation,
-         * but undocumented behavior show that ActionRow is not required,
-         * e.g. SelectMenu is a valid component, but would normally be in an ActionRow
-         */
-        /*
+        if ($component instanceof SelectMenu) {
+            $component = ActionRow::new()->addComponent($component);
+        }
+
         if (! ( $component instanceof ActionRow || $component instanceof Section || $component instanceof TextDisplay || $component instanceof MediaGallery || $component instanceof File || $component instanceof Separator )) {
             throw new \InvalidArgumentException('Invalid component type.');
         }
-        */
 
         $this->components[] = $component;
 

--- a/src/Discord/Builders/Components/SelectMenu.php
+++ b/src/Discord/Builders/Components/SelectMenu.php
@@ -527,9 +527,6 @@ abstract class SelectMenu extends Component
             $content['disabled'] = true;
         }
 
-        return [
-            'type' => Component::TYPE_ACTION_ROW,
-            'components' => [$content],
-        ];
+        return $content;
     }
 }

--- a/src/Discord/Builders/MessageBuilder.php
+++ b/src/Discord/Builders/MessageBuilder.php
@@ -441,8 +441,11 @@ class MessageBuilder implements JsonSerializable
                     throw new \OverflowException('You can only add 5 components to a v1 message');
                 }
             }
-            if (! ($component instanceof ActionRow || $component instanceof SelectMenu)) {
-                throw new \InvalidArgumentException('You can only add action rows and select menus as components to v1 messages. Put your other components inside an action row.');
+            if ($component instanceof SelectMenu) {
+                $component = ActionRow::new()->addComponent($component);
+            }
+            if (! $component instanceof ActionRow) {
+                throw new \InvalidArgumentException('You can only add action rows as components to v1 messages. Put your other components inside an action row.');
             }
         } else {
             if (isset($this->components)) {


### PR DESCRIPTION
The old behavior did this directly in [SelectMenu::jsonSerialize](https://github.com/discord-php/DiscordPHP/blob/6ed0ae1a62b105ec1553cc3232ebaae3144e7d6b/src/Discord/Builders/Components/SelectMenu.php#L530), such that anyone adding a SelectMenu manually to an ActionRow (as is the correct usage) would end up with an ActionRow nested inside of another ActionRow, which would always result in Discord rejecting with a `50035 Invalid Form Body` error message.

The new behavior moves this logic directly to Container::addComponent and MessageBuilder::addComponent by creating a new ActionRow and adding the SelectMenu to it, preserving the original usage without breaking containers.