### PR TITLE
Static modifier on some $allowed arrays

### DIFF
--- a/src/Discord/Builders/CommandAttributes.php
+++ b/src/Discord/Builders/CommandAttributes.php
@@ -323,7 +323,7 @@ trait CommandAttributes
             throw new \DomainException('Only globally-scopped commands can have an integration type.');
         }
 
-        $allowed = [
+        static $allowed = [
             Application::INTEGRATION_TYPE_GUILD_INSTALL,
             Application::INTEGRATION_TYPE_USER_INSTALL,
         ];
@@ -377,7 +377,7 @@ trait CommandAttributes
             throw new \DomainException('Only globally-scopped commands can have context.');
         }
 
-        $allowed = [
+        static $allowed = [
             Interaction::CONTEXT_TYPE_GUILD,
             Interaction::CONTEXT_TYPE_BOT_DM,
             Interaction::CONTEXT_TYPE_PRIVATE_CHANNEL,
@@ -451,7 +451,7 @@ trait CommandAttributes
             throw new \DomainException('Only PRIMARY_ENTRY_POINT Command type can have handler.');
         }
 
-        $allowed = [Command::APP_HANDLER, Command::DISCORD_LAUNCH_ACTIVITY];
+        static $allowed = [Command::APP_HANDLER, Command::DISCORD_LAUNCH_ACTIVITY];
 
         if (is_int($handler) && ! in_array($handler, $allowed)) {
             throw new \DomainException('Invalid handler provided.');

--- a/src/Discord/Builders/Components/SelectMenu.php
+++ b/src/Discord/Builders/Components/SelectMenu.php
@@ -150,7 +150,7 @@ abstract class SelectMenu extends Interactive
      */
     public function setType(int $type): self
     {
-        $allowed_types = [self::TYPE_STRING_SELECT, self::TYPE_USER_SELECT, self::TYPE_ROLE_SELECT, self::TYPE_MENTIONABLE_SELECT, self::TYPE_CHANNEL_SELECT];
+        static $allowed_types = [self::TYPE_STRING_SELECT, self::TYPE_USER_SELECT, self::TYPE_ROLE_SELECT, self::TYPE_MENTIONABLE_SELECT, self::TYPE_CHANNEL_SELECT];
         if (! in_array($type, $allowed_types)) {
             throw new \InvalidArgumentException('Invalid select menu type.');
         }
@@ -245,7 +245,7 @@ abstract class SelectMenu extends Interactive
 
     public function setDefaultValues(?array $default_values): self
     {
-        $allowed_types = [self::TYPE_USER_SELECT, self::TYPE_ROLE_SELECT, self::TYPE_MENTIONABLE_SELECT, self::TYPE_CHANNEL_SELECT];
+        static $allowed_types = [self::TYPE_USER_SELECT, self::TYPE_ROLE_SELECT, self::TYPE_MENTIONABLE_SELECT, self::TYPE_CHANNEL_SELECT];
         if (! in_array($this->type, $allowed_types)) {
             throw new \InvalidArgumentException('Default values can only be set for user, role, mentionable, and channel selects.');
         }

--- a/src/Discord/CommandClient/Command.php
+++ b/src/Discord/CommandClient/Command.php
@@ -311,7 +311,7 @@ class Command
      */
     public function __get(string $variable)
     {
-        $allowed = ['command', 'description', 'longDescription', 'usage', 'cooldown', 'cooldownMessage', 'showHelp'];
+        static $allowed = ['command', 'description', 'longDescription', 'usage', 'cooldown', 'cooldownMessage', 'showHelp'];
 
         if (in_array($variable, $allowed)) {
             return $this->{$variable};

--- a/src/Discord/Discord.php
+++ b/src/Discord/Discord.php
@@ -1225,7 +1225,7 @@ class Discord
             }
         }
 
-        $allowed = ['online', 'dnd', 'idle', 'invisible', 'offline'];
+        static $allowed = ['online', 'dnd', 'idle', 'invisible', 'offline'];
 
         if (! in_array($status, $allowed)) {
             $status = 'online';
@@ -1685,7 +1685,7 @@ class Discord
      */
     public function __get(string $name)
     {
-        $allowed = ['loop', 'options', 'logger', 'http', 'application_commands'];
+        static $allowed = ['loop', 'options', 'logger', 'http', 'application_commands'];
 
         if (in_array($name, $allowed)) {
             return $this->{$name};

--- a/src/Discord/DiscordCommandClient.php
+++ b/src/Discord/DiscordCommandClient.php
@@ -476,7 +476,7 @@ class DiscordCommandClient extends Discord
      */
     public function __get(string $name)
     {
-        $allowed = ['commands', 'aliases'];
+        static $allowed = ['commands', 'aliases'];
 
         if (in_array($name, $allowed)) {
             return $this->{$name};

--- a/src/Discord/Parts/Channel/Message/AllowedMentions.php
+++ b/src/Discord/Parts/Channel/Message/AllowedMentions.php
@@ -132,7 +132,7 @@ class AllowedMentions implements JsonSerializable
      */
     public function addParse(...$items): self
     {
-        $allowed = [self::TYPE_ROLE, self::TYPE_USER, self::TYPE_EVERYONE];
+        static $allowed = [self::TYPE_ROLE, self::TYPE_USER, self::TYPE_EVERYONE];
 
         foreach ($items as &$item) {
             if (!is_string($item)) {

--- a/src/Discord/Parts/Guild/Guild.php
+++ b/src/Discord/Parts/Guild/Guild.php
@@ -520,7 +520,7 @@ class Guild extends Part
         }
 
         if (isset($format)) {
-            $allowed = ['png', 'jpg', 'webp', 'gif'];
+            static $allowed = ['png', 'jpg', 'webp', 'gif'];
 
             if (! in_array(strtolower($format), $allowed)) {
                 $format = 'webp';
@@ -558,7 +558,7 @@ class Guild extends Part
             return null;
         }
 
-        $allowed = ['png', 'jpg', 'webp'];
+        static $allowed = ['png', 'jpg', 'webp'];
 
         if (! in_array(strtolower($format), $allowed)) {
             $format = 'webp';

--- a/src/Discord/Parts/Guild/Role.php
+++ b/src/Discord/Parts/Guild/Role.php
@@ -111,7 +111,7 @@ class Role extends Part implements Stringable
             return null;
         }
 
-        $allowed = ['png', 'jpg', 'webp'];
+        static $allowed = ['png', 'jpg', 'webp'];
 
         if (! in_array(strtolower($format), $allowed)) {
             $format = 'png';

--- a/src/Discord/Parts/Guild/ScheduledEvent.php
+++ b/src/Discord/Parts/Guild/ScheduledEvent.php
@@ -192,7 +192,7 @@ class ScheduledEvent extends Part
             return null;
         }
 
-        $allowed = ['png', 'jpg', 'webp'];
+        static $allowed = ['png', 'jpg', 'webp'];
 
         if (! in_array(strtolower($format), $allowed)) {
             $format = 'png';

--- a/src/Discord/Parts/OAuth/Application.php
+++ b/src/Discord/Parts/OAuth/Application.php
@@ -188,7 +188,7 @@ class Application extends Part
             return null;
         }
 
-        $allowed = ['png', 'jpg', 'webp'];
+        static $allowed = ['png', 'jpg', 'webp'];
         if (! in_array(strtolower($format), $allowed)) {
             $format = 'webp';
         }
@@ -256,7 +256,7 @@ class Application extends Part
             return null;
         }
 
-        $allowed = ['png', 'jpg', 'webp'];
+        static $allowed = ['png', 'jpg', 'webp'];
         if (! in_array(strtolower($format), $allowed)) {
             $format = 'webp';
         }

--- a/src/Discord/Parts/User/Member.php
+++ b/src/Discord/Parts/User/Member.php
@@ -751,7 +751,7 @@ class Member extends Part implements Stringable
         }
 
         if (isset($format)) {
-            $allowed = ['png', 'jpg', 'webp', 'gif'];
+            static $allowed = ['png', 'jpg', 'webp', 'gif'];
 
             if (! in_array(strtolower($format), $allowed)) {
                 $format = 'webp';

--- a/src/Discord/Parts/User/User.php
+++ b/src/Discord/Parts/User/User.php
@@ -193,7 +193,7 @@ class User extends Part implements Stringable
         }
 
         if (isset($format)) {
-            $allowed = ['png', 'jpg', 'webp', 'gif'];
+            static $allowed = ['png', 'jpg', 'webp', 'gif'];
 
             if (! in_array(strtolower($format), $allowed)) {
                 $format = 'webp';
@@ -232,7 +232,7 @@ class User extends Part implements Stringable
         }
 
         if (isset($format)) {
-            $allowed = ['png', 'jpg', 'webp'];
+            static $allowed = ['png', 'jpg', 'webp'];
 
             if (! in_array(strtolower($format), $allowed)) {
                 $format = 'png';
@@ -271,7 +271,7 @@ class User extends Part implements Stringable
         }
 
         if (isset($format)) {
-            $allowed = ['png', 'jpg', 'webp', 'gif'];
+            static $allowed = ['png', 'jpg', 'webp', 'gif'];
 
             if (! in_array(strtolower($format), $allowed)) {
                 $format = 'png';

--- a/src/Discord/functions.php
+++ b/src/Discord/functions.php
@@ -182,7 +182,7 @@ function imageToBase64(string $filepath): string
     }
 
     $mimetype = \mime_content_type($filepath);
-    $allowed = ['image/jpeg', 'image/png', 'image/gif'];
+    static $allowed = ['image/jpeg', 'image/png', 'image/gif'];
 
     if (! in_array($mimetype, $allowed)) {
         throw new \InvalidArgumentException('The given filepath is not one of jpeg, png or gif.');


### PR DESCRIPTION

This pull request refactors multiple methods across the codebase to improve performance by converting frequently reused `$allowed` arrays into `static` variables. This change ensures that the arrays are only initialized once, reducing memory overhead and improving efficiency. Below is a summary of the most important changes grouped by theme.

### Command and Attribute Handling

* Updated `$allowed` arrays to `static` in methods like `addIntegrationType`, `addContext`, and `setHandler` within `src/Discord/Builders/CommandAttributes.php` to optimize repeated usage. [[1]](diffhunk://#diff-3eb7dfcca1697e681b65575963ad32d6a46c7adca75b23f77fce4ac890a60025L326-R326) [[2]](diffhunk://#diff-3eb7dfcca1697e681b65575963ad32d6a46c7adca75b23f77fce4ac890a60025L380-R380) [[3]](diffhunk://#diff-3eb7dfcca1697e681b65575963ad32d6a46c7adca75b23f77fce4ac890a60025L454-R454)

### Component Configuration

* Refactored `$allowed_types` in methods like `setType` and `setDefaultValues` within `src/Discord/Builders/Components/SelectMenu.php` to use `static` for better performance. [[1]](diffhunk://#diff-a14b46cff29a11b74b35f07524ec109f00cde4eaa70098bdd08f7cd2aa49f46eL153-R153) [[2]](diffhunk://#diff-a14b46cff29a11b74b35f07524ec109f00cde4eaa70098bdd08f7cd2aa49f46eL248-R248)

### User and Guild Attribute Handling

* Changed `$allowed` arrays to `static` in various attribute-related methods across files like `Guild.php`, `Role.php`, `ScheduledEvent.php`, `Application.php`, `Member.php`, and `User.php` to optimize checks for valid formats (e.g., image formats). [[1]](diffhunk://#diff-55301723a1a9b3ef9cd1c4c07a37a3c909509ef6a2e8a7d54c7c87370092af0cL523-R523) [[2]](diffhunk://#diff-55301723a1a9b3ef9cd1c4c07a37a3c909509ef6a2e8a7d54c7c87370092af0cL561-R561) [[3]](diffhunk://#diff-baa70fb449499b452f48d616ba10ee1f5e4105b40cc835ed5a33d462ed65ca3cL114-R114) [[4]](diffhunk://#diff-0927daf1a6a6c07c8ce3e9cef56ab01ff09f8e2d4e473a97784cf5b6141bc103L195-R195) [[5]](diffhunk://#diff-64c5f10086d1972d260bb23c061023ad0e808889d7b2b85f4adb7d1d31e415baL191-R191) [[6]](diffhunk://#diff-64c5f10086d1972d260bb23c061023ad0e808889d7b2b85f4adb7d1d31e415baL259-R259) [[7]](diffhunk://#diff-4dbc83e826170b5a2c00c033c1c1feacc2761382f5992166919cdd3cc1d6cf2cL754-R754) [[8]](diffhunk://#diff-f55dedd33caf8656445dc39ba8705e4319f190d8e476063aaa9d6b41966f3864L196-R196) [[9]](diffhunk://#diff-f55dedd33caf8656445dc39ba8705e4319f190d8e476063aaa9d6b41966f3864L235-R235) [[10]](diffhunk://#diff-f55dedd33caf8656445dc39ba8705e4319f190d8e476063aaa9d6b41966f3864L274-R274)

### General Configuration and Utility Methods

* Updated `$allowed` arrays to `static` in methods like `getHelp` in `Command.php`, `updatePresence` and `getCacheConfig` in `Discord.php`, and `getCommandClientOptions` in `DiscordCommandClient.php` to reduce redundant array initialization. [[1]](diffhunk://#diff-bf9508f3f40e70877b140f91186768ae92b373e984dec056358e851b55fc7f00L314-R314) [[2]](diffhunk://#diff-61213b274e0e735402c2fc9b19c678240469ca57d492b4c32962ee5bc36ec8a4L1228-R1228) [[3]](diffhunk://#diff-61213b274e0e735402c2fc9b19c678240469ca57d492b4c32962ee5bc36ec8a4L1688-R1688) [[4]](diffhunk://#diff-1b1d3f34c674c5b48d97ea8d8e82acb1a1a67a3a283b759ee5758224885b8527L479-R479)
* Refactored `$allowed` in `setParse` in `AllowedMentions.php` and `imageToBase64` in `functions.php` to use `static` for efficiency. [[1]](diffhunk://#diff-e21fd5ef6f5bf3786dc3a1c039ba0c3b552601b6a42f863d01e9f9a0c21b3c06L135-R135) [[2]](diffhunk://#diff-146bca795c8b1c9e3150ee5a873670a194f8256077fcbfa151608467a8e0284aL185-R185)