### PR TITLE
Allow direct access of private attribute get/set

### DIFF
--- a/src/Discord/Parts/PartTrait.php
+++ b/src/Discord/Parts/PartTrait.php
@@ -112,6 +112,12 @@ trait PartTrait
             return $str;
         }
 
+        if (str_starts_with($key, 'get') && str_ends_with($key, 'Attribute')) {
+            if (method_exists($this, $key)) {
+                return $key;
+            }
+        }
+
         return false;
     }
 
@@ -130,6 +136,12 @@ trait PartTrait
 
         if (method_exists($this, $str)) {
             return $str;
+        }
+
+        if (str_starts_with($key, 'set') && str_ends_with($key, 'Attribute')) {
+            if (method_exists($this, $key)) {
+                return $key;
+            }
         }
 
         return false;


### PR DESCRIPTION
This pull request enhances the `PartTrait` functionality in `src/Discord/Parts/PartTrait.php` by introducing checks for specific method naming conventions in `checkForGetMutator` and `checkForSetMutator`. These changes improve the trait's ability to dynamically identify and handle getter and setter methods.

Enhancements to method detection:

* [`checkForGetMutator`](diffhunk://#diff-7f2ba4a73ec822dcc8c82d26178d96bfbf0afca3d9be48f35b9e3b28ea17e344R115-R120): Added logic to check if a method name starts with `get` and ends with `Attribute`, and verifies its existence using `method_exists`. If such a method exists, it is returned.
* [`checkForSetMutator`](diffhunk://#diff-7f2ba4a73ec822dcc8c82d26178d96bfbf0afca3d9be48f35b9e3b28ea17e344R141-R146): Added similar logic to detect methods starting with `set` and ending with `Attribute`, ensuring they exist before returning them.