### PR TITLE
Message reference

### DIFF
--- a/src/Discord/Parts/Channel/Message.php
+++ b/src/Discord/Parts/Channel/Message.php
@@ -28,6 +28,7 @@ use Discord\Parts\WebSockets\MessageReaction;
 use Discord\WebSockets\Event;
 use Discord\Http\Endpoint;
 use Discord\Http\Exceptions\NoPermissionsException;
+use Discord\Parts\Channel\Message\MessageReference;
 use Discord\Parts\Guild\Guild;
 use Discord\Parts\Guild\Sticker;
 use Discord\Parts\Interactions\Request\Component;
@@ -72,7 +73,7 @@ use function React\Promise\reject;
  * @property      object|null                            $application            Application of message. Requires rich presence.
  * @property      string|null                            $application_id         If the message is a response to an Interaction, this is the id of the interaction's application.
  * @property      int|null                               $flags                  Message flags.
- * @property      object|null                            $message_reference      Message that is referenced by this message. Data showing the source of a crosspost, channel follow add, pin, or reply message.
+ * @property      MessageReference|null                  $message_reference      Message that is referenced by this message. Data showing the source of a crosspost, channel follow add, pin, or reply message.
  * @property      object|null                            $message_snapshot       The message associated with the message_reference. This is a minimal subset of fields in a message (e.g. author is excluded.).
  * @property      Message|null                           $referenced_message     The message that is referenced in a reply.
  * @property      MessageInteraction|null                $interaction            Sent if the message is a response to an Interaction.
@@ -655,6 +656,15 @@ class Message extends Part
         }
 
         return null;
+    }
+
+    protected function getMessageReferenceAttribute(): ?MessageReference
+    {
+        if (! isset($this->attributes['message_reference'])) {
+            return null;
+        }
+
+        return $this->factory->part(MessageReference::class, (array) $this->attributes['message_reference'], true);
     }
 
     /**

--- a/src/Discord/Parts/Channel/Message.php
+++ b/src/Discord/Parts/Channel/Message.php
@@ -664,7 +664,7 @@ class Message extends Part
             return null;
         }
 
-        return $this->factory->part(MessageReference::class, (array) $this->attributes['message_reference'], true);
+        return $this->createOf(MessageReference::class, $this->attributes['message_reference']);
     }
 
     /**

--- a/src/Discord/Parts/Channel/Message/MessageReference.php
+++ b/src/Discord/Parts/Channel/Message/MessageReference.php
@@ -1,0 +1,181 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is a part of the DiscordPHP project.
+ *
+ * Copyright (c) 2015-present David Cole <david.cole1340@gmail.com>
+ *
+ * This file is subject to the MIT license that is bundled
+ * with this source code in the LICENSE.md file.
+ */
+
+namespace Discord\Parts\Channel\Message;
+
+use Discord\Parts\Channel\Channel;
+use Discord\Parts\Channel\Message;
+use Discord\Parts\Guild\Guild;
+use Discord\Parts\Part;
+use JsonSerializable;
+
+/**
+ * Represents a message reference object, which points to another message for replies, forwards, pins, etc.
+ *
+ * @link https://discord.com/developers/docs/resources/message#message-reference-structure
+ *
+ * @property int|null    $type                Type of reference (0 = DEFAULT, 1 = FORWARD).
+ * @property string|null $message_id          ID of the originating message.
+ * @property string|null $channel_id          ID of the originating message's channel.
+ * @property string|null $guild_id            ID of the originating message's guild.
+ * @property bool|null   $fail_if_not_exists  Whether to error if the referenced message doesn't exist (default true).
+ *
+ * @property-read Message|null        $message  The originating message.
+ * @property-read Channel|Thread|null $channel  The originating message's channel.
+ * @property-read Guild|null          $guild    The originating message's guild.
+ */
+class MessageReference extends Part implements JsonSerializable
+{
+    public const TYPE_DEFAULT = 0;
+    public const TYPE_FORWARD = 1;
+
+    /**
+     * The type of the message reference.
+     *
+     * @var int|null
+     */
+    protected $type;
+    /**
+     * The ID of the message being referenced.
+     *
+     * @var string|null
+     */
+    protected $message_id;
+    /**
+     * The ID of the channel the message was sent in.
+     *
+     * @var string|null
+     */
+    protected $channel_id;
+    /**
+     * The ID of the guild the message was sent in.
+     *
+     * @var string|null
+     */
+    protected $guild_id;
+    /**
+     * Whether to fail if the message does not exist.
+     *
+     * @var bool|null
+     */
+    protected $fail_if_not_exists;
+
+    /**
+     * {@inheritDoc}
+     */
+    protected $fillable = [
+        'type',
+        'message_id',
+        'channel_id',
+        'guild_id',
+        'fail_if_not_exists',
+    ];
+
+    /**
+     * Gets the message attribute.
+     *
+     * @return Message|null
+     */
+    protected function getMessageAttribute(): ?Message
+    {
+        if (!$this->message_id) {
+            return null;
+        }
+
+        if ($channel = $this->channel) {
+            return $channel->messages->get('id', $this->message_id);
+        }
+
+        return null;
+    }
+
+    /**
+     * Returns the channel attribute.
+     *
+     * @return Channel|Thread The channel or thread the message was sent in.
+     */
+    protected function getChannelAttribute(): ?Part
+    {
+        if (!$this->channel_id) {
+            return null;
+        }
+
+        if ($guild = $this->guild) {
+            $channels = $guild->channels;
+            if ($channel = $channels->get('id', $this->channel_id)) {
+                return $channel;
+            }
+
+            foreach ($channels as $parent) {
+                if ($thread = $parent->threads->get('id', $this->channel_id)) {
+                    return $thread;
+                }
+            }
+        }
+
+        // @todo potentially slow
+        if ($channel = $this->discord->getChannel($this->channel_id)) {
+            return $channel;
+        }
+
+        return $this->factory->part(Channel::class, [
+            'id' => $this->channel_id,
+            'type' => Channel::TYPE_DM,
+        ], true);
+    }
+
+    /**
+     * Returns the guild which the channel that the message was sent in belongs to.
+     *
+     * @return Guild|null
+     */
+    protected function getGuildAttribute(): ?Guild
+    {
+        if ($guild = $this->discord->guilds->get('id', $this->guild_id)) {
+            return $guild;
+        }
+
+        // Workaround for Channel::sendMessage() no guild_id
+        if ($this->channel_id) {
+            return $this->discord->guilds->find(function (Guild $guild) {
+                return $guild->channels->offsetExists($this->channel_id);
+            });
+        }
+
+        return null;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function jsonSerialize(): array
+    {
+        $data = [];
+        if (isset($this->type)) {
+            $data['type'] = $this->type;
+        }
+        if (isset($this->message_id)) {
+            $data['message_id'] = $this->message_id;
+        }
+        if (isset($this->channel_id)) {
+            $data['channel_id'] = $this->channel_id;
+        }
+        if (isset($this->guild_id)) {
+            $data['guild_id'] = $this->guild_id;
+        }
+        if (isset($this->fail_if_not_exists)) {
+            $data['fail_if_not_exists'] = $this->fail_if_not_exists;
+        }
+        return $data;
+    }
+}

--- a/src/Discord/Parts/Channel/Message/MessageReference.php
+++ b/src/Discord/Parts/Channel/Message/MessageReference.php
@@ -96,11 +96,11 @@ class MessageReference extends Part
             return $channel->messages->get('id', $this->message_id);
         }
 
-        return $this->createOf(Message::class, [
+        return $this->factory->part(Message::class, [
             'id' => $this->message_id,
             'channel_id' => $this->channel_id,
             'guild_id' => $this->guild_id,
-        ]);
+        ], true);
     }
 
     /**

--- a/src/Discord/Parts/Channel/Message/MessageReference.php
+++ b/src/Discord/Parts/Channel/Message/MessageReference.php
@@ -40,37 +40,6 @@ class MessageReference extends Part
     public const TYPE_FORWARD = 1;
 
     /**
-     * The type of the message reference.
-     *
-     * @var int|null
-     */
-    protected $type;
-    /**
-     * The ID of the message being referenced.
-     *
-     * @var string|null
-     */
-    protected $message_id;
-    /**
-     * The ID of the channel the message was sent in.
-     *
-     * @var string|null
-     */
-    protected $channel_id;
-    /**
-     * The ID of the guild the message was sent in.
-     *
-     * @var string|null
-     */
-    protected $guild_id;
-    /**
-     * Whether to fail if the message does not exist.
-     *
-     * @var bool|null
-     */
-    protected $fail_if_not_exists;
-
-    /**
      * {@inheritDoc}
      */
     protected $fillable = [

--- a/src/Discord/Parts/Channel/Message/MessageReference.php
+++ b/src/Discord/Parts/Channel/Message/MessageReference.php
@@ -96,7 +96,11 @@ class MessageReference extends Part
             return $channel->messages->get('id', $this->message_id);
         }
 
-        return null;
+        return $this->createOf(Message::class, [
+            'id' => $this->message_id,
+            'channel_id' => $this->channel_id,
+            'guild_id' => $this->guild_id,
+        ]);
     }
 
     /**

--- a/src/Discord/Parts/Channel/Message/MessageReference.php
+++ b/src/Discord/Parts/Channel/Message/MessageReference.php
@@ -21,6 +21,8 @@ use Discord\Parts\Part;
 /**
  * Represents a message reference object, which points to another message for replies, forwards, pins, etc.
  *
+ * @since 10.11.2
+ *
  * @link https://discord.com/developers/docs/resources/message#message-reference-structure
  *
  * @property int|null    $type                Type of reference (0 = DEFAULT, 1 = FORWARD).

--- a/src/Discord/Parts/Channel/Message/MessageReference.php
+++ b/src/Discord/Parts/Channel/Message/MessageReference.php
@@ -17,7 +17,6 @@ use Discord\Parts\Channel\Channel;
 use Discord\Parts\Channel\Message;
 use Discord\Parts\Guild\Guild;
 use Discord\Parts\Part;
-use JsonSerializable;
 
 /**
  * Represents a message reference object, which points to another message for replies, forwards, pins, etc.

--- a/src/Discord/Parts/Channel/Message/MessageReference.php
+++ b/src/Discord/Parts/Channel/Message/MessageReference.php
@@ -34,7 +34,7 @@ use JsonSerializable;
  * @property-read Channel|Thread|null $channel  The originating message's channel.
  * @property-read Guild|null          $guild    The originating message's guild.
  */
-class MessageReference extends Part implements JsonSerializable
+class MessageReference extends Part
 {
     public const TYPE_DEFAULT = 0;
     public const TYPE_FORWARD = 1;
@@ -153,29 +153,5 @@ class MessageReference extends Part implements JsonSerializable
         }
 
         return null;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function jsonSerialize(): array
-    {
-        $data = [];
-        if (isset($this->type)) {
-            $data['type'] = $this->type;
-        }
-        if (isset($this->message_id)) {
-            $data['message_id'] = $this->message_id;
-        }
-        if (isset($this->channel_id)) {
-            $data['channel_id'] = $this->channel_id;
-        }
-        if (isset($this->guild_id)) {
-            $data['guild_id'] = $this->guild_id;
-        }
-        if (isset($this->fail_if_not_exists)) {
-            $data['fail_if_not_exists'] = $this->fail_if_not_exists;
-        }
-        return $data;
     }
 }


### PR DESCRIPTION
This pull request introduces a new `MessageReference` class to represent message references in Discord messages and integrates it into the `Message` class. The most important changes include adding the `MessageReference` class, updating the `message_reference` property in `Message` to use this new class, and implementing a getter method for the `message_reference` attribute.

### New Feature: `MessageReference` Class
* [`src/Discord/Parts/Channel/Message/MessageReference.php`](diffhunk://#diff-34b66cdc24be2d103d0e2e963fd7fa3c2e08bf3e6767ada92d56992847f797feR1-R181): Added the `MessageReference` class to encapsulate details about message references, such as the originating message, channel, and guild. The class includes properties, attribute getters, and JSON serialization.

### Updates to `Message` Class
* [`src/Discord/Parts/Channel/Message.php`](diffhunk://#diff-3bc0952a87e08969969124672b2539443f4afa2fa67b5fdcddd94944c88eb1ddL75-R76): Updated the `message_reference` property to use the `MessageReference` class instead of a generic object. This improves type safety and clarity.
* [`src/Discord/Parts/Channel/Message.php`](diffhunk://#diff-3bc0952a87e08969969124672b2539443f4afa2fa67b5fdcddd94944c88eb1ddR661-R669): Added a `getMessageReferenceAttribute` method to retrieve and construct a `MessageReference` object from the `message_reference` attribute.
* [`src/Discord/Parts/Channel/Message.php`](diffhunk://#diff-3bc0952a87e08969969124672b2539443f4afa2fa67b5fdcddd94944c88eb1ddR31): Added a `use` statement for the `MessageReference` class to ensure proper namespace resolution.