### PR TITLE
Refactor Discord::Identify, Add Discord::Resume 

### DIFF
--- a/src/Discord/Discord.php
+++ b/src/Discord/Discord.php
@@ -967,27 +967,33 @@ class Discord
         if (isset($this->options['large_threshold'])) {
             $data['large_threshold'] = $this->options['large_threshold'];
         }
+
         if (isset($this->options['shard'])) {
             $data['shard'] = $this->options['shard'];
+        } elseif (isset($this->options['shard_id'], $this->options['num_shards'])) {
+            $data['shard'] = [
+                (int) $this->options['shard_id'],
+                (int) $this->options['num_shards'],
+            ];
+        } elseif (isset($this->options['shardId'], $this->options['shardCount'])) {
+            $data['shard'] = [
+                (int) $this->options['shardId'], // shard_id
+                (int) $this->options['shardCount'], // num_shards
+            ];
         }
+
         if (isset($this->options['presence'])) {
             $data['presence'] = $this->options['presence'];
         }
+
+
 
         $payload = Payload::new(
             Op::OP_IDENTIFY,
             $data,
         );
 
-        if (
-            array_key_exists('shardId', $this->options) &&
-            array_key_exists('shardCount', $this->options)
-        ) {
-            $payload->d['shard'] = [
-                (int) $this->options['shardId'],
-                (int) $this->options['shardCount'],
-            ];
-        }
+
 
         $this->logger->info('identifying', ['payload' => $payload->__debugInfo()]);
 
@@ -1567,8 +1573,6 @@ class Discord
             ->setRequired('token')
             ->setDefined([
                 'token',
-                'shardId',
-                'shardCount',
                 'loop',
                 'logger',
                 'loadAllMembers',
@@ -1577,6 +1581,10 @@ class Discord
                 'retrieveBans',
                 'large_threshold',
                 'shard',
+                'shard_id',
+                'num_shards',
+                'shardId',
+                'shardCount',
                 'presence',
                 'intents',
                 'socket_options',
@@ -1593,6 +1601,10 @@ class Discord
                 'retrieveBans' => false,
                 'large_threshold' => null,
                 'shard' => null,
+                'shard_id' => null,
+                'num_shards' => null,
+                'shardId' => null,
+                'shardCount' => null,
                 'presence' => null,
                 'intents' => Intents::getDefaultIntents(),
                 'socket_options' => [],
@@ -1609,6 +1621,10 @@ class Discord
             ->setAllowedTypes('retrieveBans', ['bool', 'array'])
             ->setAllowedTypes('large_threshold', ['null', 'int'])
             ->setAllowedTypes('shard', ['null', 'array'])
+            ->setAllowedTypes('shard_id', ['null', 'int'])
+            ->setAllowedTypes('num_shards', ['null', 'int'])
+            ->setAllowedTypes('shardId', ['null', 'int'])
+            ->setAllowedTypes('shardCount', ['null', 'int'])
             ->setAllowedTypes('presence', ['null', 'array'])
             ->setAllowedTypes('intents', ['array', 'int'])
             ->setAllowedTypes('socket_options', 'array')


### PR DESCRIPTION
This pull request refactors and enhances the Discord gateway identification and session handling logic, making the codebase more flexible and maintainable. The main improvements include separating the `identify` and `resume` logic into distinct methods, expanding shard and presence configuration options, and centralizing constant values. These changes make it easier to configure and extend the Discord client, especially for advanced use cases like sharding and presence customization.

**Gateway identification and session management improvements:**

* Refactored the `identify` method to only handle initial identification, and extracted the resume logic into a new `resume` method for replaying missed events when resuming a session. The `handleInvalidSession` method now properly chooses between `identify` and `resume` based on session resumability. [[1]](diffhunk://#diff-61213b274e0e735402c2fc9b19c678240469ca57d492b4c32962ee5bc36ec8a4L925-R933) [[2]](diffhunk://#diff-61213b274e0e735402c2fc9b19c678240469ca57d492b4c32962ee5bc36ec8a4L942-R1019)
* The `identify` method now supports additional configuration options: `large_threshold`, `shard`, `shard_id`, `num_shards`, `shardId`, `shardCount`, and `presence`, allowing for more granular control over gateway identification and sharding. [[1]](diffhunk://#diff-61213b274e0e735402c2fc9b19c678240469ca57d492b4c32962ee5bc36ec8a4L942-R1019) [[2]](diffhunk://#diff-61213b274e0e735402c2fc9b19c678240469ca57d492b4c32962ee5bc36ec8a4L1551-R1588) [[3]](diffhunk://#diff-61213b274e0e735402c2fc9b19c678240469ca57d492b4c32962ee5bc36ec8a4R1602-R1608) [[4]](diffhunk://#diff-61213b274e0e735402c2fc9b19c678240469ca57d492b4c32962ee5bc36ec8a4R1622-R1628)

**Configuration and constants:**

* Added a new `REFERRER` class constant to centralize the referrer URL, and updated the identify payload to use this constant for `referrer` and `referring_domain`. [[1]](diffhunk://#diff-61213b274e0e735402c2fc9b19c678240469ca57d492b4c32962ee5bc36ec8a4R105-R106) [[2]](diffhunk://#diff-61213b274e0e735402c2fc9b19c678240469ca57d492b4c32962ee5bc36ec8a4L942-R1019)
* Updated the options resolver to define, default, and type-check new options (`large_threshold`, `shard`, `shard_id`, `num_shards`, `shardId`, `shardCount`, `presence`) for better configuration validation. [[1]](diffhunk://#diff-61213b274e0e735402c2fc9b19c678240469ca57d492b4c32962ee5bc36ec8a4L1551-R1588) [[2]](diffhunk://#diff-61213b274e0e735402c2fc9b19c678240469ca57d492b4c32962ee5bc36ec8a4R1602-R1608) [[3]](diffhunk://#diff-61213b274e0e735402c2fc9b19c678240469ca57d492b4c32962ee5bc36ec8a4R1622-R1628)This pull request refactors the session identification and resumption logic in the `Discord` class, improves configuration flexibility, and introduces a new constant for the referrer. The main focus is on separating the identify and resume flows, enhancing option handling, and improving maintainability.

**Session Handling Improvements:**

* Refactored the `identify` method to only handle initial handshakes, moving resume logic into a new dedicated `resume` method for clearer separation of responsibilities. The `handleInvalidSession` method now calls either `resume` or `identify` based on session state. [[1]](diffhunk://#diff-61213b274e0e735402c2fc9b19c678240469ca57d492b4c32962ee5bc36ec8a4L925-R933) [[2]](diffhunk://#diff-61213b274e0e735402c2fc9b19c678240469ca57d492b4c32962ee5bc36ec8a4L942-R979) [[3]](diffhunk://#diff-61213b274e0e735402c2fc9b19c678240469ca57d492b4c32962ee5bc36ec8a4L987-L994)

**Configuration Enhancements:**

* Added support for `large_threshold`, `shard`, and `presence` options in the client configuration, including default values and allowed types, and ensured these are passed to the gateway when identifying. [[1]](diffhunk://#diff-61213b274e0e735402c2fc9b19c678240469ca57d492b4c32962ee5bc36ec8a4R1578-R1580) [[2]](diffhunk://#diff-61213b274e0e735402c2fc9b19c678240469ca57d492b4c32962ee5bc36ec8a4R1594-R1596) [[3]](diffhunk://#diff-61213b274e0e735402c2fc9b19c678240469ca57d492b4c32962ee5bc36ec8a4R1610-R1612) [[4]](diffhunk://#diff-61213b274e0e735402c2fc9b19c678240469ca57d492b4c32962ee5bc36ec8a4L942-R979)

**Maintainability and Consistency:**

* Introduced a new `REFERRER` constant to centralize the referrer URL, replacing hardcoded strings in the identify payload. [[1]](diffhunk://#diff-61213b274e0e735402c2fc9b19c678240469ca57d492b4c32962ee5bc36ec8a4R105-R106) [[2]](diffhunk://#diff-61213b274e0e735402c2fc9b19c678240469ca57d492b4c32962ee5bc36ec8a4L942-R979)