### PR TITLE
Discord::requestGuildMembers

### DIFF
--- a/src/Discord/Discord.php
+++ b/src/Discord/Discord.php
@@ -1150,7 +1150,10 @@ class Discord
     public function requestGuildMembers($guild_id, array $options = [])
     {
         if (! isset($options['query']) && ! isset($options['user_ids'])) {
-            throw new \InvalidArgumentException('Either query or user_ids must be set.');
+            if (! isset($options['limit'])) {
+                $options['limit'] = 0;
+            }
+            $options['query'] = '';
         }
 
         if (! is_string($guild_id)) {

--- a/src/Discord/Discord.php
+++ b/src/Discord/Discord.php
@@ -1146,8 +1146,10 @@ class Discord
      * @param ?string|null       $options['nonce']     Nonce to identify the Guild Members Chunk response.
      *
      * @throws \InvalidArgumentException Either query or user_ids must be set.
+     *
+     * @since v10.19.0
      */
-    public function requestGuildMembers($guild_id, array $options = [])
+    public function requestGuildMembers($guild_id, array $options = []): void
     {
         if (! isset($options['query']) && ! isset($options['user_ids'])) {
             if (! isset($options['limit'])) {

--- a/src/Discord/WebSockets/Op.php
+++ b/src/Discord/WebSockets/Op.php
@@ -49,7 +49,9 @@ class Op
     /** Used to redirect clients to a new gateway. */
     public const OP_RECONNECT = 7;
     /** Used to request member chunks. */
-    public const OP_GUILD_MEMBER_CHUNK = 8;
+    public const OP_REQUEST_GUILD_MEMBERS = 8;
+    /** @deprecated use OP_REQUEST_GUILD_MEMBERS */
+    public const OP_GUILD_MEMBER_CHUNK = self::OP_REQUEST_GUILD_MEMBERS;
     /** Used to notify clients when they have an invalid session. */
     public const OP_INVALID_SESSION = 9;
     /** Used to pass through the heartbeat interval. */

--- a/src/Discord/WebSockets/Op.php
+++ b/src/Discord/WebSockets/Op.php
@@ -50,7 +50,7 @@ class Op
     public const OP_RECONNECT = 7;
     /** Used to request member chunks. */
     public const OP_REQUEST_GUILD_MEMBERS = 8;
-    /** @deprecated use OP_REQUEST_GUILD_MEMBERS */
+    /** @deprecated 10.18.31 Use `OP_REQUEST_GUILD_MEMBERS` */
     public const OP_GUILD_MEMBER_CHUNK = self::OP_REQUEST_GUILD_MEMBERS;
     /** Used to notify clients when they have an invalid session. */
     public const OP_INVALID_SESSION = 9;


### PR DESCRIPTION
This pull request refactors how the Discord gateway requests guild members by introducing a new `requestGuildMembers` method and updating opcode naming for clarity and future compatibility. The main focus is on improving code maintainability and aligning with Discord's terminology, while keeping backward compatibility.

**Gateway member request refactor:**

* Added a new `requestGuildMembers` method to `Discord.php` that encapsulates the logic for requesting guild members from the Discord gateway, supporting both query-based and user ID-based requests, and handling optional parameters like presences and nonce.
* Updated the `setupChunking` method to use the new `requestGuildMembers` method instead of manually constructing and sending payloads, simplifying the code and reducing duplication.

**Opcode naming and backward compatibility:**

* Renamed the opcode constant `OP_GUILD_MEMBER_CHUNK` to `OP_REQUEST_GUILD_MEMBERS` in `Op.php` for clarity, and marked the old name as deprecated while keeping it as an alias for backward compatibility.