### PR TITLE
MessageCall class

### DIFF
--- a/src/Discord/Parts/Channel/Message.php
+++ b/src/Discord/Parts/Channel/Message.php
@@ -28,6 +28,7 @@ use Discord\Parts\WebSockets\MessageReaction;
 use Discord\WebSockets\Event;
 use Discord\Http\Endpoint;
 use Discord\Http\Exceptions\NoPermissionsException;
+use Discord\Parts\Channel\Message\MessageCall;
 use Discord\Parts\Guild\Guild;
 use Discord\Parts\Guild\Sticker;
 use Discord\Parts\Interactions\Request\Component;
@@ -227,6 +228,7 @@ class Message extends Part
         'position',
         'role_subscription_data',
         'poll',
+        'call',
 
         // @internal
         'guild_id',
@@ -770,6 +772,20 @@ class Message extends Part
         }
 
         return $this->factory->part(Poll::class, (array) $this->attributes['poll'] + ['channel_id' => $this->channel_id, 'message_id' => $this->id], true);
+    }
+
+    /**
+     * Returns the call attribute.
+     *
+     * @return MessageCall|null
+     */
+    protected function getCallAttribute(): ?MessageCall
+    {
+        if (! isset($this->attributes['call'])) {
+            return null;
+        }
+
+        return $this->factory->part(MessageCall::class, (array) $this->attributes['call'], true);
     }
 
     /**

--- a/src/Discord/Parts/Channel/Message.php
+++ b/src/Discord/Parts/Channel/Message.php
@@ -82,6 +82,7 @@ use function React\Promise\reject;
  * @property      int|null                               $position               A generally increasing integer (there may be gaps or duplicates) that represents the approximate position of the message in a thread, it can be used to estimate the relative position of the message in a thread in company with `total_message_sent` on parent thread.
  * @property      object|null                            $role_subscription_data Data of the role subscription purchase or renewal that prompted this `ROLE_SUBSCRIPTION_PURCHASE` message.
  * @property      Poll|null                              $poll                   The poll attached to the message.
+ * @property      MessageCall|null                       $call                   The call associated with the message
  *
  * @property-read bool $crossposted                            Message has been crossposted.
  * @property-read bool $is_crosspost                           Message is a crosspost from another channel.

--- a/src/Discord/Parts/Channel/Message/MessageCall.php
+++ b/src/Discord/Parts/Channel/Message/MessageCall.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is a part of the DiscordPHP project.
+ *
+ * Copyright (c) 2015-present David Cole <david.cole1340@gmail.com>
+ *
+ * This file is subject to the MIT license that is bundled
+ * with this source code in the LICENSE.md file.
+ */
+
+namespace Discord\Parts\Channel\Message;
+
+use Discord\Parts\Part;
+
+/**
+ * Represents information about a call in a private channel.
+ *
+ * @link https://discord.com/developers/docs/resources/message#message-call-object
+ *
+ * @property array       $participants     Array of user object IDs that participated in the call.
+ * @property string|null $ended_timestamp  Time when the call ended (ISO8601 timestamp), or null if ongoing.
+ */
+class MessageCall extends Part
+{
+    /**
+     * {@inheritDoc}
+     */
+    protected $fillable = [
+        'participants',
+        'ended_timestamp',
+    ];
+
+    /**
+     * Gets the participants attribute.
+     *
+     * @return array Array of user IDs (snowflakes).
+     */
+    protected function getParticipantsAttribute(): array
+    {
+        return $this->attributes['participants'] ?? [];
+    }
+
+    /**
+     * Gets the ended_timestamp attribute.
+     *
+     * @return string|null ISO8601 timestamp or null.
+     */
+    protected function getEndedTimestampAttribute(): ?string
+    {
+        return $this->attributes['ended_timestamp'] ?? null;
+    }
+}

--- a/src/Discord/Parts/Channel/Message/MessageCall.php
+++ b/src/Discord/Parts/Channel/Message/MessageCall.php
@@ -68,14 +68,6 @@ class MessageCall extends Part
      */
     protected function getUsersAttribute(): array
     {
-        $users = [];
-
-        foreach ($this->attributes['participants'] as $userData) {
-            if (is_string($userData)) {
-                $users[] = $this->discord->users->get('id', $userData) ?? $this->factory->create(User::class, ['id' => $userData], true);
-            }
-        }
-
-        return $users;
+        return array_map(fn($userData) => $this->discord->users->get('id', $userData) ?? $this->factory->create(User::class, ['id' => $userData], true), $this->attributes['participants']);
     }
 }

--- a/src/Discord/Parts/Channel/Message/MessageCall.php
+++ b/src/Discord/Parts/Channel/Message/MessageCall.php
@@ -24,6 +24,8 @@ use Discord\Parts\User\User;
  *
  * @property array        $participants      Array of user object IDs that participated in the call.
  * @property ?Carbon|null $ended_timestamp   Time when the call ended (ISO8601 timestamp), or null if ongoing.
+ *
+ * @property-read User[]  $users Array of user objects that participated in the call.
  */
 class MessageCall extends Part
 {
@@ -46,24 +48,6 @@ class MessageCall extends Part
     }
 
     /**
-     * Gets the participants users.
-     *
-     * @return User[]
-     */
-    protected function getParticipantUsersAttribute(): array
-    {
-        $users = [];
-
-        foreach ($this->attributes['participants'] as $userData) {
-            if (is_string($userData)) {
-                $users[] = $this->discord->users->get('id', $userData) ?? $this->factory->create(User::class, ['id' => $userData], true);
-            }
-        }
-
-        return $users;
-    }
-
-    /**
      * Gets the ended timestamp.
      *
      * @return Carbon|null
@@ -75,5 +59,23 @@ class MessageCall extends Part
         }
 
         return Carbon::parse($this->attributes['ended_timestamp']);
+    }
+
+    /**
+     * Gets the users.
+     *
+     * @return User[]
+     */
+    protected function getUsersAttribute(): array
+    {
+        $users = [];
+
+        foreach ($this->attributes['participants'] as $userData) {
+            if (is_string($userData)) {
+                $users[] = $this->discord->users->get('id', $userData) ?? $this->factory->create(User::class, ['id' => $userData], true);
+            }
+        }
+
+        return $users;
     }
 }

--- a/src/Discord/Parts/Channel/Message/MessageCall.php
+++ b/src/Discord/Parts/Channel/Message/MessageCall.php
@@ -20,6 +20,8 @@ use Discord\Parts\User\User;
 /**
  * Represents information about a call in a private channel.
  *
+ * @since 10.11.2
+ *
  * @link https://discord.com/developers/docs/resources/message#message-call-object
  *
  * @property array        $participants      Array of user object IDs that participated in the call.
@@ -36,16 +38,6 @@ class MessageCall extends Part
         'participants',
         'ended_timestamp',
     ];
-
-    /**
-     * Gets the participants attribute.
-     *
-     * @return array Array of user IDs (snowflakes).
-     */
-    protected function getParticipantsAttribute(): array
-    {
-        return $this->attributes['participants'];
-    }
 
     /**
      * Gets the ended timestamp.
@@ -68,6 +60,9 @@ class MessageCall extends Part
      */
     protected function getUsersAttribute(): array
     {
-        return array_map(fn($userData) => $this->discord->users->get('id', $userData) ?? $this->factory->create(User::class, ['id' => $userData], true), $this->attributes['participants']);
+        return array_map(
+            fn($userData) => $this->discord->users->get('id', $userData) ?? $this->factory->create(User::class, ['id' => $userData], true),
+            $this->attributes['participants']
+        );
     }
 }

--- a/src/Discord/Parts/Channel/Message/MessageCall.php
+++ b/src/Discord/Parts/Channel/Message/MessageCall.php
@@ -23,7 +23,7 @@ use Discord\Parts\User\User;
  * @link https://discord.com/developers/docs/resources/message#message-call-object
  *
  * @property array        $participants      Array of user object IDs that participated in the call.
- * @property ?Carbon|null $ended_timestamp  Time when the call ended (ISO8601 timestamp), or null if ongoing.
+ * @property ?Carbon|null $ended_timestamp   Time when the call ended (ISO8601 timestamp), or null if ongoing.
  */
 class MessageCall extends Part
 {


### PR DESCRIPTION
This pull request introduces support for a new `MessageCall` object in the DiscordPHP library, which represents information about calls in private channels. The most important changes include adding a new property to the `Message` class for referencing `MessageCall` and defining the `MessageCall` class with its attributes and methods.

### Enhancements to the `Message` class:

* Added a new `call` property to the `Message` class to represent the call associated with a message. This property is of type `MessageCall` and is nullable.

### Addition of the `MessageCall` class:

* Introduced the `MessageCall` class to encapsulate call-related data, including `participants` (array of user IDs) and `ended_timestamp` (ISO8601 timestamp or null if the call is ongoing). This class includes methods to retrieve these attributes.