### PR TITLE
Guild\MessageRepository with freshen dosc

### DIFF
--- a/src/Discord/Parts/Guild/Guild.php
+++ b/src/Discord/Parts/Guild/Guild.php
@@ -36,6 +36,7 @@ use Discord\Repository\Guild\RoleRepository;
 use Discord\Parts\Guild\AuditLog\AuditLog;
 use Discord\Parts\Guild\AuditLog\Entry;
 use Discord\Parts\Permissions\RolePermission;
+use Discord\Repository\Guild\MessageRepository;
 use Discord\Repository\Guild\AutoModerationRuleRepository;
 use Discord\Repository\Guild\CommandPermissionsRepository;
 use Discord\Repository\Guild\GuildCommandRepository;
@@ -201,7 +202,7 @@ class Guild extends Part
     public const HUB_TYPE_COLLEGE = 2;
 
     /**
-     * {@inheritDoc}
+     * @inheritDoc
      */
     protected $fillable = [
         'id',
@@ -256,7 +257,7 @@ class Guild extends Part
     ];
 
     /**
-     * {@inheritDoc}
+     * @inheritDoc
      */
     protected $visible = [
         'feature_animated_banner',
@@ -299,7 +300,7 @@ class Guild extends Part
     ];
 
     /**
-     * {@inheritDoc}
+     * @inheritDoc
      */
     protected $repositories = [
         'roles' => RoleRepository::class,
@@ -317,6 +318,8 @@ class Guild extends Part
         'invites' => InviteRepository::class,
         'sounds' => SoundRepository::class,
         'templates' => GuildTemplateRepository::class,
+
+        'messages' => MessageRepository::class,
     ];
 
     /**
@@ -327,7 +330,7 @@ class Guild extends Part
     protected $regions;
 
     /**
-     * {@inheritDoc}
+     * @inheritDoc
      */
     protected function setChannelsAttribute(?array $channels): void
     {
@@ -1395,7 +1398,7 @@ class Guild extends Part
     }
 
     /**
-     * {@inheritDoc}
+     * @inheritDoc
      *
      * @link https://discord.com/developers/docs/resources/guild#create-guild-json-params
      */
@@ -1422,7 +1425,7 @@ class Guild extends Part
     }
 
     /**
-     * {@inheritDoc}
+     * @inheritDoc
      *
      * @link https://discord.com/developers/docs/resources/guild#modify-guild-json-params
      */

--- a/src/Discord/Repository/Guild/MessageRepository.php
+++ b/src/Discord/Repository/Guild/MessageRepository.php
@@ -40,7 +40,7 @@ use React\Promise\PromiseInterface;
  *                                                                   - sort_order: Sorting order. See SortingOrder schema.
  *                                                                   - content: Message content to search for (string, max 1024 chars).
  *                                                                   - slop: Integer, minimum 0, maximum 100.
- *                                                                   - contents: Message contents (string|null, max 1024 chars each, up to 100 items).
+ *                                                                   - contents: Array of message contents to search for (string|null, max 1024 chars each, up to 100 items).
  *                                                                   - author_id: Author ID (SnowflakeType|null, up to 1521 unique items).
  *                                                                   - author_type: Author type (AuthorType, up to 1521 unique items).
  *                                                                   - mentions: Mentioned user ID (SnowflakeType|null, up to 1521 unique items).

--- a/src/Discord/Repository/Guild/MessageRepository.php
+++ b/src/Discord/Repository/Guild/MessageRepository.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is a part of the DiscordPHP project.
+ *
+ * Copyright (c) 2015-present David Cole <david.cole1340@gmail.com>
+ *
+ * This file is subject to the MIT license that is bundled
+ * with this source code in the LICENSE.md file.
+ */
+
+namespace Discord\Repository\Guild;
+
+use Discord\Http\Endpoint;
+use Discord\Parts\Channel\Message;
+use Discord\Repository\AbstractRepository;
+use React\Promise\PromiseInterface;
+
+/**
+ * Used only to search messages sent in a guild.
+ *
+ * All bots with the message content intent can use it, but it's not considered stable yet, and Discord might make changes or remove bot access if necessary.
+ *
+ * @see Message
+ * @see \Discord\Parts\Channel\Channel
+ *
+ * @since 10.19.0
+ *
+ * @method Message|null get(string $discrim, $key)
+ * @method Message|null pull(string|int $key, $default = null)
+ * @method Message|null first()
+ * @method Message|null last()
+ * @method Message|null find(callable $callback)
+ *
+ * @method Message|null             freshen(array $queryparams = [])
+ *                                                                   Query string params to add to the request (no validation). Supported parameters:
+ *                                                                   - sort_by: Sorting mode. See SortingMode schema.
+ *                                                                   - sort_order: Sorting order. See SortingOrder schema.
+ *                                                                   - content: Message content to search for (string, max 1024 chars).
+ *                                                                   - slop: Integer, minimum 0, maximum 100.
+ *                                                                   - contents: Array of message contents (string|null, max 1024 chars each, up to 100 items).
+ *                                                                   - author_id: Array of author IDs (SnowflakeType|null, up to 1521 unique items).
+ *                                                                   - author_type: Array of author types (AuthorType, up to 1521 unique items).
+ *                                                                   - mentions: Array of mentioned user IDs (SnowflakeType|null, up to 1521 unique items).
+ *                                                                   - mention_everyone: Boolean, whether to include messages mentioning everyone.
+ *                                                                   - min_id: Minimum message ID (SnowflakeType).
+ *                                                                   - max_id: Maximum message ID (SnowflakeType).
+ *                                                                   - limit: Integer, minimum 1, maximum 25.
+ *                                                                   - offset: Integer, minimum 0, maximum 9975.
+ *                                                                   - cursor: Cursor for pagination (ScoreCursor or TimestampCursor).
+ *                                                                   - has: Array of message features (HasOption, up to 1521 unique items).
+ *                                                                   - link_hostname: Array of link hostnames (string|null, max 152133 chars each, up to 1521 unique items).
+ *                                                                   - embed_provider: Array of embed providers (string|null, max 256 chars each, up to 1521 unique items).
+ *                                                                   - embed_type: Array of embed types (SearchableEmbedType|null, up to 1521 unique items).
+ *                                                                   - attachment_extension: Array of attachment extensions (string|null, max 152133 chars each, up to 1521 unique items).
+ *                                                                   - attachment_filename: Attachment filename (string, max 1024 chars).
+ *                                                                   - pinned: Boolean, whether to include pinned messages.
+ *                                                                   - command_id: Command ID (SnowflakeType).
+ *                                                                   - command_name: Command name (string, max 32 chars).
+ *                                                                   - include_nsfw: Boolean, whether to include NSFW messages.
+ *                                                                   - channel_id: Array of channel IDs (SnowflakeType, up to 500 unique items).
+ * @return PromiseInterface<static>
+ * @throws \Exception
+ */
+class MessageRepository extends AbstractRepository
+{
+    /**
+     * @inheritDoc
+     */
+    protected $endpoints = [
+        'all' => Endpoint::GUILD_MESSAGES_SEARCH,
+    ];
+
+    /**
+     * @inheritDoc
+     */
+    protected $class = Message::class;
+}

--- a/src/Discord/Repository/Guild/MessageRepository.php
+++ b/src/Discord/Repository/Guild/MessageRepository.php
@@ -40,27 +40,27 @@ use React\Promise\PromiseInterface;
  *                                                                   - sort_order: Sorting order. See SortingOrder schema.
  *                                                                   - content: Message content to search for (string, max 1024 chars).
  *                                                                   - slop: Integer, minimum 0, maximum 100.
- *                                                                   - contents: Array of message contents (string|null, max 1024 chars each, up to 100 items).
- *                                                                   - author_id: Array of author IDs (SnowflakeType|null, up to 1521 unique items).
- *                                                                   - author_type: Array of author types (AuthorType, up to 1521 unique items).
- *                                                                   - mentions: Array of mentioned user IDs (SnowflakeType|null, up to 1521 unique items).
+ *                                                                   - contents: Message contents (string|null, max 1024 chars each, up to 100 items).
+ *                                                                   - author_id: Author ID (SnowflakeType|null, up to 1521 unique items).
+ *                                                                   - author_type: Author type (AuthorType, up to 1521 unique items).
+ *                                                                   - mentions: Mentioned user ID (SnowflakeType|null, up to 1521 unique items).
  *                                                                   - mention_everyone: Boolean, whether to include messages mentioning everyone.
  *                                                                   - min_id: Minimum message ID (SnowflakeType).
  *                                                                   - max_id: Maximum message ID (SnowflakeType).
  *                                                                   - limit: Integer, minimum 1, maximum 25.
  *                                                                   - offset: Integer, minimum 0, maximum 9975.
  *                                                                   - cursor: Cursor for pagination (ScoreCursor or TimestampCursor).
- *                                                                   - has: Array of message features (HasOption, up to 1521 unique items).
- *                                                                   - link_hostname: Array of link hostnames (string|null, max 152133 chars each, up to 1521 unique items).
- *                                                                   - embed_provider: Array of embed providers (string|null, max 256 chars each, up to 1521 unique items).
- *                                                                   - embed_type: Array of embed types (SearchableEmbedType|null, up to 1521 unique items).
- *                                                                   - attachment_extension: Array of attachment extensions (string|null, max 152133 chars each, up to 1521 unique items).
+ *                                                                   - has: Nessage feature (HasOption, up to 1521 unique items).
+ *                                                                   - link_hostname: Link hostname (string|null, max 152133 chars each, up to 1521 unique items).
+ *                                                                   - embed_provider: Embed providers (string|null, max 256 chars each, up to 1521 unique items).
+ *                                                                   - embed_type: Embed type (SearchableEmbedType|null, up to 1521 unique items).
+ *                                                                   - attachment_extension: Attachment extension (string|null, max 152133 chars each, up to 1521 unique items).
  *                                                                   - attachment_filename: Attachment filename (string, max 1024 chars).
  *                                                                   - pinned: Boolean, whether to include pinned messages.
  *                                                                   - command_id: Command ID (SnowflakeType).
  *                                                                   - command_name: Command name (string, max 32 chars).
  *                                                                   - include_nsfw: Boolean, whether to include NSFW messages.
- *                                                                   - channel_id: Array of channel IDs (SnowflakeType, up to 500 unique items).
+ *                                                                   - channel_id: Channel IDs (SnowflakeType, up to 500 unique items).
  * @return PromiseInterface<static>
  * @throws \Exception
  */


### PR DESCRIPTION
This pull request adds support for searching messages within a guild by introducing a new `MessageRepository` and integrating it into the `Guild` class.

**Guild message search feature:**

* Added new `MessageRepository` in `src/Discord/Repository/Guild/MessageRepository.php`, enabling bots to search messages within a guild using various query parameters.
* Registered the `messages` repository in the `Guild` class, allowing access to message search functionality via the guild object. [[1]](diffhunk://#diff-55301723a1a9b3ef9cd1c4c07a37a3c909509ef6a2e8a7d54c7c87370092af0cR39) [[2]](diffhunk://#diff-55301723a1a9b3ef9cd1c4c07a37a3c909509ef6a2e8a7d54c7c87370092af0cR321-R322)