### PR TITLE
Remove ext-json requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,6 @@
         "trafficcophp/bytebuffer": "^0.3",
         "monolog/monolog": "^2.1.1 || ^3.0",
         "react/event-loop": "^1.2",
-        "ext-json": "*",
         "ext-zlib": "*",
         "discord-php/http": "^10.1.7",
         "react/child-process": "^0.6.3",


### PR DESCRIPTION
As of PHP 8.0, json is bundled into core