### PR TITLE
Voice decryption

### DIFF
--- a/src/Discord/Voice/VoiceClient.php
+++ b/src/Discord/Voice/VoiceClient.php
@@ -158,9 +158,9 @@ class VoiceClient extends EventEmitter
     protected $udpPort;
 
     /**
-     * The supported encryption modes the voice server expects.
+     * The supported transport encryption modes the voice server expects.
      *
-     * @var array<string> The supported encryption modes.
+     * @var array<string> The supported transport encryption modes.
      */
     protected $supportedModes;
 

--- a/src/Discord/Voice/VoiceClient.php
+++ b/src/Discord/Voice/VoiceClient.php
@@ -522,13 +522,14 @@ class VoiceClient extends EventEmitter
      *
      * @param string $ip   The IP address to use for the voice connection.
      * @param int    $port The port number to use for the voice connection.
-     *
-     * @throws \DomainException
      */
     protected function selectProtocol($ip, $port): void
     {
         if (! in_array($this->mode, $this->supportedModes)) {
-            throw new \DomainException("{$this->mode} is not a valid transport encryption connection mode. Valid modes are: " . implode(', ', $this->supportedModes));
+            $this->logger->warning("{$this->mode} is not a valid transport encryption connection mode. Valid modes are: " . implode(', ', $this->supportedModes));
+            $fallback = $this->supportedModes[0];
+            $this->logger->info('Switching voice transport encryption mode to: ' . $fallback);
+            $this->mode = $fallback;
         }
 
         $payload = Payload::new(


### PR DESCRIPTION
This pull request updates the `VoiceClient` class to improve support for modern Discord voice encryption modes, enhance error handling, and refactor audio packet decryption logic. The main focus is on transitioning to AEAD-based encryption modes and making the codebase more robust and maintainable.

**Encryption mode updates and protocol handling:**

* Changed the default transport encryption mode from `xsalsa20_poly1305` to `aead_aes256_gcm_rtpsize`, reflecting Discord's move to more secure AEAD modes.
* Updated the terminology and documentation to consistently refer to "transport encryption modes" throughout the class.
* Improved the `selectProtocol` method: instead of throwing an exception for unsupported modes, it now logs a warning and gracefully falls back to the first supported mode.
* Added a `setMode` method to allow changing the transport encryption mode at runtime.

**Audio packet decryption refactor:**

* Refactored audio packet decryption into a new `decryptVoicePacket` method, with explicit handling for AEAD (AES-GCM and XChaCha20-Poly1305) and legacy modes. This ensures correct nonce handling and future extensibility.
* Updated `handleAudioData` to use the new decryption method and improved variable naming for clarity.