### PR TITLE
Select Menu support for Modals

### DIFF
--- a/src/Discord/Builders/Components/Component.php
+++ b/src/Discord/Builders/Components/Component.php
@@ -43,6 +43,7 @@ abstract class Component implements JsonSerializable
     public const TYPE_SEPARATOR = 14;
     public const TYPE_CONTENT_INVENTORY_ENTRY = 16; // Not documented
     public const TYPE_CONTAINER = 17;
+    public const TYPE_LABEL = 18;
 
     /** @deprecated 7.4.0 Use `Component::TYPE_STRING_SELECT` */
     public const TYPE_SELECT_MENU = 3;

--- a/src/Discord/Builders/Components/Label.php
+++ b/src/Discord/Builders/Components/Label.php
@@ -1,0 +1,144 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is a part of the DiscordPHP project.
+ *
+ * Copyright (c) 2015-present David Cole <david.cole1340@gmail.com>
+ *
+ * This file is subject to the MIT license that is bundled
+ * with this source code in the LICENSE.md file.
+ */
+
+namespace Discord\Builders\Components;
+
+use Discord\Builders\Components\StringSelect;
+
+/**
+ * A Label is a top-level component.
+ *
+ * @link https://discord.com/developers/docs/components/reference#label
+ *
+ * @todo Update to match Discord's documentation upon public release.
+ * @todo Update Label class to extend the relevant base class.
+ * @todo Confirm if Label will be usable in Message components.
+ *
+ * @since 10.19.0
+ *
+ * @property int                    $type        18 for label component.
+ * @property string                 $label       The text for the label.
+ * @property string|null            $description Optional description for the label.
+ * @property StringSelect|TextInput $component   The component associated with the label.
+ */
+class Label extends ComponentObject
+{
+    public const USAGE = ['Modal'];
+
+    /**
+     * Component type.
+     *
+     * @var int
+     */
+    protected $type = Component::TYPE_LABEL;
+
+    /**
+     * The text for the label.
+     *
+     * @var string
+     */
+    protected $label;
+
+    /**
+     * Optional description for the label.
+     *
+     * @var string|null
+     */
+    protected $description;
+
+    /**
+     * The component associated with the label.
+     *
+     * @var StringSelect|TextInput
+     */
+    protected $component;
+
+     /**
+     * Creates a new label component.
+     *
+     * @param string                 $label The text for the label.
+     * @param StringSelect|TextInput $component The component associated with the label.
+     * @param string|null            $description Optional description for the label.
+     *
+     * @return self
+     */
+    public static function new(string $label, StringSelect|TextInput $component, ?string $description = null): self
+    {
+        $label_component = new self();
+
+        $label_component->setLabel($label);
+        $label_component->setComponent($component);
+        $label_component->setDescription($description);
+
+        return $label_component;
+    }
+
+    /**
+     * Sets the label text.
+     *
+     * @param string $label The text for the label.
+     *
+     * @return self
+     */
+    public function setLabel(string $label): self
+    {
+        $this->label = $label;
+
+        return $this;
+    }
+
+    /**
+     * Sets the description text.
+     *
+     * @param string|null $description The description for the label.
+     *
+     * @return self
+     */
+    public function setDescription(string|null $description): self
+    {
+        $this->description = $description;
+
+        return $this;
+    }
+
+    /** Sets the component associated with the label.
+     *
+     * @param StringSelect|TextInput $component The component associated with the label.
+     *
+     * @return self
+     */
+    public function setComponent(StringSelect|TextInput $component): self
+    {
+        $this->component = $component;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function jsonSerialize(): array
+    {
+        $data = [
+            'type' => $this->type,
+            'label' => $this->label,
+            'component' => $this->component
+        ];
+
+        if (isset($this->description)) {
+            $data['description'] = $this->description;
+        }
+
+        return $data;
+    }
+}

--- a/src/Discord/Builders/Components/Label.php
+++ b/src/Discord/Builders/Components/Label.php
@@ -70,7 +70,7 @@ class Label extends ComponentObject
      *
      * @return self
      */
-    public static function new(string $label, StringSelect|TextInput $component, ?string $description = null): self
+    public static function new(string $label, $component, ?string $description = null): self
     {
         $label_component = new self();
 
@@ -102,7 +102,7 @@ class Label extends ComponentObject
      *
      * @return self
      */
-    public function setDescription(string|null $description): self
+    public function setDescription(?string $description = null): self
     {
         $this->description = $description;
 
@@ -115,8 +115,12 @@ class Label extends ComponentObject
      *
      * @return self
      */
-    public function setComponent(StringSelect|TextInput $component): self
+    public function setComponent($component): self
     {
+        if (!in_array($component->type, [Component::TYPE_STRING_SELECT, Component::TYPE_TEXT_INPUT], true)) {
+            throw new \InvalidArgumentException('Component must be a StringSelect or TextInput.');
+        }
+
         $this->component = $component;
 
         return $this;

--- a/src/Discord/Builders/Components/Label.php
+++ b/src/Discord/Builders/Components/Label.php
@@ -13,8 +13,6 @@ declare(strict_types=1);
 
 namespace Discord\Builders\Components;
 
-use Discord\Builders\Components\StringSelect;
-
 /**
  * A Label is a top-level component.
  *
@@ -63,11 +61,11 @@ class Label extends ComponentObject
      */
     protected $component;
 
-     /**
+    /**
      * Creates a new label component.
      *
-     * @param string                 $label The text for the label.
-     * @param StringSelect|TextInput $component The component associated with the label.
+     * @param string                 $label       The text for the label.
+     * @param StringSelect|TextInput $component   The component associated with the label.
      * @param string|null            $description Optional description for the label.
      *
      * @return self
@@ -125,14 +123,14 @@ class Label extends ComponentObject
     }
 
     /**
-     * {@inheritDoc}
+     * @inheritDoc
      */
     public function jsonSerialize(): array
     {
         $data = [
             'type' => $this->type,
             'label' => $this->label,
-            'component' => $this->component
+            'component' => $this->component,
         ];
 
         if (isset($this->description)) {

--- a/src/Discord/Builders/Components/SelectMenu.php
+++ b/src/Discord/Builders/Components/SelectMenu.php
@@ -104,6 +104,13 @@ abstract class SelectMenu extends Interactive
     protected $disabled;
 
     /**
+     * Whether the select menu is required. (Modal only)
+     *
+     * @var bool|null
+     */
+    protected $required;
+
+    /**
      * Callback used to listen for `INTERACTION_CREATE` events.
      *
      * @var callable|null
@@ -305,6 +312,20 @@ abstract class SelectMenu extends Interactive
     public function setDisabled(bool $disabled = true): self
     {
         $this->disabled = $disabled;
+
+        return $this;
+    }
+
+     /**
+     * Sets whether the select menu is required. (Modal only)
+     *
+     * @param bool|null $required
+     *
+     * @return $this
+     */
+    public function setRequired(?bool $required = false): self
+    {
+        $this->required = $required;
 
         return $this;
     }
@@ -538,7 +559,7 @@ abstract class SelectMenu extends Interactive
             $content['min_values'] = $this->min_values;
         }
 
-        if ($this->max_values) {
+        if (isset($this->max_values) && $this->max_values) {
             if (isset($this->options) && $this->max_values > count($this->options)) {
                 throw new \OutOfBoundsException('There are less options than the maximum number of options to be selected.');
             }
@@ -546,8 +567,12 @@ abstract class SelectMenu extends Interactive
             $content['max_values'] = $this->max_values;
         }
 
-        if ($this->disabled) {
+        if (isset($this->disabled) && $this->disabled) {
             $content['disabled'] = true;
+        }
+
+        if (isset($this->required)) {
+            $content['required'] = true;
         }
 
         return $content;

--- a/src/Discord/Builders/Components/SelectMenu.php
+++ b/src/Discord/Builders/Components/SelectMenu.php
@@ -35,7 +35,7 @@ use function Discord\poly_strlen;
  */
 abstract class SelectMenu extends Interactive
 {
-    public const USAGE = ['Message'];
+    public const USAGE = ['Message', 'Modal'];
 
     /**
      * Component type.

--- a/src/Discord/Builders/Components/SelectMenu.php
+++ b/src/Discord/Builders/Components/SelectMenu.php
@@ -104,7 +104,7 @@ abstract class SelectMenu extends Interactive
     protected $disabled;
 
     /**
-     * Whether the select menu is required. (Modal only)
+     * Whether the select menu is required. (Modal only).
      *
      * @var bool|null
      */
@@ -316,8 +316,8 @@ abstract class SelectMenu extends Interactive
         return $this;
     }
 
-     /**
-     * Sets whether the select menu is required. (Modal only)
+    /**
+     * Sets whether the select menu is required. (Modal only).
      *
      * @param bool|null $required
      *
@@ -526,7 +526,7 @@ abstract class SelectMenu extends Interactive
     }
 
     /**
-     * {@inheritDoc}
+     * @inheritDoc
      */
     public function jsonSerialize(): array
     {

--- a/src/Discord/Builders/Components/StringSelect.php
+++ b/src/Discord/Builders/Components/StringSelect.php
@@ -23,7 +23,7 @@ namespace Discord\Builders\Components;
  */
 class StringSelect extends SelectMenu
 {
-    public const USAGE = ['Message'];
+    public const USAGE = ['Message', 'Modal'];
 
     /**
      * Component type.

--- a/src/Discord/Builders/Components/TextInput.php
+++ b/src/Discord/Builders/Components/TextInput.php
@@ -46,7 +46,9 @@ class TextInput extends Interactive
     /**
      * Label for the text input.
      *
-     * @var string
+     * @var string|null
+     *
+     * @deprecated Use top-level Component::Label instead.
      */
     private $label;
 
@@ -92,7 +94,7 @@ class TextInput extends Interactive
      * @param int         $style     The style of the text input.
      * @param string|null $custom_id The custom ID of the text input. If not given, a UUID will be used
      */
-    public function __construct(string $label, int $style, ?string $custom_id = null)
+    public function __construct(?string $label = null, int $style, ?string $custom_id = null)
     {
         $this->setLabel($label);
         $this->setStyle($style);
@@ -108,7 +110,7 @@ class TextInput extends Interactive
      *
      * @return self
      */
-    public static function new(string $label, int $style, ?string $custom_id = null): self
+    public static function new(?string $label = null, int $style, ?string $custom_id = null): self
     {
         return new self($label, $style, $custom_id);
     }
@@ -156,15 +158,15 @@ class TextInput extends Interactive
     /**
      * Sets the label of the text input.
      *
-     * @param string $label Label of the text input. Maximum 45 characters.
+     * @param string|null $label Label of the text input. Maximum 45 characters.
      *
      * @throws \LengthException
      *
      * @return $this
      */
-    public function setLabel(string $label): self
+    public function setLabel(?string $label = null): self
     {
-        if (poly_strlen($label) > 45) {
+        if (isset($label) && poly_strlen($label) > 45) {
             throw new \LengthException('Label must be maximum 45 characters.');
         }
 
@@ -326,8 +328,11 @@ class TextInput extends Interactive
             'type' => $this->type,
             'custom_id' => $this->custom_id,
             'style' => $this->style,
-            'label' => $this->label,
         ];
+
+        if (isset($this->label)) {
+            $content['label'] = $this->label;
+        }
 
         if (isset($this->min_length)) {
             $content['min_length'] = $this->min_length;

--- a/src/Discord/Builders/Components/TextInput.php
+++ b/src/Discord/Builders/Components/TextInput.php
@@ -320,7 +320,7 @@ class TextInput extends Interactive
     }
 
     /**
-     * {@inheritDoc}
+     * @inheritDoc
      */
     public function jsonSerialize(): array
     {

--- a/src/Discord/Builders/Components/TextInput.php
+++ b/src/Discord/Builders/Components/TextInput.php
@@ -46,9 +46,10 @@ class TextInput extends Interactive
     /**
      * Label for the text input.
      *
+     * Deprecated for use with modals. Use a top-level Component::Label.
+     *
      * @var string|null
      *
-     * @deprecated Use top-level Component::Label instead.
      */
     private $label;
 

--- a/src/Discord/Parts/Channel/Message/ActionRow.php
+++ b/src/Discord/Parts/Channel/Message/ActionRow.php
@@ -14,10 +14,12 @@ declare(strict_types=1);
 namespace Discord\Parts\Channel\Message;
 
 /**
- * An Action Row is a top-level layout component used in messages and modals.
+ * An Action Row is a top-level layout component used in messages.
+ *
+ * Using ActionRows in modals is now deprecated - use Component::Label as the top level component!
  *
  * Action Rows can contain:
-
+ *
  * Up to 5 contextually grouped buttons
  * A single text input
  * A single select component (string select, user select, role select, mentionable select, or channel select)

--- a/src/Discord/Parts/Channel/Message/Component.php
+++ b/src/Discord/Parts/Channel/Message/Component.php
@@ -60,7 +60,7 @@ class Component extends Part
     ];
 
     /**
-     * {@inheritDoc}
+     * @inheritDoc
      */
     protected $fillable = [
         'type',

--- a/src/Discord/Parts/Channel/Message/Component.php
+++ b/src/Discord/Parts/Channel/Message/Component.php
@@ -56,6 +56,7 @@ class Component extends Part
         ComponentBuilder::TYPE_FILE => File::class,
         ComponentBuilder::TYPE_SEPARATOR => Separator::class,
         ComponentBuilder::TYPE_CONTAINER => Container::class,
+        ComponentBuilder::TYPE_LABEL => Label::class,
     ];
 
     /**

--- a/src/Discord/Parts/Channel/Message/Label.php
+++ b/src/Discord/Parts/Channel/Message/Label.php
@@ -31,7 +31,7 @@ namespace Discord\Parts\Channel\Message;
 class Label extends Component
 {
     /**
-     * {@inheritDoc}
+     * @inheritDoc
      */
     protected $fillable = [
         'id',
@@ -43,7 +43,7 @@ class Label extends Component
 
     public function getComponentAttribute(): StringSelect|TextInput|null
     {
-        if (!isset($this->attributes['component'])) {
+        if (! isset($this->attributes['component'])) {
             return null;
         }
 

--- a/src/Discord/Parts/Channel/Message/Label.php
+++ b/src/Discord/Parts/Channel/Message/Label.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is a part of the DiscordPHP project.
+ *
+ * Copyright (c) 2015-present David Cole <david.cole1340@gmail.com>
+ *
+ * This file is subject to the MIT license that is bundled
+ * with this source code in the LICENSE.md file.
+ */
+
+namespace Discord\Parts\Channel\Message;
+
+/**
+ * A Label is a top-level component.
+ *
+ * @link https://discord.com/developers/docs/components/reference#label
+ *
+ * @todo Update to match Discord's documentation upon public release.
+ * @todo Update Label class to extend the relevant base class.
+ *
+ * @since 10.19.0
+ *
+ * @property int                    $type        18 for label component.
+ * @property string                 $label       The text for the label.
+ * @property string|null            $description Optional description for the label.
+ * @property StringSelect|TextInput $component   The component associated with the label.
+ */
+class Label extends Component
+{
+    /**
+     * {@inheritDoc}
+     */
+    protected $fillable = [
+        'id',
+        'type',
+        'label',
+        'description',
+        'component',
+    ];
+
+    public function getComponentAttribute(): StringSelect|TextInput|null
+    {
+        if (!isset($this->attributes['component'])) {
+            return null;
+        }
+
+        return $this->createOf(Component::TYPES[$this->attributes['component']->type ?? 0], $this->attributes['component']);
+    }
+}

--- a/src/Discord/Parts/Channel/Message/Label.php
+++ b/src/Discord/Parts/Channel/Message/Label.php
@@ -41,12 +41,8 @@ class Label extends Component
         'component',
     ];
 
-    public function getComponentAttribute(): StringSelect|TextInput|null
+    public function getComponentAttribute(): StringSelect|TextInput
     {
-        if (! isset($this->attributes['component'])) {
-            return null;
-        }
-
         return $this->createOf(Component::TYPES[$this->attributes['component']->type ?? 0], $this->attributes['component']);
     }
 }


### PR DESCRIPTION
This pull request introduces support for Discord's new "Label" component, updates the handling of select menus and text inputs for modals, and deprecates the use of ActionRows in modals. The changes are focused on supporting the evolving Discord components API, especially for modals, and ensuring the codebase aligns with Discord's latest documentation and best practices.

**Support for Label Component:**

- Added a new `Label` component as a top-level component for modals, including its builder (`Label.php`) and part (`Label.php`) classes, and registered it in the component type map. [[1]](diffhunk://#diff-25653c744e335263269cc98c678d86536af1f25e576415691dc13ca1b39e1899R1-R146) [[2]](diffhunk://#diff-98f17f33b01f5dc7d16f46fe6e0ea27e818bf1cc375e38999af57461cab81ef8R1-R48) [[3]](diffhunk://#diff-6bc46b2522425e41958ffebe2d734550d3120cec23e6a4be9f9c3b020a1c0c4bR46) [[4]](diffhunk://#diff-3fd1e67713eb4409c31c52712e707d44e2cec7cc1896da1f184afb21dd05c2cfR59-R63)

**Modal and Select Menu Improvements:**

- Updated `SelectMenu` and `StringSelect` components to be usable in both messages and modals, added a `required` property, and ensured proper serialization of this property. [[1]](diffhunk://#diff-a14b46cff29a11b74b35f07524ec109f00cde4eaa70098bdd08f7cd2aa49f46eL38-R38) [[2]](diffhunk://#diff-a14b46cff29a11b74b35f07524ec109f00cde4eaa70098bdd08f7cd2aa49f46eR106-R112) [[3]](diffhunk://#diff-a14b46cff29a11b74b35f07524ec109f00cde4eaa70098bdd08f7cd2aa49f46eR319-R332) [[4]](diffhunk://#diff-a14b46cff29a11b74b35f07524ec109f00cde4eaa70098bdd08f7cd2aa49f46eL541-R577) [[5]](diffhunk://#diff-0e70c2cbcd6a7143b82bd78ce6bc1f3c2ed68b323250a20efb6bf7774857e6eaL26-R26)

**TextInput Adjustments for Modals:**

- Made the `label` property of `TextInput` optional and deprecated its use for modals in favor of the new `Label` component. Updated constructor and serialization logic accordingly. [[1]](diffhunk://#diff-8ab7a56e0f9fd5a24f4326b30355c012c89eb7d86b77e57ac768a2fe2e189fd3L49-R52) [[2]](diffhunk://#diff-8ab7a56e0f9fd5a24f4326b30355c012c89eb7d86b77e57ac768a2fe2e189fd3L95-R98) [[3]](diffhunk://#diff-8ab7a56e0f9fd5a24f4326b30355c012c89eb7d86b77e57ac768a2fe2e189fd3L111-R114) [[4]](diffhunk://#diff-8ab7a56e0f9fd5a24f4326b30355c012c89eb7d86b77e57ac768a2fe2e189fd3L159-R170) [[5]](diffhunk://#diff-8ab7a56e0f9fd5a24f4326b30355c012c89eb7d86b77e57ac768a2fe2e189fd3L321-R337)

**ActionRow Deprecation in Modals:**

- Updated documentation to mark the use of `ActionRow` as a top-level component in modals as deprecated, recommending the new `Label` component instead.

These changes ensure the library remains compatible with Discord's latest component system, especially for building modals with proper top-level components.