### PR TITLE
(Feature preview) Guild messages search

### DIFF
--- a/src/Discord/Parts/Guild/Guild.php
+++ b/src/Discord/Parts/Guild/Guild.php
@@ -36,7 +36,6 @@ use Discord\Repository\Guild\RoleRepository;
 use Discord\Parts\Guild\AuditLog\AuditLog;
 use Discord\Parts\Guild\AuditLog\Entry;
 use Discord\Parts\Permissions\RolePermission;
-use Discord\Repository\Guild\MessageRepository;
 use Discord\Repository\Guild\AutoModerationRuleRepository;
 use Discord\Repository\Guild\CommandPermissionsRepository;
 use Discord\Repository\Guild\GuildCommandRepository;
@@ -45,6 +44,7 @@ use Discord\Repository\Guild\StickerRepository;
 use Discord\Repository\Guild\ScheduledEventRepository;
 use Discord\Repository\Guild\GuildTemplateRepository;
 use Discord\Repository\Guild\IntegrationRepository;
+use Discord\Repository\Guild\MessageRepository;
 use React\Promise\PromiseInterface;
 use ReflectionClass;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -155,6 +155,7 @@ use function React\Promise\resolve;
  * @property CommandPermissionsRepository $command_permissions
  * @property IntegrationRepository        $integrations
  * @property InviteRepository             $invites
+ * @property MessageRepository            $messages
  * @property SoundRepository              $sounds
  * @property GuildTemplateRepository      $templates
  */
@@ -202,7 +203,7 @@ class Guild extends Part
     public const HUB_TYPE_COLLEGE = 2;
 
     /**
-     * @inheritDoc
+     * {@inheritDoc}
      */
     protected $fillable = [
         'id',
@@ -257,7 +258,7 @@ class Guild extends Part
     ];
 
     /**
-     * @inheritDoc
+     * {@inheritDoc}
      */
     protected $visible = [
         'feature_animated_banner',
@@ -300,7 +301,7 @@ class Guild extends Part
     ];
 
     /**
-     * @inheritDoc
+     * {@inheritDoc}
      */
     protected $repositories = [
         'roles' => RoleRepository::class,
@@ -316,10 +317,9 @@ class Guild extends Part
         'command_permissions' => CommandPermissionsRepository::class,
         'integrations' => IntegrationRepository::class,
         'invites' => InviteRepository::class,
+        'messages' => MessageRepository::class,
         'sounds' => SoundRepository::class,
         'templates' => GuildTemplateRepository::class,
-
-        'messages' => MessageRepository::class,
     ];
 
     /**
@@ -330,7 +330,7 @@ class Guild extends Part
     protected $regions;
 
     /**
-     * @inheritDoc
+     * {@inheritDoc}
      */
     protected function setChannelsAttribute(?array $channels): void
     {
@@ -1398,7 +1398,7 @@ class Guild extends Part
     }
 
     /**
-     * @inheritDoc
+     * {@inheritDoc}
      *
      * @link https://discord.com/developers/docs/resources/guild#create-guild-json-params
      */
@@ -1425,7 +1425,7 @@ class Guild extends Part
     }
 
     /**
-     * @inheritDoc
+     * {@inheritDoc}
      *
      * @link https://discord.com/developers/docs/resources/guild#modify-guild-json-params
      */

--- a/src/Discord/Parts/Guild/Guild.php
+++ b/src/Discord/Parts/Guild/Guild.php
@@ -36,6 +36,7 @@ use Discord\Repository\Guild\RoleRepository;
 use Discord\Parts\Guild\AuditLog\AuditLog;
 use Discord\Parts\Guild\AuditLog\Entry;
 use Discord\Parts\Permissions\RolePermission;
+use Discord\Repository\Guild\MessageRepository;
 use Discord\Repository\Guild\AutoModerationRuleRepository;
 use Discord\Repository\Guild\CommandPermissionsRepository;
 use Discord\Repository\Guild\GuildCommandRepository;
@@ -201,7 +202,7 @@ class Guild extends Part
     public const HUB_TYPE_COLLEGE = 2;
 
     /**
-     * {@inheritDoc}
+     * @inheritDoc
      */
     protected $fillable = [
         'id',
@@ -256,7 +257,7 @@ class Guild extends Part
     ];
 
     /**
-     * {@inheritDoc}
+     * @inheritDoc
      */
     protected $visible = [
         'feature_animated_banner',
@@ -299,7 +300,7 @@ class Guild extends Part
     ];
 
     /**
-     * {@inheritDoc}
+     * @inheritDoc
      */
     protected $repositories = [
         'roles' => RoleRepository::class,
@@ -317,6 +318,8 @@ class Guild extends Part
         'invites' => InviteRepository::class,
         'sounds' => SoundRepository::class,
         'templates' => GuildTemplateRepository::class,
+
+        'messages' => MessageRepository::class,
     ];
 
     /**
@@ -327,7 +330,7 @@ class Guild extends Part
     protected $regions;
 
     /**
-     * {@inheritDoc}
+     * @inheritDoc
      */
     protected function setChannelsAttribute(?array $channels): void
     {
@@ -1395,7 +1398,7 @@ class Guild extends Part
     }
 
     /**
-     * {@inheritDoc}
+     * @inheritDoc
      *
      * @link https://discord.com/developers/docs/resources/guild#create-guild-json-params
      */
@@ -1422,7 +1425,7 @@ class Guild extends Part
     }
 
     /**
-     * {@inheritDoc}
+     * @inheritDoc
      *
      * @link https://discord.com/developers/docs/resources/guild#modify-guild-json-params
      */

--- a/src/Discord/Parts/Guild/GuildSearch.php
+++ b/src/Discord/Parts/Guild/GuildSearch.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is a part of the DiscordPHP project.
+ *
+ * Copyright (c) 2015-present David Cole <david.cole1340@gmail.com>
+ *
+ * This file is subject to the MIT license that is bundled
+ * with this source code in the LICENSE.md file.
+ */
+
+namespace Discord\Parts\Guild;
+
+use Discord\Helpers\Collection;
+use Discord\Helpers\ExCollectionInterface;
+use Discord\Parts\Channel\Message;
+use Discord\Parts\Part;
+use Discord\Parts\Thread\Thread;
+use Discord\Parts\User\Member;
+
+/**
+ * TODO.
+ *
+ * @link TODO
+ *
+ * @property string                                 $analytics_id
+ * @property ExCollectionInterface<Message>         $messages
+ * @property bool                                   $doing_deep_historical_index
+ * @property int                                    $total_results
+ * @property ExCollectionInterface<Thread>|Thread[] $threads
+ * @property ExCollectionInterface<Member>|Member[] $members
+ * @property ?int|null                              $documents_indexed
+ */
+class GuildSearch extends Part
+{
+    /**
+     * @inheritDoc
+     */
+    protected $fillable = [
+        'analytics_id',
+        'messages',
+        'doing_deep_historical_index',
+        'total_results',
+        'threads',
+        'members',
+        'documents_indexed',
+    ];
+
+    /**
+     * Returns a collection of messages found in the search.
+     *
+     * @return ExCollectionInterface|Message[]|null
+     */
+    protected function getMessagesAttribute(): ?ExCollectionInterface
+    {
+        if (! isset($this->attributes['messages'])) {
+            return null;
+        }
+
+        $collection = Collection::for(Message::class);
+
+        foreach ($this->attributes['messages'] as $snowflake => $message) {
+            if ($guild = $this->discord->guilds->get('id', $this->guild_id)) {
+                if ($channel = $guild->channels->get('id', $message->channel_id)) {
+                    $messagePart = $channel->messages->get('id', $snowflake);
+                }
+            }
+
+            $collection->pushItem($messagePart ?? $this->factory->part(Message::class, (array) $message + ['guild_id' => $this->guild_id], true));
+        }
+
+        return $collection;
+    }
+
+    /**
+     * Returns a collection of members found in the search.
+     *
+     * @return ExCollectionInterface|Member[]|null
+     */
+    protected function getMembersAttribute(): ?ExCollectionInterface
+    {
+        $collection = Collection::for(Member::class);
+
+        foreach ($this->attributes['members'] ?? [] as $snowflake => $member) {
+            if ($guild_id = $member->guild_id ?? null) {
+                if ($guild = $this->discord->guilds->get('id', $guild_id)) {
+                    $memberPart = $guild->members->get('id', $snowflake);
+                }
+            }
+
+            if (! isset($memberPart)) {
+                $member->user = $this->attributes['users']->$snowflake;
+                $memberPart = $this->factory->part(Member::class, (array) $member + ['guild_id' => $this->guild_id], true);
+            }
+
+            $collection->pushItem($memberPart);
+        }
+
+        return $collection;
+    }
+
+    /**
+     * Returns a collection of threads found in the search.
+     *
+     * @return ExCollectionInterface|Thread[]
+     */
+    protected function getThreadsAttribute(): ExCollectionInterface
+    {
+        $collection = Collection::for(Thread::class);
+
+        foreach ($this->attributes['threads'] ?? [] as $thread) {
+            $collection->pushItem($this->factory->part(Thread::class, (array) $thread, true));
+        }
+
+        return $collection;
+    }
+}

--- a/src/Discord/Repository/AbstractRepository.php
+++ b/src/Discord/Repository/AbstractRepository.php
@@ -51,7 +51,7 @@ abstract class AbstractRepository extends Collection implements AbstractReposito
      *
      * @var string
      */
-    protected $class;
+    protected $class = \stdClass::class;
 
     /**
      * AbstractRepository constructor.

--- a/src/Discord/Repository/AbstractRepository.php
+++ b/src/Discord/Repository/AbstractRepository.php
@@ -51,7 +51,7 @@ abstract class AbstractRepository extends Collection implements AbstractReposito
      *
      * @var string
      */
-    protected $class = \stdClass::class;
+    protected $class;
 
     /**
      * AbstractRepository constructor.

--- a/src/Discord/Repository/Guild/MessageRepository.php
+++ b/src/Discord/Repository/Guild/MessageRepository.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is a part of the DiscordPHP project.
+ *
+ * Copyright (c) 2015-present David Cole <david.cole1340@gmail.com>
+ *
+ * This file is subject to the MIT license that is bundled
+ * with this source code in the LICENSE.md file.
+ */
+
+namespace Discord\Repository\Guild;
+
+use Discord\Http\Endpoint;
+use Discord\Parts\Channel\Message;
+use Discord\Repository\AbstractRepository;
+use React\Promise\PromiseInterface;
+
+/**
+ * Used only to search messages sent in a guild.
+ *
+ * All bots with the message content intent can use it, but it's not considered stable yet, and Discord might make changes or remove bot access if necessary.
+ *
+ * @see Message
+ * @see \Discord\Parts\Channel\Channel
+ *
+ * @since 10.19.0
+ *
+ * @method Message|null get(string $discrim, $key)
+ * @method Message|null pull(string|int $key, $default = null)
+ * @method Message|null first()
+ * @method Message|null last()
+ * @method Message|null find(callable $callback)
+ *
+ * @method Message|null             freshen(array $queryparams = [])
+ *                                                                   Query string params to add to the request (no validation). Supported parameters:
+ *                                                                   - sort_by: Sorting mode. See SortingMode schema.
+ *                                                                   - sort_order: Sorting order. See SortingOrder schema.
+ *                                                                   - content: Message content to search for (string, max 1024 chars).
+ *                                                                   - slop: Integer, minimum 0, maximum 100.
+ *                                                                   - contents: Array of message contents to search for (string|null, max 1024 chars each, up to 100 items).
+ *                                                                   - author_id: Author ID (SnowflakeType|null, up to 1521 unique items).
+ *                                                                   - author_type: Author type (AuthorType, up to 1521 unique items).
+ *                                                                   - mentions: Mentioned user ID (SnowflakeType|null, up to 1521 unique items).
+ *                                                                   - mention_everyone: Boolean, whether to include messages mentioning everyone.
+ *                                                                   - min_id: Minimum message ID (SnowflakeType).
+ *                                                                   - max_id: Maximum message ID (SnowflakeType).
+ *                                                                   - limit: Integer, minimum 1, maximum 25.
+ *                                                                   - offset: Integer, minimum 0, maximum 9975.
+ *                                                                   - cursor: Cursor for pagination (ScoreCursor or TimestampCursor).
+ *                                                                   - has: Nessage feature (HasOption, up to 1521 unique items).
+ *                                                                   - link_hostname: Link hostname (string|null, max 152133 chars each, up to 1521 unique items).
+ *                                                                   - embed_provider: Embed providers (string|null, max 256 chars each, up to 1521 unique items).
+ *                                                                   - embed_type: Embed type (SearchableEmbedType|null, up to 1521 unique items).
+ *                                                                   - attachment_extension: Attachment extension (string|null, max 152133 chars each, up to 1521 unique items).
+ *                                                                   - attachment_filename: Attachment filename (string, max 1024 chars).
+ *                                                                   - pinned: Boolean, whether to include pinned messages.
+ *                                                                   - command_id: Command ID (SnowflakeType).
+ *                                                                   - command_name: Command name (string, max 32 chars).
+ *                                                                   - include_nsfw: Boolean, whether to include NSFW messages.
+ *                                                                   - channel_id: Channel IDs (SnowflakeType, up to 500 unique items).
+ * @return PromiseInterface<static>
+ * @throws \Exception
+ */
+class MessageRepository extends AbstractRepository
+{
+    /**
+     * @inheritDoc
+     */
+    protected $endpoints = [
+        'all' => Endpoint::GUILD_MESSAGES_SEARCH,
+    ];
+
+    /**
+     * @inheritDoc
+     */
+    //protected $class = Message::class;
+
+
+}

--- a/src/Discord/Repository/Guild/MessageRepository.php
+++ b/src/Discord/Repository/Guild/MessageRepository.php
@@ -19,7 +19,7 @@ use Discord\Parts\Guild\GuildSearch;
 use Discord\Repository\AbstractRepository;
 use React\Promise\PromiseInterface;
 
-use function React\Promise\reject;
+use function React\Promise\resolve;
 
 /**
  * Used only to search messages sent in a guild.
@@ -93,13 +93,12 @@ class MessageRepository extends AbstractRepository
      *
      * @return PromiseInterface<static>
      *
-     * @throws \InvalidArgumentException If no query parameters are provided.
      * @throws \Exception
      */
     public function freshen(array $queryparams = []): PromiseInterface
     {
         if (empty($queryparams)) {
-            return reject(new \InvalidArgumentException('Query parameters must be provided to search messages.'));
+            return resolve($this);
         }
 
         $endpoint = new Endpoint($this->endpoints['all']);

--- a/src/Discord/Repository/Guild/MessageRepository.php
+++ b/src/Discord/Repository/Guild/MessageRepository.php
@@ -18,9 +18,6 @@ use Discord\Parts\Channel\Message;
 use Discord\Parts\Guild\GuildSearch;
 use Discord\Repository\AbstractRepository;
 use React\Promise\PromiseInterface;
-use WeakReference;
-
-use function React\Promise\reject;
 
 /**
  * Used only to search messages sent in a guild.
@@ -65,33 +62,33 @@ class MessageRepository extends AbstractRepository
     /**
      * Freshens the repository cache.
      *
-    * @param array $queryparams Query string params to add to the request (no validation).
-    *                           Supported parameters:
-    *                             - sort_by: Sorting mode. See SortingMode schema.
-    *                             - sort_order: Sorting order. See SortingOrder schema.
-    *                             - content: Message content to search for (string, max 1024 chars).
-    *                             - slop: Integer, minimum 0, maximum 100.
-    *                             - contents: Array of message contents to search for (string|null, max 1024 chars each, up to 100 items).
-    *                             - author_id: Author ID (SnowflakeType|null, up to 1521 unique items).
-    *                             - author_type: Author type (AuthorType, up to 1521 unique items).
-    *                             - mentions: Mentioned user ID (SnowflakeType|null, up to 1521 unique items).
-    *                             - mention_everyone: Boolean, whether to include messages mentioning everyone.
-    *                             - min_id: Minimum message ID (SnowflakeType).
-    *                             - max_id: Maximum message ID (SnowflakeType).
-    *                             - limit: Integer, minimum 1, maximum 25.
-    *                             - offset: Integer, minimum 0, maximum 9975.
-    *                             - cursor: Cursor for pagination (ScoreCursor or TimestampCursor).
-    *                             - has: Message feature (HasOption, up to 1521 unique items).
-    *                             - link_hostname: Link hostname (string|null, max 152133 chars each, up to 1521 unique items).
-    *                             - embed_provider: Embed providers (string|null, max 256 chars each, up to 1521 unique items).
-    *                             - embed_type: Embed type (SearchableEmbedType|null, up to 1521 unique items).
-    *                             - attachment_extension: Attachment extension (string|null, max 152133 chars each, up to 1521 unique items).
-    *                             - attachment_filename: Attachment filename (string, max 1024 chars).
-    *                             - pinned: Boolean, whether to include pinned messages.
-    *                             - command_id: Command ID (SnowflakeType).
-    *                             - command_name: Command name (string, max 32 chars).
-    *                             - include_nsfw: Boolean, whether to include NSFW messages.
-    *                             - channel_id: Channel IDs (SnowflakeType, up to 500 unique items).
+     * @param array $queryparams Query string params to add to the request (no validation).
+     *                           Supported parameters:
+     *                           - sort_by: Sorting mode. See SortingMode schema.
+     *                           - sort_order: Sorting order. See SortingOrder schema.
+     *                           - content: Message content to search for (string, max 1024 chars).
+     *                           - slop: Integer, minimum 0, maximum 100.
+     *                           - contents: Array of message contents to search for (string|null, max 1024 chars each, up to 100 items).
+     *                           - author_id: Author ID (SnowflakeType|null, up to 1521 unique items).
+     *                           - author_type: Author type (AuthorType, up to 1521 unique items).
+     *                           - mentions: Mentioned user ID (SnowflakeType|null, up to 1521 unique items).
+     *                           - mention_everyone: Boolean, whether to include messages mentioning everyone.
+     *                           - min_id: Minimum message ID (SnowflakeType).
+     *                           - max_id: Maximum message ID (SnowflakeType).
+     *                           - limit: Integer, minimum 1, maximum 25.
+     *                           - offset: Integer, minimum 0, maximum 9975.
+     *                           - cursor: Cursor for pagination (ScoreCursor or TimestampCursor).
+     *                           - has: Message feature (HasOption, up to 1521 unique items).
+     *                           - link_hostname: Link hostname (string|null, max 152133 chars each, up to 1521 unique items).
+     *                           - embed_provider: Embed providers (string|null, max 256 chars each, up to 1521 unique items).
+     *                           - embed_type: Embed type (SearchableEmbedType|null, up to 1521 unique items).
+     *                           - attachment_extension: Attachment extension (string|null, max 152133 chars each, up to 1521 unique items).
+     *                           - attachment_filename: Attachment filename (string, max 1024 chars).
+     *                           - pinned: Boolean, whether to include pinned messages.
+     *                           - command_id: Command ID (SnowflakeType).
+     *                           - command_name: Command name (string, max 32 chars).
+     *                           - include_nsfw: Boolean, whether to include NSFW messages.
+     *                           - channel_id: Channel IDs (SnowflakeType, up to 500 unique items).
      *
      * @return PromiseInterface<static>
      *
@@ -108,6 +105,7 @@ class MessageRepository extends AbstractRepository
 
         return $this->http->get($endpoint)->then(function ($response) {
             $part = $this->factory->create($this->class, $response, true);
+
             return $this->cacheFreshen($part);
         });
     }

--- a/src/Discord/Repository/Guild/MessageRepository.php
+++ b/src/Discord/Repository/Guild/MessageRepository.php
@@ -26,8 +26,7 @@ use function React\Promise\reject;
  *
  * All bots with the message content intent can use it, but it's not considered stable yet, and Discord might make changes or remove bot access if necessary.
  *
- * @see Message
- * @see \Discord\Parts\Channel\Channel
+ * @see \Discord\Parts\Guild\GuildSearch
  *
  * @since 10.19.0
  *

--- a/src/Discord/Repository/Guild/MessageRepository.php
+++ b/src/Discord/Repository/Guild/MessageRepository.php
@@ -18,6 +18,9 @@ use Discord\Parts\Channel\Message;
 use Discord\Parts\Guild\GuildSearch;
 use Discord\Repository\AbstractRepository;
 use React\Promise\PromiseInterface;
+use WeakReference;
+
+use function React\Promise\reject;
 
 /**
  * Used only to search messages sent in a guild.
@@ -35,33 +38,6 @@ use React\Promise\PromiseInterface;
  * @method Message|null last()
  * @method Message|null find(callable $callback)
  *
- * @method Message|null             freshen(array $queryparams = [])
- *                                                                   Query string params to add to the request (no validation). Supported parameters:
- *                                                                   - sort_by: Sorting mode. See SortingMode schema.
- *                                                                   - sort_order: Sorting order. See SortingOrder schema.
- *                                                                   - content: Message content to search for (string, max 1024 chars).
- *                                                                   - slop: Integer, minimum 0, maximum 100.
- *                                                                   - contents: Array of message contents to search for (string|null, max 1024 chars each, up to 100 items).
- *                                                                   - author_id: Author ID (SnowflakeType|null, up to 1521 unique items).
- *                                                                   - author_type: Author type (AuthorType, up to 1521 unique items).
- *                                                                   - mentions: Mentioned user ID (SnowflakeType|null, up to 1521 unique items).
- *                                                                   - mention_everyone: Boolean, whether to include messages mentioning everyone.
- *                                                                   - min_id: Minimum message ID (SnowflakeType).
- *                                                                   - max_id: Maximum message ID (SnowflakeType).
- *                                                                   - limit: Integer, minimum 1, maximum 25.
- *                                                                   - offset: Integer, minimum 0, maximum 9975.
- *                                                                   - cursor: Cursor for pagination (ScoreCursor or TimestampCursor).
- *                                                                   - has: Nessage feature (HasOption, up to 1521 unique items).
- *                                                                   - link_hostname: Link hostname (string|null, max 152133 chars each, up to 1521 unique items).
- *                                                                   - embed_provider: Embed providers (string|null, max 256 chars each, up to 1521 unique items).
- *                                                                   - embed_type: Embed type (SearchableEmbedType|null, up to 1521 unique items).
- *                                                                   - attachment_extension: Attachment extension (string|null, max 152133 chars each, up to 1521 unique items).
- *                                                                   - attachment_filename: Attachment filename (string, max 1024 chars).
- *                                                                   - pinned: Boolean, whether to include pinned messages.
- *                                                                   - command_id: Command ID (SnowflakeType).
- *                                                                   - command_name: Command name (string, max 32 chars).
- *                                                                   - include_nsfw: Boolean, whether to include NSFW messages.
- *                                                                   - channel_id: Channel IDs (SnowflakeType, up to 500 unique items).
  * @return PromiseInterface<static>
  * @throws \Exception
  */
@@ -85,4 +61,54 @@ class MessageRepository extends AbstractRepository
      * @inheritDoc
      */
     protected $class = GuildSearch::class;
+
+    /**
+     * Freshens the repository cache.
+     *
+    * @param array $queryparams Query string params to add to the request (no validation).
+    *                           Supported parameters:
+    *                             - sort_by: Sorting mode. See SortingMode schema.
+    *                             - sort_order: Sorting order. See SortingOrder schema.
+    *                             - content: Message content to search for (string, max 1024 chars).
+    *                             - slop: Integer, minimum 0, maximum 100.
+    *                             - contents: Array of message contents to search for (string|null, max 1024 chars each, up to 100 items).
+    *                             - author_id: Author ID (SnowflakeType|null, up to 1521 unique items).
+    *                             - author_type: Author type (AuthorType, up to 1521 unique items).
+    *                             - mentions: Mentioned user ID (SnowflakeType|null, up to 1521 unique items).
+    *                             - mention_everyone: Boolean, whether to include messages mentioning everyone.
+    *                             - min_id: Minimum message ID (SnowflakeType).
+    *                             - max_id: Maximum message ID (SnowflakeType).
+    *                             - limit: Integer, minimum 1, maximum 25.
+    *                             - offset: Integer, minimum 0, maximum 9975.
+    *                             - cursor: Cursor for pagination (ScoreCursor or TimestampCursor).
+    *                             - has: Message feature (HasOption, up to 1521 unique items).
+    *                             - link_hostname: Link hostname (string|null, max 152133 chars each, up to 1521 unique items).
+    *                             - embed_provider: Embed providers (string|null, max 256 chars each, up to 1521 unique items).
+    *                             - embed_type: Embed type (SearchableEmbedType|null, up to 1521 unique items).
+    *                             - attachment_extension: Attachment extension (string|null, max 152133 chars each, up to 1521 unique items).
+    *                             - attachment_filename: Attachment filename (string, max 1024 chars).
+    *                             - pinned: Boolean, whether to include pinned messages.
+    *                             - command_id: Command ID (SnowflakeType).
+    *                             - command_name: Command name (string, max 32 chars).
+    *                             - include_nsfw: Boolean, whether to include NSFW messages.
+    *                             - channel_id: Channel IDs (SnowflakeType, up to 500 unique items).
+     *
+     * @return PromiseInterface<static>
+     *
+     * @throws \Exception
+     */
+    public function freshen(array $queryparams = []): PromiseInterface
+    {
+        $endpoint = new Endpoint($this->endpoints['all']);
+        $endpoint->bindAssoc($this->vars);
+
+        foreach ($queryparams as $query => $param) {
+            $endpoint->addQuery($query, $param);
+        }
+
+        return $this->http->get($endpoint)->then(function ($response) {
+            $part = $this->factory->create($this->class, $response, true);
+            return $this->cacheFreshen($part);
+        });
+    }
 }

--- a/src/Discord/Repository/Guild/MessageRepository.php
+++ b/src/Discord/Repository/Guild/MessageRepository.php
@@ -15,6 +15,7 @@ namespace Discord\Repository\Guild;
 
 use Discord\Http\Endpoint;
 use Discord\Parts\Channel\Message;
+use Discord\Parts\Guild\GuildSearch;
 use Discord\Repository\AbstractRepository;
 use React\Promise\PromiseInterface;
 
@@ -67,6 +68,13 @@ use React\Promise\PromiseInterface;
 class MessageRepository extends AbstractRepository
 {
     /**
+     * The collection discriminator.
+     *
+     * @var string Discriminator.
+     */
+    protected $discrim = 'analytics_id';
+
+    /**
      * @inheritDoc
      */
     protected $endpoints = [
@@ -76,7 +84,5 @@ class MessageRepository extends AbstractRepository
     /**
      * @inheritDoc
      */
-    //protected $class = Message::class;
-
-
+    protected $class = GuildSearch::class;
 }


### PR DESCRIPTION
This pull request adds support for searching messages within a guild by introducing a new `MessageRepository` and a corresponding `GuildSearch` part. It also integrates the new repository into the `Guild` class, enabling message search functionality as a first-class feature for guilds.

**Guild Message Search Feature:**

* Added a new `MessageRepository` in `src/Discord/Repository/Guild/MessageRepository.php`, allowing bots to search messages in a guild with a variety of query parameters and handling caching of search results.
* Introduced the `GuildSearch` part in `src/Discord/Parts/Guild/GuildSearch.php`, representing the result of a guild message search, including collections of messages, threads, and members found.

**Integration with Guild Class:**

* Registered `MessageRepository` in the `Guild` class, making it accessible via the `$messages` property and adding it to the repositories array for guilds. [[1]](diffhunk://#diff-55301723a1a9b3ef9cd1c4c07a37a3c909509ef6a2e8a7d54c7c87370092af0cR47) [[2]](diffhunk://#diff-55301723a1a9b3ef9cd1c4c07a37a3c909509ef6a2e8a7d54c7c87370092af0cR158) [[3]](diffhunk://#diff-55301723a1a9b3ef9cd1c4c07a37a3c909509ef6a2e8a7d54c7c87370092af0cR320)