### PR TITLE
Transport encryption modes

### DIFF
--- a/src/Discord/Voice/VoiceClient.php
+++ b/src/Discord/Voice/VoiceClient.php
@@ -158,9 +158,9 @@ class VoiceClient extends EventEmitter
     protected $udpPort;
 
     /**
-     * The supported encryption modes the voice server expects.
+     * The supported transport encryption modes the voice server expects.
      *
-     * @var array<string> The supported encryption modes.
+     * @var array<string> The supported transport encryption modes.
      */
     protected $supportedModes;
 

--- a/src/Discord/Voice/VoiceClient.php
+++ b/src/Discord/Voice/VoiceClient.php
@@ -522,13 +522,14 @@ class VoiceClient extends EventEmitter
      *
      * @param string $ip   The IP address to use for the voice connection.
      * @param int    $port The port number to use for the voice connection.
-     *
-     * @throws \DomainException
      */
     protected function selectProtocol($ip, $port): void
     {
         if (! in_array($this->mode, $this->supportedModes)) {
-            throw new \DomainException("{$this->mode} is not a valid transport encryption connection mode. Valid modes are: " . implode(', ', $this->supportedModes));
+            $this->logger->warning("{$this->mode} is not a valid transport encryption connection mode. Valid modes are: " . implode(', ', $this->supportedModes));
+            $fallback = $this->supportedModes[0];
+            $this->logger->info('Switching voice transport encryption mode to: ' . $fallback);
+            $this->mode = $fallback;
         }
 
         $payload = Payload::new(


### PR DESCRIPTION
This pull request updates the voice encryption handling in the `VoiceClient` to support modern AEAD encryption modes, making it more secure and flexible. The main changes are the switch to a more secure default encryption mode, the addition of a setter for the encryption mode, and a refactor of the decryption logic to support multiple encryption schemes.

**Encryption mode improvements:**

* Changed the default `mode` in `VoiceClient` from `'xsalsa20_poly1305'` to the more secure `'aead_aes256_gcm_rtpsize'`.
* Added a `setMode` method to allow dynamic selection of the transport encryption mode at runtime.

**Decryption logic refactor:**

* Refactored the audio data handling to use a new `decryptVoicePacket` method, which supports multiple encryption modes (including AEAD modes and the legacy mode). [[1]](diffhunk://#diff-7a2f3798bc3eb078cbf2d218a055dafd03180366955c157e610bc585940e634aL1727-R1749) [[2]](diffhunk://#diff-7a2f3798bc3eb078cbf2d218a055dafd03180366955c157e610bc585940e634aR1805-R1845)
* Implemented AEAD (AES-GCM and XChaCha20-Poly1305) decryption, handling nonce extraction and decryption for each supported mode.