### PR TITLE
PartTrait::getConstArray()

### DIFF
--- a/src/Discord/Parts/PartTrait.php
+++ b/src/Discord/Parts/PartTrait.php
@@ -447,9 +447,9 @@ trait PartTrait
      *
      * @since 10.19.0
      */
-    public static function getConstArray(): array
+    public function getConstArray(): array
     {
-        $reflection = new \ReflectionClass(self::class);
+        $reflection = new \ReflectionClass($this::class);
         $map = [];
         foreach ($reflection->getConstants() as $name => $value) {
             $map[$value] = $name;


### PR DESCRIPTION
This pull request introduces a new method to improve the functionality of the `PartTrait` class in the `src/Discord/Parts/PartTrait.php` file. The most important change is the addition of the `getConstArray` method.

### New functionality:

* Added a `getConstArray` method to return an array mapping constant values to their names for the class. This method uses reflection to dynamically retrieve constants and is annotated with `@since 10.19.0`. (`[src/Discord/Parts/PartTrait.phpR443-R459](diffhunk://#diff-7f2ba4a73ec822dcc8c82d26178d96bfbf0afca3d9be48f35b9e3b28ea17e344R443-R459)`)