### PR TITLE
Application->activity_instances

### DIFF
--- a/src/Discord/Parts/OAuth/ActivityInstance.php
+++ b/src/Discord/Parts/OAuth/ActivityInstance.php
@@ -13,7 +13,10 @@ declare(strict_types=1);
 
 namespace Discord\Parts\OAuth;
 
+use Discord\Helpers\Collection;
+use Discord\Helpers\ExCollectionInterface;
 use Discord\Parts\Part;
+use Discord\Parts\User\User;
 
 /**
  * Represents an Activity Instance.
@@ -22,11 +25,11 @@ use Discord\Parts\Part;
  *
  * @since 10.17.0
  *
- * @property string           $application_id Application ID.
- * @property string           $instance_id    Activity Instance ID.
- * @property string           $launch_id      Unique identifier for the launch.
- * @property ActivityLocation $location       Location the instance is running in.
- * @property array            $users          IDs of the Users currently connected to the instance.
+ * @property string                       $application_id Application ID.
+ * @property string                       $instance_id    Activity Instance ID.
+ * @property string                       $launch_id      Unique identifier for the launch.
+ * @property ActivityLocation             $location       Location the instance is running in.
+ * @property ExCollectionInterface|User[] $users          IDs of the Users currently connected to the instance.
  */
 class ActivityInstance extends Part
 {
@@ -50,5 +53,21 @@ class ActivityInstance extends Part
         }
 
         return $this->factory->part(ActivityLocation::class, (array) $this->attributes['location'], true);
+    }
+
+    /**
+     * Returns a collection of users currently connected to the instance.
+     *
+     * @return ExCollectionInterface|User[]
+     */
+    protected function getUsersAttribute(): ExCollectionInterface
+    {
+        $collection = Collection::for(User::class);
+
+        foreach ($this->attributes['users'] as $user) {
+            $collection->pushItem($this->discord->users->get('id', $user->id) ?: $this->factory->part(User::class, (array) $user, true));
+        }
+
+        return $collection;
     }
 }

--- a/src/Discord/Parts/OAuth/ActivityInstance.php
+++ b/src/Discord/Parts/OAuth/ActivityInstance.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is a part of the DiscordPHP project.
+ *
+ * Copyright (c) 2015-present David Cole <david.cole1340@gmail.com>
+ *
+ * This file is subject to the MIT license that is bundled
+ * with this source code in the LICENSE.md file.
+ */
+
+namespace Discord\Parts\OAuth;
+
+use Discord\Parts\Part;
+
+/**
+ * Represents an Activity Instance.
+ *
+ * @property string           $application_id Application ID.
+ * @property string           $instance_id    Activity Instance ID.
+ * @property string           $launch_id      Unique identifier for the launch.
+ * @property ActivityLocation $location       Location the instance is running in.
+ * @property array            $users          IDs of the Users currently connected to the instance.
+ */
+class ActivityInstance extends Part
+{
+    protected $fillable = [
+        'application_id',
+        'instance_id',
+        'launch_id',
+        'location',
+        'users',
+    ];
+
+    /**
+     * Gets the location object.
+     *
+     * @return ActivityLocation|null
+     */
+    protected function getLocationAttribute(): ?ActivityLocation
+    {
+        if (!isset($this->attributes['location'])) {
+            return null;
+        }
+
+        return $this->factory->part(ActivityLocation::class, (array) $this->attributes['location'], true);
+    }
+}

--- a/src/Discord/Parts/OAuth/ActivityInstance.php
+++ b/src/Discord/Parts/OAuth/ActivityInstance.php
@@ -18,6 +18,10 @@ use Discord\Parts\Part;
 /**
  * Represents an Activity Instance.
  *
+ * @link https://discord.com/developers/docs/resources/application#get-application-activity-instance-activity-instance-object
+ *
+ * @since 10.17.0
+ *
  * @property string           $application_id Application ID.
  * @property string           $instance_id    Activity Instance ID.
  * @property string           $launch_id      Unique identifier for the launch.

--- a/src/Discord/Parts/OAuth/ActivityLocation.php
+++ b/src/Discord/Parts/OAuth/ActivityLocation.php
@@ -77,7 +77,7 @@ class ActivityLocation extends Part
     /**
      * Returns the guild attribute.
      *
-     * @return Guild|null The guild attribute.
+     * @return Guild|null
      */
     protected function getGuildAttribute(): ?Guild
     {

--- a/src/Discord/Parts/OAuth/ActivityLocation.php
+++ b/src/Discord/Parts/OAuth/ActivityLocation.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Discord\Parts\OAuth;
 
 use Discord\Parts\Channel\Channel;
+use Discord\Parts\Guild\Guild;
 use Discord\Parts\Part;
 
 /**
@@ -29,6 +30,7 @@ use Discord\Parts\Part;
  * @property string|null $guild_id   ID of the Guild.
  *
  * @property-read Channel|null $channel
+ * @property-read Guild|null   $guild
  */
 class ActivityLocation extends Part
 {
@@ -70,5 +72,19 @@ class ActivityLocation extends Part
         }
 
         return $this->factory->part(Channel::class, ['id' => $this->attributes['channel_id']] + ['guild_id' => $this->attributes['guild_id'] ?? null], true);
+    }
+
+    /**
+     * Returns the guild attribute.
+     *
+     * @return Guild|null The guild attribute.
+     */
+    protected function getGuildAttribute(): ?Guild
+    {
+        if (!isset($this->attributes['guild_id'])) {
+            return null;
+        }
+
+        return $this->discord->guilds->get('id', $this->attributes['guild_id']);
     }
 }

--- a/src/Discord/Parts/OAuth/ActivityLocation.php
+++ b/src/Discord/Parts/OAuth/ActivityLocation.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is a part of the DiscordPHP project.
+ *
+ * Copyright (c) 2015-present David Cole <david.cole1340@gmail.com>
+ *
+ * This file is subject to the MIT license that is bundled
+ * with this source code in the LICENSE.md file.
+ */
+
+namespace Discord\Parts\OAuth;
+
+use Discord\Parts\Channel\Channel;
+use Discord\Parts\Part;
+
+/**
+ * Represents an Activity Location.
+ *
+ * @property string      $id         Unique identifier for the location.
+ * @property string      $kind       Enum describing kind of location ('gc' or 'pc').
+ * @property string      $channel_id ID of the Channel.
+ * @property string|null $guild_id   ID of the Guild.
+ *
+ * @property-read Channel|null $channel
+ */
+class ActivityLocation extends Part
+{
+    /** Location is a Guild Channel */
+    public const KIND_GUILD_CHANNEL = 'gc';
+
+    /** Location is a Private Channel (DM or GDM) */
+    public const KIND_PRIVATE_CHANNEL = 'pc';
+
+    protected $fillable = [
+        'id',
+        'kind',
+        'channel_id',
+        'guild_id',
+    ];
+
+    /**
+     * Gets the channel part.
+     *
+     * @return Channel|null
+     */
+    protected function getChannelAttribute(): ?Channel
+    {
+        if (!isset($this->attributes['channel_id'])) {
+            return null;
+        }
+
+        if (isset($this->attributes['guild_id'])) {
+            if ($guild = $this->discord->guilds->get('id', $this->attributes['guild_id'])) {
+                if ($channel = $guild->channels->get('id', $this->attributes['channel_id'])) {
+                    return $channel;
+                }
+            }
+        }
+
+        // @todo potentially slow code
+        if ($channel = $this->discord->getChannel($this->attributes['channel_id'])) {
+            return $channel;
+        }
+
+        return $this->factory->part(Channel::class, ['id' => $this->attributes['channel_id']] + ['guild_id' => $this->attributes['guild_id'] ?? null], true);
+    }
+}

--- a/src/Discord/Parts/OAuth/ActivityLocation.php
+++ b/src/Discord/Parts/OAuth/ActivityLocation.php
@@ -19,6 +19,10 @@ use Discord\Parts\Part;
 /**
  * Represents an Activity Location.
  *
+ * @link https://discord.com/developers/docs/resources/application#get-application-activity-instance-activity-location-object
+ *
+ * @since 10.17.0
+ *
  * @property string      $id         Unique identifier for the location.
  * @property string      $kind       Enum describing kind of location ('gc' or 'pc').
  * @property string      $channel_id ID of the Channel.

--- a/src/Discord/Parts/OAuth/Application.php
+++ b/src/Discord/Parts/OAuth/Application.php
@@ -17,6 +17,7 @@ use Discord\Http\Endpoint;
 use Discord\Parts\Part;
 use Discord\Parts\Permissions\Permission;
 use Discord\Parts\User\User;
+use Discord\Repository\ActivityInstanceRepository;
 use Discord\Repository\Monetization\EntitlementRepository;
 use Discord\Repository\Monetization\SKURepository;
 use Discord\Repository\Interaction\GlobalCommandRepository;
@@ -64,9 +65,10 @@ use function React\Promise\reject;
  *
  * @property string $invite_url The invite URL to invite the bot to a guild.
  *
- * @property GlobalCommandRepository $commands     The application global commands.
- * @property EntitlementRepository   $entitlements The application entitlements.
- * @property SKURepository           $skus         The application SKUs.
+ * @property GlobalCommandRepository    $commands           The application global commands.
+ * @property EntitlementRepository      $entitlements       The application entitlements.
+ * @property SKURepository              $skus               The application SKUs.
+ * @property ActivityInstanceRepository $activity_instances The application activity instances.
  */
 class Application extends Part
 {
@@ -140,6 +142,7 @@ class Application extends Part
         'commands' => GlobalCommandRepository::class,
         'entitlements' => EntitlementRepository::class,
         'skus' => SKURepository::class,
+        'activity_instances' => ActivityInstanceRepository::class,
     ];
 
     /**

--- a/src/Discord/Parts/OAuth/Application.php
+++ b/src/Discord/Parts/OAuth/Application.php
@@ -13,12 +13,14 @@ declare(strict_types=1);
 
 namespace Discord\Parts\OAuth;
 
+use Discord\Http\Endpoint;
 use Discord\Parts\Part;
 use Discord\Parts\Permissions\Permission;
 use Discord\Parts\User\User;
 use Discord\Repository\Monetization\EntitlementRepository;
 use Discord\Repository\Monetization\SKURepository;
 use Discord\Repository\Interaction\GlobalCommandRepository;
+use React\Promise\PromiseInterface;
 
 /**
  * The OAuth2 application of the bot.
@@ -137,6 +139,25 @@ class Application extends Part
         'entitlements' => EntitlementRepository::class,
         'skus' => SKURepository::class,
     ];
+
+    /**
+     * Returns a serialized activity instance, if it exists.
+     * Useful for preventing unwanted activity sessions.
+     *
+     * @param string $instance_id The activity instance ID.
+     *
+     * @return PromiseInterface<?ActivityInstance>
+     */
+    public function getActivityInstance(string $instance_id): PromiseInterface
+    {
+        return $this->http->get(Endpoint::bind(Endpoint::APPLICATION_ACTIVITY_INSTANCE, $this->id, $instance_id))
+            ->then(function ($response) {
+                if (empty($response)) {
+                    return null;
+                }
+                return $this->factory->part(ActivityInstance::class, (array) $response, true);
+            });
+    }
 
     /**
      * Returns the application icon.

--- a/src/Discord/Parts/OAuth/Application.php
+++ b/src/Discord/Parts/OAuth/Application.php
@@ -144,12 +144,16 @@ class Application extends Part
      * Returns a serialized activity instance, if it exists.
      * Useful for preventing unwanted activity sessions.
      *
-     * @param string $instance_id The activity instance ID.
+     * @param ActivityInstance|string $instance_id The activity instance ID.
      *
      * @return PromiseInterface<?ActivityInstance>
      */
-    public function getActivityInstance(string $instance_id): PromiseInterface
+    public function getActivityInstance($instance_id): PromiseInterface
     {
+        if ($instance_id instanceof ActivityInstance) {
+            $instance_id = $instance_id->id;
+        }
+
         return $this->http->get(Endpoint::bind(Endpoint::APPLICATION_ACTIVITY_INSTANCE, $this->id, $instance_id))
             ->then(function ($response) {
                 if (empty($response)) {

--- a/src/Discord/Parts/OAuth/Application.php
+++ b/src/Discord/Parts/OAuth/Application.php
@@ -22,6 +22,8 @@ use Discord\Repository\Monetization\SKURepository;
 use Discord\Repository\Interaction\GlobalCommandRepository;
 use React\Promise\PromiseInterface;
 
+use function React\Promise\reject;
+
 /**
  * The OAuth2 application of the bot.
  *
@@ -146,10 +148,16 @@ class Application extends Part
      *
      * @param ActivityInstance|string $instance_id The activity instance ID.
      *
+     * @throws \DomainException Missing instance ID.
+     *
      * @return PromiseInterface<?ActivityInstance>
      */
     public function getActivityInstance($instance_id): PromiseInterface
     {
+        if (!isset($instance_id)) {
+            return reject(new \DomainException('You must provide an instance ID to get an activity instance.'));
+        }
+
         if ($instance_id instanceof ActivityInstance) {
             $instance_id = $instance_id->id;
         }

--- a/src/Discord/Repository/ActivityInstanceRepository.php
+++ b/src/Discord/Repository/ActivityInstanceRepository.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is a part of the DiscordPHP project.
+ *
+ * Copyright (c) 2015-present David Cole <david.cole1340@gmail.com>
+ *
+ * This file is subject to the MIT license that is bundled
+ * with this source code in the LICENSE.md file.
+ */
+
+namespace Discord\Repository;
+
+use Discord\Discord;
+use Discord\Http\Endpoint;
+use Discord\Parts\OAuth\ActivityInstance;
+
+/**
+ * Contains activity instances of an application.
+ *
+ * @see ActivityInstance
+ * @see \Discord\Parts\User\Client
+ *
+ * @since 10.17.0
+ */
+class ActivityInstanceRepository extends AbstractRepository
+{
+    /**
+     * {@inheritDoc}
+     */
+    protected $endpoints = [
+        'get' => Endpoint::APPLICATION_ACTIVITY_INSTANCE,
+    ];
+
+    /**
+     * {@inheritDoc}
+     */
+    protected $class = ActivityInstance::class;
+
+    /**
+     * {@inheritDoc}
+     */
+    public function __construct(Discord $discord, array $vars = [])
+    {
+        $vars['application_id'] = $discord->application->id;
+
+        parent::__construct($discord, $vars);
+    }
+}


### PR DESCRIPTION
This pull request introduces new functionality for managing activity instances and locations within the DiscordPHP library. The most significant changes include the addition of two new classes, `ActivityInstance` and `ActivityLocation`, as well as a new method in the `Application` class to retrieve serialized activity instances. These updates enhance the library's capabilities for handling activity-related data.

### Additions to Activity Management:

* **`src/Discord/Parts/OAuth/ActivityInstance.php`:** Added a new `ActivityInstance` class to represent activity instances, including properties such as `application_id`, `instance_id`, `launch_id`, `location`, and `users`. Includes a method to retrieve the associated `ActivityLocation` object.
* **`src/Discord/Parts/OAuth/ActivityLocation.php`:** Added a new `ActivityLocation` class to represent activity locations, including properties such as `id`, `kind`, `channel_id`, and `guild_id`. Includes constants for location types and a method to retrieve the associated `Channel` object.

### Enhancements to the `Application` Class:

* **`src/Discord/Parts/OAuth/Application.php`:** Added a new method `getActivityInstance` to retrieve a serialized activity instance by its ID, enabling better management of activity sessions.

### Minor Updates:

* **`src/Discord/Parts/OAuth/Application.php`:** Added `React\Promise\PromiseInterface` and `Discord\Http\Endpoint` imports to support the new `getActivityInstance` method.