### PR TITLE
Fix and refactor VoiceClient 

### DIFF
--- a/src/Discord/Voice/VoiceClient.php
+++ b/src/Discord/Voice/VoiceClient.php
@@ -218,7 +218,7 @@ class VoiceClient extends EventEmitter
      *
      * @var string The transport encryption mode.
      */
-    protected $mode = 'xsalsa20_poly1305';
+    protected $mode = 'aead_aes256_gcm_rtpsize';
 
     /**
      * The secret key used for encrypting voice.

--- a/src/Discord/Voice/VoiceClient.php
+++ b/src/Discord/Voice/VoiceClient.php
@@ -158,9 +158,9 @@ class VoiceClient extends EventEmitter
     protected $udpPort;
 
     /**
-     * The supported encryption modes the voice server expects.
+     * The supported transport encryption modes the voice server expects.
      *
-     * @var array<string> The supported encryption modes.
+     * @var array<string> The supported transport encryption modes.
      */
     protected $supportedModes;
 

--- a/src/Discord/Voice/VoiceClient.php
+++ b/src/Discord/Voice/VoiceClient.php
@@ -522,13 +522,14 @@ class VoiceClient extends EventEmitter
      *
      * @param string $ip   The IP address to use for the voice connection.
      * @param int    $port The port number to use for the voice connection.
-     *
-     * @throws \DomainException
      */
     protected function selectProtocol($ip, $port): void
     {
         if (! in_array($this->mode, $this->supportedModes)) {
-            throw new \DomainException("{$this->mode} is not a valid transport encryption connection mode. Valid modes are: " . implode(', ', $this->supportedModes));
+            $this->logger->warning("{$this->mode} is not a valid transport encryption connection mode. Valid modes are: " . implode(', ', $this->supportedModes));
+            $fallback = $this->supportedModes[0];
+            $this->logger->info('Switching voice transport encryption mode to: ' . $fallback);
+            $this->mode = $fallback;
         }
 
         $payload = Payload::new(


### PR DESCRIPTION
This pull request refactors the `VoiceClient` class to modernize and improve the handling of Discord voice transport encryption modes, streamline UDP discovery and protocol selection, and enhance audio packet decryption logic. The major changes include switching to a more secure default encryption mode, robustly handling fallback scenarios, refactoring UDP connection logic, and supporting multiple decryption methods for incoming voice packets.

### Encryption Mode Handling

* Changed the default transport encryption mode from `xsalsa20_poly1305` to the more secure `aead_aes256_gcm_rtpsize`, and updated related property and docblock names for clarity. [[1]](diffhunk://#diff-7a2f3798bc3eb078cbf2d218a055dafd03180366955c157e610bc585940e634aL221-R221) [[2]](diffhunk://#diff-7a2f3798bc3eb078cbf2d218a055dafd03180366955c157e610bc585940e634aL161-R163)
* Added a `setMode` method to allow dynamic switching of the encryption mode.
* Updated protocol selection to log a warning and automatically fall back to a supported mode if the current mode is invalid, instead of throwing an exception.

### UDP Discovery and Protocol Flow

* Refactored the UDP discovery process by removing the `discoverUdp` method. The logic is now handled in a new `ready` method, which sets up the UDP client, manages heartbeats, and handles errors more robustly. [[1]](diffhunk://#diff-7a2f3798bc3eb078cbf2d218a055dafd03180366955c157e610bc585940e634aL539-R589) [[2]](diffhunk://#diff-7a2f3798bc3eb078cbf2d218a055dafd03180366955c157e610bc585940e634aL750-R754)
* Simplified the UDP packet decoding process using PHP's `unpack` function, and improved logging and event handling for UDP connection setup.

### Audio Data Handling and Decryption

* Refactored the audio data handler to skip processing when the client is deafened, and added detailed debug logging for received data.
* Extracted decryption logic into a new `decryptVoicePacket` method, supporting AEAD and legacy encryption modes, and handling nonce extraction appropriately for each mode.
* Removed redundant logic for toggling audio data listeners when muting or deafening, as this is now handled in the audio data handler itself.

### Miscellaneous Improvements

* Renamed the internal `speaking` handler to `handleSpeaking` for clarity and added debug logging for received speaking packets. [[1]](diffhunk://#diff-7a2f3798bc3eb078cbf2d218a055dafd03180366955c157e610bc585940e634aL708-R700) [[2]](diffhunk://#diff-7a2f3798bc3eb078cbf2d218a055dafd03180366955c157e610bc585940e634aL786-R775)

These changes collectively modernize the voice client, improve maintainability, and enhance compatibility with Discord's evolving voice encryption standards.