### PR TITLE
MessageInteractionMetadata class

### DIFF
--- a/src/Discord/Parts/Channel/Message.php
+++ b/src/Discord/Parts/Channel/Message.php
@@ -614,7 +614,11 @@ class Message extends Part
      */
     protected function getInteractionMetadataAttribute(): ?MessageInteractionMetadata
     {
-        return $this->attributes['interaction_metadata'] ?? null;
+        if (! isset($this->attributes['interaction_metadata'])) {
+            return null;
+        }
+
+        return $this->createOf(MessageInteractionMetadata::class, (array) $this->attributes['interaction_metadata']);
     }
 
     /**

--- a/src/Discord/Parts/Channel/Message.php
+++ b/src/Discord/Parts/Channel/Message.php
@@ -48,41 +48,41 @@ use function React\Promise\reject;
  *
  * @since 2.0.0
  *
- * @property      string                                 $id                     The unique identifier of the message.
- * @property      string                                 $channel_id             The unique identifier of the channel that the message was sent in.
- * @property-read Channel|Thread                         $channel                The channel that the message was sent in.
- * @property      User|null                              $author                 The author of the message. Will be a webhook if sent from one.
- * @property-read string|null                            $user_id                The user id of the author.
- * @property      string                                 $content                The content of the message if it is a normal message.
- * @property      Carbon                                 $timestamp              A timestamp of when the message was sent.
- * @property      Carbon|null                            $edited_timestamp       A timestamp of when the message was edited, or null.
- * @property      bool                                   $tts                    Whether the message was sent as a text-to-speech message.
- * @property      bool                                   $mention_everyone       Whether the message contained an @everyone mention.
- * @property      ExCollectionInterface|User[]           $mentions               A collection of the users mentioned in the message.
- * @property      ExCollectionInterface|Role[]           $mention_roles          A collection of roles that were mentioned in the message.
- * @property      ExCollectionInterface|Channel[]        $mention_channels       Collection of mentioned channels.
- * @property      ExCollectionInterface|Attachment[]     $attachments            Collection of attachment objects.
- * @property      ExCollectionInterface|Embed[]          $embeds                 A collection of embed objects.
- * @property      ReactionRepository                     $reactions              Collection of reactions on the message.
- * @property      string|null                            $nonce                  A randomly generated string that provides verification for the client. Not required.
- * @property      bool                                   $pinned                 Whether the message is pinned to the channel.
- * @property      string|null                            $webhook_id             ID of the webhook that made the message, if any.
- * @property      int                                    $type                   The type of message.
- * @property      object|null                            $activity               Current message activity. Requires rich presence.
- * @property      object|null                            $application            Application of message. Requires rich presence.
- * @property      string|null                            $application_id         If the message is a response to an Interaction, this is the id of the interaction's application.
- * @property      int|null                               $flags                  Message flags.
- * @property      object|null                            $message_reference      Message that is referenced by this message. Data showing the source of a crosspost, channel follow add, pin, or reply message.
- * @property      object|null                            $message_snapshot       The message associated with the message_reference. This is a minimal subset of fields in a message (e.g. author is excluded.).
- * @property      Message|null                           $referenced_message     The message that is referenced in a reply.
- * @property      MessageInteractionMetadata|null        $interaction_metadata   Sent if the message is sent as a result of an interaction.
- * @property      MessageInteraction|null                $interaction            Sent if the message is a response to an Interaction.
- * @property      Thread|null                            $thread                 The thread that was started from this message, includes thread member object.
- * @property      ExCollectionInterface|Component[]|null $components             Sent if the message contains components like buttons, action rows, or other interactive components.
- * @property      ExCollectionInterface|Sticker[]|null   $sticker_items          Stickers attached to the message.
- * @property      int|null                               $position               A generally increasing integer (there may be gaps or duplicates) that represents the approximate position of the message in a thread, it can be used to estimate the relative position of the message in a thread in company with `total_message_sent` on parent thread.
- * @property      object|null                            $role_subscription_data Data of the role subscription purchase or renewal that prompted this `ROLE_SUBSCRIPTION_PURCHASE` message.
- * @property      Poll|null                              $poll                   The poll attached to the message.
+ * @property      string                                       $id                     The unique identifier of the message.
+ * @property      string                                       $channel_id             The unique identifier of the channel that the message was sent in.
+ * @property-read Channel|Thread                               $channel                The channel that the message was sent in.
+ * @property      User|null                                    $author                 The author of the message. Will be a webhook if sent from one.
+ * @property-read string|null                                  $user_id                The user id of the author.
+ * @property      string                                       $content                The content of the message if it is a normal message.
+ * @property      Carbon                                       $timestamp              A timestamp of when the message was sent.
+ * @property      Carbon|null                                  $edited_timestamp       A timestamp of when the message was edited, or null.
+ * @property      bool                                         $tts                    Whether the message was sent as a text-to-speech message.
+ * @property      bool                                         $mention_everyone       Whether the message contained an @everyone mention.
+ * @property      ExCollectionInterface|User[]                 $mentions               A collection of the users mentioned in the message.
+ * @property      ExCollectionInterface|Role[]                 $mention_roles          A collection of roles that were mentioned in the message.
+ * @property      ExCollectionInterface|Channel[]              $mention_channels       Collection of mentioned channels.
+ * @property      ExCollectionInterface|Attachment[]           $attachments            Collection of attachment objects.
+ * @property      ExCollectionInterface|Embed[]                $embeds                 A collection of embed objects.
+ * @property      ReactionRepository                           $reactions              Collection of reactions on the message.
+ * @property      string|null                                  $nonce                  A randomly generated string that provides verification for the client. Not required.
+ * @property      bool                                         $pinned                 Whether the message is pinned to the channel.
+ * @property      string|null                                  $webhook_id             ID of the webhook that made the message, if any.
+ * @property      int                                          $type                   The type of message.
+ * @property      object|null                                  $activity               Current message activity. Requires rich presence.
+ * @property      object|null                                  $application            Application of message. Requires rich presence.
+ * @property      string|null                                  $application_id         If the message is a response to an Interaction, this is the id of the interaction's application.
+ * @property      int|null                                     $flags                  Message flags.
+ * @property      object|null                                  $message_reference      Message that is referenced by this message. Data showing the source of a crosspost, channel follow add, pin, or reply message.
+ * @property      object|null                                  $message_snapshot       The message associated with the message_reference. This is a minimal subset of fields in a message (e.g. author is excluded.).
+ * @property      Message|null                                 $referenced_message     The message that is referenced in a reply.
+ * @property      MessageInteractionMetadata|null              $interaction_metadata   Sent if the message is sent as a result of an interaction.
+ * @property      MessageInteraction|null                      $interaction            Sent if the message is a response to an Interaction.
+ * @property      Thread|null                                  $thread                 The thread that was started from this message, includes thread member object.
+ * @property      ExCollectionInterface|Component[]|null       $components             Sent if the message contains components like buttons, action rows, or other interactive components.
+ * @property      ExCollectionInterface|Sticker[]|null         $sticker_items          Stickers attached to the message.
+ * @property      int|null                                     $position               A generally increasing integer (there may be gaps or duplicates) that represents the approximate position of the message in a thread, it can be used to estimate the relative position of the message in a thread in company with `total_message_sent` on parent thread.
+ * @property      object|null                                  $role_subscription_data Data of the role subscription purchase or renewal that prompted this `ROLE_SUBSCRIPTION_PURCHASE` message.
+ * @property      Poll|null                                    $poll                   The poll attached to the message.
  *
  * @property-read bool $crossposted                            Message has been crossposted.
  * @property-read bool $is_crosspost                           Message is a crosspost from another channel.

--- a/src/Discord/Parts/Channel/Message.php
+++ b/src/Discord/Parts/Channel/Message.php
@@ -17,7 +17,7 @@ use Carbon\Carbon;
 use Discord\Builders\MessageBuilder;
 use Discord\Helpers\Collection;
 use Discord\Helpers\ExCollectionInterface;
-use Discord\Parts\Channel\Poll;
+use Discord\Parts\Channel\Message\MessageInteractionMetadata;
 use Discord\Parts\Embed\Embed;
 use Discord\Parts\Guild\Emoji;
 use Discord\Parts\Guild\Role;
@@ -75,6 +75,7 @@ use function React\Promise\reject;
  * @property      object|null                            $message_reference      Message that is referenced by this message. Data showing the source of a crosspost, channel follow add, pin, or reply message.
  * @property      object|null                            $message_snapshot       The message associated with the message_reference. This is a minimal subset of fields in a message (e.g. author is excluded.).
  * @property      Message|null                           $referenced_message     The message that is referenced in a reply.
+ * @property      MessageInteractionMetadata|null        $interaction_metadata   Sent if the message is sent as a result of an interaction.
  * @property      MessageInteraction|null                $interaction            Sent if the message is a response to an Interaction.
  * @property      Thread|null                            $thread                 The thread that was started from this message, includes thread member object.
  * @property      ExCollectionInterface|Component[]|null $components             Sent if the message contains components like buttons, action rows, or other interactive components.
@@ -603,6 +604,17 @@ class Message extends Part
         }
 
         return $embeds;
+    }
+
+    /**
+     * Returns the interaction_metadata attribute, if present.
+     * Contains metadata about the interaction that caused this message.
+     *
+     * @return object|null
+     */
+    protected function getInteractionMetadataAttribute(): ?MessageInteractionMetadata
+    {
+        return $this->attributes['interaction_metadata'] ?? null;
     }
 
     /**

--- a/src/Discord/Parts/Channel/Message.php
+++ b/src/Discord/Parts/Channel/Message.php
@@ -618,7 +618,7 @@ class Message extends Part
             return null;
         }
 
-        return $this->createOf(MessageInteractionMetadata::class, (array) $this->attributes['interaction_metadata']);
+        return $this->createOf(MessageInteractionMetadata::class, (array) $this->attributes['interaction_metadata'] + ['guild_id' => $this->guild_id] + ['channel_id' => $this->channel_id]);
     }
 
     /**

--- a/src/Discord/Parts/Channel/Message.php
+++ b/src/Discord/Parts/Channel/Message.php
@@ -220,6 +220,7 @@ class Message extends Part
         'message_snapshot',
         'flags',
         'referenced_message',
+        'interaction_metadata',
         'interaction',
         'thread',
         'components',
@@ -227,7 +228,6 @@ class Message extends Part
         'position',
         'role_subscription_data',
         'poll',
-
         // @internal
         'guild_id',
         'member',
@@ -610,7 +610,7 @@ class Message extends Part
      * Returns the interaction_metadata attribute, if present.
      * Contains metadata about the interaction that caused this message.
      *
-     * @return object|null
+     * @return MessageInteractionMetadata|null
      */
     protected function getInteractionMetadataAttribute(): ?MessageInteractionMetadata
     {

--- a/src/Discord/Parts/Channel/Message/MessageInteractionMetadata.php
+++ b/src/Discord/Parts/Channel/Message/MessageInteractionMetadata.php
@@ -68,6 +68,7 @@ class MessageInteractionMetadata extends Part
         if (!isset($this->attributes['target_user'])) {
             return null;
         }
+
         return $this->factory->part(User::class, (array) $this->attributes['target_user'], true);
     }
 
@@ -81,6 +82,7 @@ class MessageInteractionMetadata extends Part
         if (!isset($this->attributes['triggering_interaction_metadata'])) {
             return null;
         }
+
         return $this->factory->part(self::class, (array) $this->attributes['triggering_interaction_metadata'], true);
     }
 }

--- a/src/Discord/Parts/Channel/Message/MessageInteractionMetadata.php
+++ b/src/Discord/Parts/Channel/Message/MessageInteractionMetadata.php
@@ -64,6 +64,14 @@ class MessageInteractionMetadata extends Part
     ];
 
     /**
+     * {@inheritDoc}
+     */
+    protected $hidden = [
+        'guild_id',
+        'channel_id'
+    ];
+
+    /**
      * Returns the user who triggered the interaction.
      *
      * @return User

--- a/src/Discord/Parts/Channel/Message/MessageInteractionMetadata.php
+++ b/src/Discord/Parts/Channel/Message/MessageInteractionMetadata.php
@@ -34,9 +34,9 @@ use Discord\Parts\User\User;
  * @property string|null                     $interacted_message_id           The ID of the message that contained the interactive component (message component interactions only).
  * @property MessageInteractionMetadata|null $triggering_interaction_metadata Metadata for the interaction that was used to open the modal (modal submit interactions only).
  *
- * @property-read ?string|null  $guild_id                  The ID of the guild the interaction was sent in.
+ * @property-read string        $guild_id                  The ID of the guild the interaction was sent in.
  * @property-read ?Guild|null   $guild                     The guild the interaction was sent in.
- * @property-read ?string|null  $channel_id                The ID of the channel the interaction was sent in.
+ * @property-read string        $channel_id                The ID of the channel the interaction was sent in.
  * @property-read ?Channel|null $channel                   The channel the interaction was sent in.
  * @property-read ?Message|null $original_response_message The original response message (follow-ups only).
  * @property-read ?Message|null $target_message            The message the command was run on (message command interactions only).

--- a/src/Discord/Parts/Channel/Message/MessageInteractionMetadata.php
+++ b/src/Discord/Parts/Channel/Message/MessageInteractionMetadata.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is a part of the DiscordPHP project.
+ *
+ * Copyright (c) 2015-present David Cole <david.cole1340@gmail.com>
+ *
+ * This file is subject to the MIT license that is bundled
+ * with this source code in the LICENSE.md file.
+ */
+
+namespace Discord\Parts\Channel\Message;
+
+use Discord\Parts\Part;
+use Discord\Parts\User\User;
+
+/**
+ * Represents metadata about the interaction that caused a message.
+ *
+ * @link https://discord.com/developers/docs/resources/message#message-interaction-metadata-object
+ *
+ * @property string                          $id                              ID of the interaction.
+ * @property int                             $type                            Type of interaction.
+ * @property User                            $user                            User who triggered the interaction.
+ * @property array                           $authorizing_integration_owners  IDs for installation context(s) related to the interaction.
+ * @property string|null                     $original_response_message_id    ID of the original response message (follow-ups only).
+ * @property User|null                       $target_user                     The user the command was run on (user command interactions only).
+ * @property string|null                     $target_message_id               The ID of the message the command was run on (message command interactions only).
+ * @property string|null                     $interacted_message_id           The ID of the message that contained the interactive component (message component interactions only).
+ * @property MessageInteractionMetadata|null $triggering_interaction_metadata Metadata for the interaction that was used to open the modal (modal submit interactions only).
+ */
+class MessageInteractionMetadata extends Part
+{
+    /**
+     * {@inheritDoc}
+     */
+    protected $fillable = [
+        'id',
+        'type',
+        'user',
+        'authorizing_integration_owners',
+        'original_response_message_id',
+        'target_user',
+        'target_message_id',
+        'interacted_message_id',
+        'triggering_interaction_metadata',
+    ];
+
+    /**
+     * Returns the user who triggered the interaction.
+     *
+     * @return User
+     */
+    protected function getUserAttribute(): User
+    {
+        return $this->factory->part(User::class, (array) $this->attributes['user'], true);
+    }
+
+    /**
+     * Returns the target user (if present).
+     *
+     * @return User|null
+     */
+    protected function getTargetUserAttribute(): ?User
+    {
+        if (!isset($this->attributes['target_user'])) {
+            return null;
+        }
+        return $this->factory->part(User::class, (array) $this->attributes['target_user'], true);
+    }
+
+    /**
+     * Returns the triggering interaction metadata (for modal submit interactions).
+     *
+     * @return MessageInteractionMetadata|null
+     */
+    protected function getTriggeringInteractionMetadataAttribute(): ?MessageInteractionMetadata
+    {
+        if (!isset($this->attributes['triggering_interaction_metadata'])) {
+            return null;
+        }
+        return $this->factory->part(self::class, (array) $this->attributes['triggering_interaction_metadata'], true);
+    }
+}

--- a/src/Discord/Parts/Channel/Message/MessageInteractionMetadata.php
+++ b/src/Discord/Parts/Channel/Message/MessageInteractionMetadata.php
@@ -112,7 +112,11 @@ class MessageInteractionMetadata extends Part
             return null;
         }
 
-        // @TODO
+        if (! $channel = $this->channel) {
+            return null;
+        }
+
+        return $channel->messages->get('id', $this->attributes['original_response_message_id']);
     }
 
     /**

--- a/src/Discord/Parts/Channel/Message/MessageInteractionMetadata.php
+++ b/src/Discord/Parts/Channel/Message/MessageInteractionMetadata.php
@@ -13,6 +13,9 @@ declare(strict_types=1);
 
 namespace Discord\Parts\Channel\Message;
 
+use Discord\Parts\Channel\Channel;
+use Discord\Parts\Channel\Message;
+use Discord\Parts\Guild\Guild;
 use Discord\Parts\Part;
 use Discord\Parts\User\User;
 
@@ -30,6 +33,14 @@ use Discord\Parts\User\User;
  * @property string|null                     $target_message_id               The ID of the message the command was run on (message command interactions only).
  * @property string|null                     $interacted_message_id           The ID of the message that contained the interactive component (message component interactions only).
  * @property MessageInteractionMetadata|null $triggering_interaction_metadata Metadata for the interaction that was used to open the modal (modal submit interactions only).
+ *
+ * @property-read ?string|null  $guild_id                  The ID of the guild the interaction was sent in.
+ * @property-read ?Guild|null   $guild                     The guild the interaction was sent in.
+ * @property-read ?string|null  $channel_id                The ID of the channel the interaction was sent in.
+ * @property-read ?Channel|null $channel                   The channel the interaction was sent in.
+ * @property-read ?Message|null $original_response_message The original response message (follow-ups only).
+ * @property-read ?Message|null $target_message            The message the command was run on (message command interactions only).
+ * @property-read ?Message|null $interacted_message        The message that contained the interactive component (message component interactions only).
  */
 class MessageInteractionMetadata extends Part
 {
@@ -46,6 +57,10 @@ class MessageInteractionMetadata extends Part
         'target_message_id',
         'interacted_message_id',
         'triggering_interaction_metadata',
+
+        // @internal
+        'guild_id',
+        'channel_id',
     ];
 
     /**
@@ -84,5 +99,77 @@ class MessageInteractionMetadata extends Part
         }
 
         return $this->factory->part(self::class, (array) $this->attributes['triggering_interaction_metadata'], true);
+    }
+
+    /**
+     * Returns the original response message associated with this interaction, if available.
+     *
+     * @return Message|null
+     */
+    protected function getOriginalResponseMessageAttribute(): ?Message
+    {
+        if (!isset($this->attributes['original_response_message_id'])) {
+            return null;
+        }
+
+        // @TODO
+    }
+
+    /**
+     * Returns the target message associated with this interaction, if available.
+     *
+     * @return Message|null
+     */
+    protected function getTargetMessageAttribute(): ?Message
+    {
+        if (!isset($this->attributes['target_message_id'])) {
+            return null;
+        }
+
+        if (! $channel = $this->channel) {
+            return null;
+        }
+
+        return $channel->messages->get('id', $this->attributes['target_message_id']);
+    }
+
+    /**
+     * Returns the interacted message associated with this interaction, if available.
+     *
+     * @return Message|null
+     */
+    protected function getInteractedMessageAttribute(): ?Message
+    {
+        if (!isset($this->attributes['interacted_message_id'])) {
+            return null;
+        }
+
+        if (! $channel = $this->channel) {
+            return null;
+        }
+
+        return $channel->messages->get('id', $this->attributes['interacted_message_id']);
+    }
+
+    protected function getGuildAttribute(): ?Guild
+    {
+        if (!isset($this->attributes['guild_id'])) {
+            return null;
+        }
+
+        return $this->discord->guilds->get('id', $this->attributes['guild_id']);
+    }
+
+    protected function getChannelAttribute(): ?Channel
+    {
+        if (!isset($this->attributes['channel_id'])) {
+            return null;
+        }
+
+        if (! $guild = $this->guild) {
+            return null;
+        }
+
+        return $guild->channels->get('id', $this->attributes['channel_id']);
     }
 }

--- a/src/Discord/Parts/Channel/Message/MessageInteractionMetadata.php
+++ b/src/Discord/Parts/Channel/Message/MessageInteractionMetadata.php
@@ -22,6 +22,8 @@ use Discord\Parts\User\User;
 /**
  * Represents metadata about the interaction that caused a message.
  *
+ * @since 10.11.2
+ *
  * @link https://discord.com/developers/docs/resources/message#message-interaction-metadata-object
  *
  * @property string                          $id                              ID of the interaction.


### PR DESCRIPTION
This pull request introduces support for handling interaction metadata in Discord messages, enabling the retrieval and representation of metadata about interactions that caused a message. The key changes include adding a new `MessageInteractionMetadata` class, updating the `Message` class to incorporate this metadata, and defining methods to access it.

### Enhancements to `Message` class:

* Added a new property `interaction_metadata` to the `Message` class, representing metadata about the interaction that caused the message.
* Introduced the `getInteractionMetadataAttribute` method in the `Message` class to retrieve the `interaction_metadata` attribute, if present.

### Addition of `MessageInteractionMetadata` class:

* Created a new `MessageInteractionMetadata` class to represent interaction metadata, including properties like `id`, `type`, `user`, and other related fields.
* Defined methods in `MessageInteractionMetadata` for accessing nested attributes, such as the user who triggered the interaction and metadata for triggering interactions.

### Codebase adjustments:

* Updated imports in `Message.php` to include the new `MessageInteractionMetadata` class and remove the unused `Poll` class.