### PR TITLE
Role tags

### DIFF
--- a/src/Discord/Parts/Guild/Role.php
+++ b/src/Discord/Parts/Guild/Role.php
@@ -37,7 +37,7 @@ use Stringable;
  * @property      RolePermission $permissions   Permission bit set.
  * @property      bool           $managed       Whether this role is managed by an integration.
  * @property      bool           $mentionable   Whether the role is mentionable.
- * @property      object|null    $tags          The tags this role has (`bot_id`, `integration_id`, `premium_subscriber`, `subscription_listing_id`, `available_for_purchase`, and `guild_connections`).
+ * @property      RoleTags|null  $tags          The tags this role has (`bot_id`, `integration_id`, `premium_subscriber`, `subscription_listing_id`, `available_for_purchase`, and `guild_connections`).
  * @property      int            $flags         Role flags combined as a bitfield.
  *
  * @property      string|null $guild_id The unique identifier of the guild that the role belongs to.
@@ -175,6 +175,22 @@ class Role extends Part implements Stringable
     protected function getIconHashAttribute(): ?string
     {
         return $this->attributes['icon'] ?? null;
+    }
+
+    /**
+     * Gets the Role Tag attribute.
+     *
+     * @return RoleTags|null The role's tags.
+     *
+     * @since 10.19.0
+     */
+    protected function getRoleTagAttribute(): ?RoleTags
+    {
+        if (! isset($this->attributes['tags'])) {
+            return null;
+        }
+
+        return $this->createOf(RoleTags::class, $this->attributes['tags']);
     }
 
     /**

--- a/src/Discord/Parts/Guild/RoleTags.php
+++ b/src/Discord/Parts/Guild/RoleTags.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is a part of the DiscordPHP project.
+ *
+ * Copyright (c) 2015-present David Cole <david.cole1340@gmail.com>
+ *
+ * This file is subject to the MIT license that is bundled
+ * with this source code in the LICENSE.md file.
+ */
+
+namespace Discord\Parts\Guild;
+
+use Discord\Parts\Part;
+use Stringable;
+
+/**
+ * Role tags for a Discord role.
+ *
+ * Tags with type null represent booleans. They will be present and set to null if they are "true", and will be not present if they are "false".
+ * The library currently overrides this behavior to return a boolean if the tag is present at all.
+ *
+ * @link https://discord.com/developers/docs/topics/permissions#role-object-role-tags-structure
+ *
+ * @since 10.19.0
+ *
+ * @property string $bot_id                  The id of the bot this role belongs to.
+ * @property string $integration_id          The id of the integration this role belongs to.
+ * @property bool   $premium_subscriber      Whether this is the guild's Booster role.
+ * @property string $subscription_listing_id The id of this role's subscription sku and listing.
+ * @property bool   $available_for_purchase  Whether this role is available for purchase.
+ * @property bool   $guild_connections       Whether this role is a guild's linked role.
+ */
+class RoleTags extends Part implements Stringable
+{
+    /**
+     * @inheritDoc
+     */
+    protected $fillable = [
+        'bot_id',
+        'integration_id',
+        'premium_subscriber',
+        'subscription_listing_id',
+        'available_for_purchase',
+        'guild_connections',
+    ];
+
+    protected function getPremiumSubscriberAttribute(): bool
+    {
+        return array_key_exists('premium_subscriber', $this->attributes);
+    }
+
+    protected function getAvailableForPurchaseAttribute(): bool
+    {
+        return array_key_exists('available_for_purchase', $this->attributes);
+    }
+
+    protected function getGuildConnectionsAttribute(): bool
+    {
+        return array_key_exists('guild_connections', $this->attributes);
+    }
+}


### PR DESCRIPTION
This pull request introduces a new `RoleTags` class to improve the handling of role tags in Discord roles, replaces the `tags` property type in the `Role` class to use the new `RoleTags` class, and adds a getter method for the `RoleTags` attribute. These changes enhance code clarity and provide a more structured approach to managing role tags.

### Enhancements to Role Tag Handling:

* **New `RoleTags` Class**: Created the `RoleTags` class to encapsulate the structure and behavior of role tags, including properties like `bot_id`, `integration_id`, and `premium_subscriber`. This class also includes boolean attribute overrides for specific tags. (`src/Discord/Parts/Guild/RoleTags.php`)

* **Updated `tags` Property in `Role` Class**: Changed the `tags` property type in the `Role` class from `object|null` to `RoleTags|null` for better type safety and clarity. (`src/Discord/Parts/Guild/Role.php`)

* **Added Getter Method for Role Tags**: Introduced the `getRoleTagAttribute` method in the `Role` class to retrieve and instantiate the `RoleTags` object from the `tags` attribute. (`src/Discord/Parts/Guild/Role.php`)