### PR TITLE
Guild messages search

### DIFF
--- a/src/Discord/Repository/Guild/MessageRepository.php
+++ b/src/Discord/Repository/Guild/MessageRepository.php
@@ -19,7 +19,7 @@ use Discord\Parts\Guild\GuildSearch;
 use Discord\Repository\AbstractRepository;
 use React\Promise\PromiseInterface;
 
-use function React\Promise\resolve;
+use function React\Promise\reject;
 
 /**
  * Used only to search messages sent in a guild.
@@ -97,7 +97,7 @@ class MessageRepository extends AbstractRepository
     public function freshen(array $queryparams = []): PromiseInterface
     {
         if (empty($queryparams)) {
-            return resolve($this);
+            return reject(new \InvalidArgumentException('Query parameters are required.'));
         }
 
         $endpoint = new Endpoint($this->endpoints['all']);

--- a/src/Discord/Repository/Guild/MessageRepository.php
+++ b/src/Discord/Repository/Guild/MessageRepository.php
@@ -122,6 +122,6 @@ class MessageRepository extends AbstractRepository
      */
     protected function cacheFreshen($response): PromiseInterface
     {
-        return $this->cache->set($response->{$this->discrim}, (array) $response)->then(fn ($success) => $this);
+        return $this->cache->set($response->{$this->discrim}, $response)->then(fn ($success) => $this);
     }
 }

--- a/src/Discord/Repository/Guild/MessageRepository.php
+++ b/src/Discord/Repository/Guild/MessageRepository.php
@@ -109,7 +109,9 @@ class MessageRepository extends AbstractRepository
 
         return $this->http->get($endpoint)->then(function ($response) {
             $part = $this->factory->create($this->class, (array) $response, true);
-            return $this->cacheFreshen($part);
+            $promise = $this->cacheFreshen($part);
+            $this->discord->emit('GuildSearch', [$part]);
+            return $promise;
         });
     }
 


### PR DESCRIPTION
This pull request updates the `MessageRepository` in the Discord Guild repository to improve error handling and event emission when searching for messages. The changes ensure that invalid queries are properly rejected, events are emitted after freshening the cache, and caching logic is streamlined.

**Error handling improvements:**

* The `freshen` method now rejects the promise with an `InvalidArgumentException` when no query parameters are provided, instead of resolving with the repository itself.
* The import of the `reject` function from React Promise replaces the unused `resolve` function, aligning with the new error handling approach.

**Event emission and caching logic:**

* After successfully fetching and processing a message, the `GuildSearch` event is emitted with the message part, allowing listeners to react to message searches.
* The `cacheFreshen` method now stores the part in the cache rather than casting it to an array, which was unintended.