### PR TITLE
Message::delete bug fix

### DIFF
--- a/src/Discord/Parts/Channel/Message.php
+++ b/src/Discord/Parts/Channel/Message.php
@@ -1271,7 +1271,7 @@ class Message extends Part
         }
 
         if ($channel = $this->channel) {
-            return $channel->messages->delete($this->id, $reason);
+            return $channel->messages->delete($this, $reason);
         }
 
         // We can still delete the message if we don't have the channel object cached.


### PR DESCRIPTION
Direct deletion should only be attempted if the channel object isn't cached, because it will not remove the part from the messages repository.