### PR TITLE
Refactor message::deleteReaction into separate public methods

### DIFF
--- a/src/Discord/Parts/Channel/Message.php
+++ b/src/Discord/Parts/Channel/Message.php
@@ -1099,6 +1099,8 @@ class Message extends Part
     /**
      * Deletes all reactions from the message.
      *
+     * @since 10.14.0
+     *
      * @throws NoPermissionsException Missing manage_messages permission when deleting others reaction.
      *
      * @return PromiseInterface
@@ -1117,6 +1119,8 @@ class Message extends Part
 
     /**
      * Deletes the bot's own reaction from the message.
+     *
+     * @since 10.14.0
      *
      * @param Emoji|string $emoticon
      *
@@ -1139,6 +1143,8 @@ class Message extends Part
 
     /**
      * Deletes a specific user's reaction from the message.
+     *
+     * @since 10.14.0
      *
      * @param Emoji|string $emoticon
      * @param string $user_id
@@ -1178,6 +1184,8 @@ class Message extends Part
 
     /**
      * Deletes all reactions for a specific emoji from the message.
+     *
+     * @since 10.14.0
      *
      * @param Emoji|string $emoticon
      *

--- a/src/Discord/Parts/Channel/Message.php
+++ b/src/Discord/Parts/Channel/Message.php
@@ -1067,6 +1067,8 @@ class Message extends Part
     /**
      * Deletes a reaction.
      *
+     * @deprecated 10.14.0 Use `Message::deleteAllReactions()`, `Message::deleteOwnReaction()`, `Message::deleteUserReaction()`, or `Message::deleteEmojiReactions()`.
+     *
      * @link https://discord.com/developers/docs/resources/channel#delete-own-reaction
      * @link https://discord.com/developers/docs/resources/channel#delete-user-reaction
      *

--- a/src/Discord/Parts/Channel/Message.php
+++ b/src/Discord/Parts/Channel/Message.php
@@ -1099,6 +1099,8 @@ class Message extends Part
     /**
      * Deletes all reactions from the message.
      *
+     * @throws NoPermissionsException Missing manage_messages permission when deleting others reaction.
+     *
      * @return PromiseInterface
      */
     public function deleteAllReactions(): PromiseInterface
@@ -1117,6 +1119,8 @@ class Message extends Part
      * Deletes the bot's own reaction from the message.
      *
      * @param Emoji|string $emoticon
+     *
+     * @throws \DomainException Missing emoji when deleting own reaction.
      *
      * @return PromiseInterface
      */
@@ -1138,6 +1142,9 @@ class Message extends Part
      *
      * @param Emoji|string $emoticon
      * @param string $user_id
+     *
+     * @throws \DomainException       Missing emoji or user ID when deleting reaction by user ID.
+     * @throws NoPermissionsException Missing manage_messages permission when deleting others reaction.
      *
      * @return PromiseInterface
      */
@@ -1173,6 +1180,9 @@ class Message extends Part
      * Deletes all reactions for a specific emoji from the message.
      *
      * @param Emoji|string $emoticon
+     *
+     * @throws \DomainException       Missing emoji when deleting reaction by reaction.
+     * @throws NoPermissionsException Missing manage_messages permission when deleting others reaction.
      *
      * @return PromiseInterface
      */


### PR DESCRIPTION
This pull request refactors the `deleteReaction` method in `src/Discord/Parts/Channel/Message.php` to improve code clarity and functionality by introducing specialized methods for different reaction deletion scenarios. The changes enhance maintainability and provide more explicit error handling.

### Refactoring of `deleteReaction` Method:

* **Switch-based logic replaced with specialized methods**: The `deleteReaction` method now delegates to specific methods (`deleteAllReactions`, `deleteOwnReaction`, `deleteUserReaction`, `deleteEmojiReactions`) based on the reaction type, improving readability and separation of concerns.
* **Deprecation Notice**: Added a `@deprecated` annotation to the `deleteReaction` method, recommending the use of newly introduced methods for reaction deletion.

### New Methods for Reaction Deletion:

* **`deleteAllReactions`**: Deletes all reactions from a message, with permission checks to ensure the bot has the `manage_messages` permission.
* **`deleteOwnReaction`**: Deletes the bot's own reaction, ensuring an emoji is provided and handling errors explicitly.
* **`deleteUserReaction`**: Deletes a specific user's reaction, with validation for both the emoji and user ID, along with permission checks for reactions by others.
* **`deleteEmojiReactions`**: Deletes all reactions for a specific emoji, with validation and permission checks similar to other methods.