### PR TITLE
Static generateuuid

### DIFF
--- a/src/Discord/Builders/Components/Button.php
+++ b/src/Discord/Builders/Components/Button.php
@@ -116,7 +116,7 @@ class Button extends Component
 
         $this->style = $style;
         if ($this->style != self::STYLE_LINK) {
-            $this->setCustomId($custom_id ?? $this->generateUuid());
+            $this->setCustomId($custom_id ?? self::generateUuid());
         }
     }
 
@@ -320,7 +320,7 @@ class Button extends Component
         }
 
         if (! isset($this->custom_id)) {
-            $this->custom_id = $this->generateUuid();
+            $this->custom_id = self::generateUuid();
         }
 
         // Remove any existing listener

--- a/src/Discord/Builders/Components/Option.php
+++ b/src/Discord/Builders/Components/Option.php
@@ -80,7 +80,7 @@ class Option extends Component
         }
 
         $this->label = $label;
-        $this->value = $value ?? $this->generateUuid();
+        $this->value = $value ?? self::generateUuid();
     }
 
     /**

--- a/src/Discord/Builders/Components/SelectMenu.php
+++ b/src/Discord/Builders/Components/SelectMenu.php
@@ -120,7 +120,7 @@ abstract class SelectMenu extends Component
      */
     public function __construct(?string $custom_id)
     {
-        $this->setCustomId($custom_id ?? $this->generateUuid());
+        $this->setCustomId($custom_id ?? self::generateUuid());
     }
 
     /**

--- a/src/Discord/Builders/Components/TextInput.php
+++ b/src/Discord/Builders/Components/TextInput.php
@@ -94,7 +94,7 @@ class TextInput extends Component
     {
         $this->setLabel($label);
         $this->setStyle($style);
-        $this->setCustomId($custom_id ?? $this->generateUuid());
+        $this->setCustomId($custom_id ?? self::generateUuid());
     }
 
     /**


### PR DESCRIPTION
This pull request refactors the usage of the `generateUuid` method across multiple components in the `src/Discord/Builders/Components` directory. The changes ensure that `generateUuid` is consistently called as a static method (`self::generateUuid()`) rather than an instance method (`$this->generateUuid()`).

### Refactoring of `generateUuid` usage:

* `src/Discord/Builders/Components/Button.php`:
  - Updated `__construct` to use `self::generateUuid` for setting the `custom_id` when not provided.
  - Updated `setListener` to use `self::generateUuid` for assigning a default `custom_id`.

* `src/Discord/Builders/Components/Option.php`:
  - Updated `__construct` to use `self::generateUuid` for setting the `value` when not provided.

* `src/Discord/Builders/Components/SelectMenu.php`:
  - Updated `__construct` to use `self::generateUuid` for setting the `custom_id` when not provided.

* `src/Discord/Builders/Components/TextInput.php`:
  - Updated `__construct` to use `self::generateUuid` for setting the `custom_id` when not provided.