### PR TITLE
Embed types

### DIFF
--- a/src/Discord/Parts/Channel/Message.php
+++ b/src/Discord/Parts/Channel/Message.php
@@ -629,7 +629,7 @@ class Message extends Part
         $embeds = Collection::for(Embed::class, null);
 
         foreach ($this->attributes['embeds'] ?? [] as $embed) {
-            $embeds->pushItem($this->createOf(Embed::class, $embed));
+            $embeds->pushItem($this->createOf(Embed::TYPES[$embed->type ?? 0], $embed));
         }
 
         return $embeds;

--- a/src/Discord/Parts/Embed/Author.php
+++ b/src/Discord/Parts/Embed/Author.php
@@ -22,15 +22,15 @@ use Discord\Parts\Part;
  *
  * @since 4.0.3
  *
- * @property      string      $name           The name of the author.
- * @property      string|null $url            The URL to the author.
- * @property      string|null $icon_url       The source of the author icon. Must be https.
- * @property-read string|null $proxy_icon_url A proxied version of the icon url.
+ * @property      string       $name           The name of the author.
+ * @property      ?string|null $url            The URL to the author.
+ * @property      ?string|null $icon_url       The source of the author icon. Must be https.
+ * @property-read ?string|null $proxy_icon_url A proxied version of the icon url.
  */
 class Author extends Part
 {
     /**
-     * {@inheritDoc}
+     * @inheritDoc
      */
     protected $fillable = [
         'name',

--- a/src/Discord/Parts/Embed/Embed.php
+++ b/src/Discord/Parts/Embed/Embed.php
@@ -166,7 +166,7 @@ class Embed extends Part
      */
     protected function getFieldsAttribute(): ExCollectionInterface
     {
-        $fields = Collection::for(Field::class, null);
+        $fields = Collection::for(Field::class, 'name');
 
         if (! array_key_exists('fields', $this->attributes)) {
             return $fields;

--- a/src/Discord/Parts/Embed/Embed.php
+++ b/src/Discord/Parts/Embed/Embed.php
@@ -24,23 +24,23 @@ use function Discord\poly_strlen;
 /**
  * An embed object to be sent with a message.
  *
- * @link https://discord.com/developers/docs/resources/channel#embed-object
+ * @link https://discord.com/developers/docs/resources/message#embed-object-embed-structure
  *
  * @since 4.0.3
  *
- * @property      string|null                   $title       The title of the embed.
- * @property-read string|null                   $type        The type of the embed.
- * @property      string|null                   $description A description of the embed.
- * @property      string|null                   $url         The URL of the embed.
- * @property      Carbon|null                   $timestamp   A timestamp of the embed.
- * @property      int|null                      $color       The color of the embed.
- * @property      Footer|null                   $footer      The footer of the embed.
- * @property      Image|null                    $image       The image of the embed.
- * @property      Image|null                    $thumbnail   The thumbnail of the embed.
- * @property-read Video|null                    $video       The video of the embed.
- * @property-read object|null                   $provider    The provider of the embed.
- * @property      Author|null                   $author      The author of the embed.
- * @property      ExCollectionInterface|Field[] $fields      A collection of embed fields.
+ * @property      ?string|null                        $title       The title of the embed.
+ * @property-read ?string|null                        $type        The type of the embed (always "rich" for webhook embeds).
+ * @property      ?string|null                        $description A description of the embed.
+ * @property      ?string|null                        $url         The URL of the embed.
+ * @property      ?Carbon|null                        $timestamp   A timestamp of the embed.
+ * @property      ?int|null                           $color       The color of the embed.
+ * @property      ?Footer|null                        $footer      The footer of the embed.
+ * @property      ?Image|null                         $image       The image of the embed.
+ * @property      ?Image|null                         $thumbnail   The thumbnail of the embed.
+ * @property-read ?Video|null                         $video       The video of the embed.
+ * @property-read ?object|null                        $provider    The provider of the embed.
+ * @property      ?Author|null                        $author      The author of the embed.
+ * @property      ?ExCollectionInterface|Field[]|null $fields      A collection of embed fields (max of 25).
  */
 class Embed extends Part
 {
@@ -50,9 +50,10 @@ class Embed extends Part
     public const TYPE_GIFV = 'gifv';
     public const TYPE_ARTICLE = 'article';
     public const TYPE_LINK = 'link';
+    public const TYPE_POLL_RESULT = 'poll_result';
 
     /**
-     * {@inheritDoc}
+     * @inheritDoc
      */
     protected $fillable = [
         'title',
@@ -609,6 +610,7 @@ class Embed extends Part
             self::TYPE_GIFV,
             self::TYPE_ARTICLE,
             self::TYPE_LINK,
+            self::TYPE_POLL_RESULT,
         ];
     }
 }

--- a/src/Discord/Parts/Embed/Embed.php
+++ b/src/Discord/Parts/Embed/Embed.php
@@ -27,6 +27,7 @@ use function Discord\poly_strlen;
  * @link https://discord.com/developers/docs/resources/message#embed-object-embed-structure
  *
  * @since 4.0.3
+ * @since 10.19.0 The `provider` property was added and `thumbnail` was updated to return `Thumbnail`.
  *
  * @property      ?string|null                        $title       The title of the embed.
  * @property-read ?string|null                        $type        The type of the embed (always "rich" for webhook embeds).
@@ -36,14 +37,25 @@ use function Discord\poly_strlen;
  * @property      ?int|null                           $color       The color of the embed.
  * @property      ?Footer|null                        $footer      The footer of the embed.
  * @property      ?Image|null                         $image       The image of the embed.
- * @property      ?Image|null                         $thumbnail   The thumbnail of the embed.
+ * @property      ?Thumbnail|null                     $thumbnail   The thumbnail of the embed.
  * @property-read ?Video|null                         $video       The video of the embed.
- * @property-read ?object|null                        $provider    The provider of the embed.
+ * @property-read ?Provider|null                      $provider    The provider of the embed.
  * @property      ?Author|null                        $author      The author of the embed.
  * @property      ?ExCollectionInterface|Field[]|null $fields      A collection of embed fields (max of 25).
  */
 class Embed extends Part
 {
+    public const TYPES = [
+        0 => Embed::class, // Fallback for unknown types
+        self::TYPE_RICH => EmbedRich::class,
+        self::TYPE_IMAGE => EmbedImage::class,
+        self::TYPE_VIDEO => EmbedVideo::class,
+        self::TYPE_GIFV => EmbedGifv::class,
+        self::TYPE_ARTICLE => EmbedArticle::class,
+        self::TYPE_LINK => EmbedLink::class,
+        self::TYPE_POLL_RESULT => EmbedPollResult::class,
+    ];
+
     public const TYPE_RICH = 'rich';
     public const TYPE_IMAGE = 'image';
     public const TYPE_VIDEO = 'video';
@@ -110,11 +122,11 @@ class Embed extends Part
     /**
      * Gets the thumbnail attribute.
      *
-     * @return Image The thumbnail attribute.
+     * @return Thumbnail The thumbnail attribute.
      */
-    protected function getThumbnailAttribute(): Image
+    protected function getThumbnailAttribute(): Thumbnail
     {
-        return $this->attributeHelper('thumbnail', Image::class);
+        return $this->attributeHelper('thumbnail', Thumbnail::class);
     }
 
     /**
@@ -125,6 +137,16 @@ class Embed extends Part
     protected function getVideoAttribute(): Video
     {
         return $this->attributeHelper('video', Video::class);
+    }
+
+    /**
+     * Gets the provider attribute.
+     *
+     * @return Provider The provider attribute.
+     */
+    protected function getProviderAttribute(): Provider
+    {
+        return $this->attributeHelper('provider', Provider::class);
     }
 
     /**

--- a/src/Discord/Parts/Embed/EmbedArticle.php
+++ b/src/Discord/Parts/Embed/EmbedArticle.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is a part of the DiscordPHP project.
+ *
+ * Copyright (c) 2015-present David Cole <david.cole1340@gmail.com>
+ *
+ * This file is subject to the MIT license that is bundled
+ * with this source code in the LICENSE.md file.
+ */
+
+namespace Discord\Parts\Embed;
+
+class EmbedArticle extends Embed
+{
+    public const TYPE = self::TYPE_ARTICLE;
+}

--- a/src/Discord/Parts/Embed/EmbedGifv.php
+++ b/src/Discord/Parts/Embed/EmbedGifv.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is a part of the DiscordPHP project.
+ *
+ * Copyright (c) 2015-present David Cole <david.cole1340@gmail.com>
+ *
+ * This file is subject to the MIT license that is bundled
+ * with this source code in the LICENSE.md file.
+ */
+
+namespace Discord\Parts\Embed;
+
+class EmbedGifv extends Embed
+{
+    public const TYPE = self::TYPE_GIFV;
+}

--- a/src/Discord/Parts/Embed/EmbedImage.php
+++ b/src/Discord/Parts/Embed/EmbedImage.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is a part of the DiscordPHP project.
+ *
+ * Copyright (c) 2015-present David Cole <david.cole1340@gmail.com>
+ *
+ * This file is subject to the MIT license that is bundled
+ * with this source code in the LICENSE.md file.
+ */
+
+namespace Discord\Parts\Embed;
+
+class EmbedImage extends Embed
+{
+    public const TYPE = self::TYPE_IMAGE;
+}

--- a/src/Discord/Parts/Embed/EmbedLink.php
+++ b/src/Discord/Parts/Embed/EmbedLink.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is a part of the DiscordPHP project.
+ *
+ * Copyright (c) 2015-present David Cole <david.cole1340@gmail.com>
+ *
+ * This file is subject to the MIT license that is bundled
+ * with this source code in the LICENSE.md file.
+ */
+
+namespace Discord\Parts\Embed;
+
+class EmbedLink extends Embed
+{
+    public const TYPE = self::TYPE_LINK;
+}

--- a/src/Discord/Parts/Embed/EmbedPollResult.php
+++ b/src/Discord/Parts/Embed/EmbedPollResult.php
@@ -28,7 +28,7 @@ use Discord\Helpers\ExCollectionInterface;
  * @property-read ?Video|null                         $video                                  The video of the embed.
  * @property-read ?Provider|null                      $provider                               The provider of the embed.
  * @property      ?Author|null                        $author                                 The author of the embed.
- * @property      ?ExCollectionInterface|Field[]|null $fields                                 A collection of embed fields (max of 25).
+ * @property      ExCollectionInterface|Field[]       $fields                                 A collection of embed fields (max of 25).
  * @property      string|null                         $fields['poll_question_text']           Question text from the original poll
  * @property      int|null                            $fields['victor_answer_votes']          Number of votes for the answer(s) with the most votes
  * @property      int|null                            $fields['total_votes']                  Total number of votes in the poll

--- a/src/Discord/Parts/Embed/EmbedPollResult.php
+++ b/src/Discord/Parts/Embed/EmbedPollResult.php
@@ -13,32 +13,51 @@ declare(strict_types=1);
 
 namespace Discord\Parts\Embed;
 
+use Discord\Helpers\Collection;
 use Discord\Helpers\ExCollectionInterface;
 
 /**
- * @property      ?string|null                        $title                                  The title of the embed.
- * @property-read ?string|null                        $type                                   The type of the embed (always "rich" for webhook embeds).
- * @property      ?string|null                        $description                            A description of the embed.
- * @property      ?string|null                        $url                                    The URL of the embed.
- * @property      ?Carbon|null                        $timestamp                              A timestamp of the embed.
- * @property      ?int|null                           $color                                  The color of the embed.
- * @property      ?Footer|null                        $footer                                 The footer of the embed.
- * @property      ?Image|null                         $image                                  The image of the embed.
- * @property      ?Thumbnail|null                     $thumbnail                              The thumbnail of the embed.
- * @property-read ?Video|null                         $video                                  The video of the embed.
- * @property-read ?Provider|null                      $provider                               The provider of the embed.
- * @property      ?Author|null                        $author                                 The author of the embed.
- * @property      ExCollectionInterface|Field[]       $fields                                 A collection of embed fields (max of 25).
- * @property      string|null                         $fields['poll_question_text']           Question text from the original poll
- * @property      int|null                            $fields['victor_answer_votes']          Number of votes for the answer(s) with the most votes
- * @property      int|null                            $fields['total_votes']                  Total number of votes in the poll
- * @property      ?string|null                        $fields['victor_answer_id']             ID for the winning answer (optional)
- * @property      ?string|null                        $fields['victor_answer_text']           Text for the winning answer (optional)
- * @property      ?string|null                        $fields['victor_answer_emoji_id']       ID for an emoji associated with the winning answer (optional)
- * @property      ?string|null                        $fields['victor_answer_emoji_name']     Name of an emoji associated with the winning answer (optional)
- * @property      ?bool|null                          $fields['victor_answer_emoji_animated'] If an emoji associated with the winning answer is animated (optional)
+ * @property      ?string|null                  $title                                       The title of the embed.
+ * @property-read ?string|null                  $type                                        The type of the embed (always "rich" for webhook embeds).
+ * @property      ?string|null                  $description                                 A description of the embed.
+ * @property      ?string|null                  $url                                         The URL of the embed.
+ * @property      ?Carbon|null                  $timestamp                                   A timestamp of the embed.
+ * @property      ?int|null                     $color                                       The color of the embed.
+ * @property      ?Footer|null                  $footer                                      The footer of the embed.
+ * @property      ?Image|null                   $image                                       The image of the embed.
+ * @property      ?Thumbnail|null               $thumbnail                                   The thumbnail of the embed.
+ * @property-read ?Video|null                   $video                                       The video of the embed.
+ * @property-read ?Provider|null                $provider                                    The provider of the embed.
+ * @property      ?Author|null                  $author                                      The author of the embed.
+ * @property      ExCollectionInterface|Field[] $fields                                      A collection of embed fields (max of 25).
+ * @property-read array                         $poll_fields                                 A collection of poll fields.
+ * @property      string|null                   $poll_fields['poll_question_text']           Question text from the original poll
+ * @property      int|null                      $poll_fields['victor_answer_votes']          Number of votes for the answer(s) with the most votes
+ * @property      int|null                      $poll_fields['total_votes']                  Total number of votes in the poll
+ * @property      ?string|null                  $poll_fields['victor_answer_id']             ID for the winning answer (optional)
+ * @property      ?string|null                  $poll_fields['victor_answer_text']           Text for the winning answer (optional)
+ * @property      ?string|null                  $poll_fields['victor_answer_emoji_id']       ID for an emoji associated with the winning answer (optional)
+ * @property      ?string|null                  $poll_fields['victor_answer_emoji_name']     Name of an emoji associated with the winning answer (optional)
+ * @property      ?bool|null                    $poll_fields['victor_answer_emoji_animated'] If an emoji associated with the winning answer is animated (optional)
  */
 class EmbedPollResult extends Embed
 {
     public const TYPE = self::TYPE_POLL_RESULT;
+
+    protected function getPollFieldsAttribute(): array
+    {
+        $fields = [];
+
+        if (! array_key_exists('fields', $this->attributes)) {
+            return $fields;
+        }
+
+        $fields = array_filter(
+            $this->attributes['fields'] ?? [],
+            fn($key) => !in_array($key, ['name', 'value', 'inline']),
+            ARRAY_FILTER_USE_KEY
+        );
+
+        return $fields;
+    }
 }

--- a/src/Discord/Parts/Embed/EmbedPollResult.php
+++ b/src/Discord/Parts/Embed/EmbedPollResult.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is a part of the DiscordPHP project.
+ *
+ * Copyright (c) 2015-present David Cole <david.cole1340@gmail.com>
+ *
+ * This file is subject to the MIT license that is bundled
+ * with this source code in the LICENSE.md file.
+ */
+
+namespace Discord\Parts\Embed;
+
+class EmbedPollResult extends Embed
+{
+    public const TYPE = self::TYPE_POLL_RESULT;
+}

--- a/src/Discord/Parts/Embed/EmbedPollResult.php
+++ b/src/Discord/Parts/Embed/EmbedPollResult.php
@@ -31,14 +31,14 @@ use Discord\Helpers\ExCollectionInterface;
  * @property      ?Author|null                  $author                                      The author of the embed.
  * @property      ExCollectionInterface|Field[] $fields                                      A collection of embed fields (max of 25).
  * @property-read array                         $poll_fields                                 A collection of poll fields.
- * @property      string|null                   $poll_fields['poll_question_text']           Question text from the original poll
- * @property      int|null                      $poll_fields['victor_answer_votes']          Number of votes for the answer(s) with the most votes
- * @property      int|null                      $poll_fields['total_votes']                  Total number of votes in the poll
- * @property      ?string|null                  $poll_fields['victor_answer_id']             ID for the winning answer (optional)
- * @property      ?string|null                  $poll_fields['victor_answer_text']           Text for the winning answer (optional)
- * @property      ?string|null                  $poll_fields['victor_answer_emoji_id']       ID for an emoji associated with the winning answer (optional)
- * @property      ?string|null                  $poll_fields['victor_answer_emoji_name']     Name of an emoji associated with the winning answer (optional)
- * @property      ?bool|null                    $poll_fields['victor_answer_emoji_animated'] If an emoji associated with the winning answer is animated (optional)
+ * @property-read string|null                   $poll_fields['poll_question_text']           Question text from the original poll
+ * @property-read  int|null                      $poll_fields['victor_answer_votes']          Number of votes for the answer(s) with the most votes
+ * @property-read  int|null                      $poll_fields['total_votes']                  Total number of votes in the poll
+ * @property-read  ?string|null                  $poll_fields['victor_answer_id']             ID for the winning answer (optional)
+ * @property-read  ?string|null                  $poll_fields['victor_answer_text']           Text for the winning answer (optional)
+ * @property-read  ?string|null                  $poll_fields['victor_answer_emoji_id']       ID for an emoji associated with the winning answer (optional)
+ * @property-read  ?string|null                  $poll_fields['victor_answer_emoji_name']     Name of an emoji associated with the winning answer (optional)
+ * @property-read  ?bool|null                    $poll_fields['victor_answer_emoji_animated'] If an emoji associated with the winning answer is animated (optional)
  */
 class EmbedPollResult extends Embed
 {

--- a/src/Discord/Parts/Embed/EmbedPollResult.php
+++ b/src/Discord/Parts/Embed/EmbedPollResult.php
@@ -13,6 +13,31 @@ declare(strict_types=1);
 
 namespace Discord\Parts\Embed;
 
+use Discord\Helpers\ExCollectionInterface;
+
+/**
+ * @property      ?string|null                        $title                                  The title of the embed.
+ * @property-read ?string|null                        $type                                   The type of the embed (always "rich" for webhook embeds).
+ * @property      ?string|null                        $description                            A description of the embed.
+ * @property      ?string|null                        $url                                    The URL of the embed.
+ * @property      ?Carbon|null                        $timestamp                              A timestamp of the embed.
+ * @property      ?int|null                           $color                                  The color of the embed.
+ * @property      ?Footer|null                        $footer                                 The footer of the embed.
+ * @property      ?Image|null                         $image                                  The image of the embed.
+ * @property      ?Thumbnail|null                     $thumbnail                              The thumbnail of the embed.
+ * @property-read ?Video|null                         $video                                  The video of the embed.
+ * @property-read ?Provider|null                      $provider                               The provider of the embed.
+ * @property      ?Author|null                        $author                                 The author of the embed.
+ * @property      ?ExCollectionInterface|Field[]|null $fields                                 A collection of embed fields (max of 25).
+ * @property      string|null                         $fields['poll_question_text']           Question text from the original poll
+ * @property      int|null                            $fields['victor_answer_votes']          Number of votes for the answer(s) with the most votes
+ * @property      int|null                            $fields['total_votes']                  Total number of votes in the poll
+ * @property      ?string|null                        $fields['victor_answer_id']             ID for the winning answer (optional)
+ * @property      ?string|null                        $fields['victor_answer_text']           Text for the winning answer (optional)
+ * @property      ?string|null                        $fields['victor_answer_emoji_id']       ID for an emoji associated with the winning answer (optional)
+ * @property      ?string|null                        $fields['victor_answer_emoji_name']     Name of an emoji associated with the winning answer (optional)
+ * @property      ?bool|null                          $fields['victor_answer_emoji_animated'] If an emoji associated with the winning answer is animated (optional)
+ */
 class EmbedPollResult extends Embed
 {
     public const TYPE = self::TYPE_POLL_RESULT;

--- a/src/Discord/Parts/Embed/EmbedRich.php
+++ b/src/Discord/Parts/Embed/EmbedRich.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is a part of the DiscordPHP project.
+ *
+ * Copyright (c) 2015-present David Cole <david.cole1340@gmail.com>
+ *
+ * This file is subject to the MIT license that is bundled
+ * with this source code in the LICENSE.md file.
+ */
+
+namespace Discord\Parts\Embed;
+
+class EmbedRich extends Embed
+{
+    public const TYPE = self::TYPE_RICH;
+}

--- a/src/Discord/Parts/Embed/EmbedVideo.php
+++ b/src/Discord/Parts/Embed/EmbedVideo.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is a part of the DiscordPHP project.
+ *
+ * Copyright (c) 2015-present David Cole <david.cole1340@gmail.com>
+ *
+ * This file is subject to the MIT license that is bundled
+ * with this source code in the LICENSE.md file.
+ */
+
+namespace Discord\Parts\Embed;
+
+class EmbedVideo extends Embed
+{
+    public const TYPE = self::TYPE_VIDEO;
+}

--- a/src/Discord/Parts/Embed/Field.php
+++ b/src/Discord/Parts/Embed/Field.php
@@ -22,14 +22,14 @@ use Discord\Parts\Part;
  *
  * @since 4.0.3
  *
- * @property string    $name   The name of the field.
- * @property string    $value  The value of the field.
- * @property bool|null $inline Whether the field should be displayed in-line.
+ * @property string     $name   The name of the field.
+ * @property string     $value  The value of the field.
+ * @property ?bool|null $inline Whether the field should be displayed in-line.
  */
 class Field extends Part
 {
     /**
-     * {@inheritDoc}
+     * @inheritDoc
      */
     protected $fillable = [
         'name',

--- a/src/Discord/Parts/Embed/Field.php
+++ b/src/Discord/Parts/Embed/Field.php
@@ -18,7 +18,7 @@ use Discord\Parts\Part;
 /**
  * A field of an embed object.
  *
- * @link https://discord.com/developers/docs/resources/channel#embed-object-embed-field-structure
+ * @link https://discord.com/developers/docs/resources/message#embed-object-embed-field-structure
  *
  * @since 4.0.3
  *

--- a/src/Discord/Parts/Embed/Footer.php
+++ b/src/Discord/Parts/Embed/Footer.php
@@ -22,14 +22,14 @@ use Discord\Parts\Part;
  *
  * @since 4.0.3
  *
- * @property      string      $text           Footer text.
- * @property      string|null $icon_url       URL of an icon for the footer. Must be https.
- * @property-read string|null $proxy_icon_url Proxied version of the icon URL.
+ * @property      string       $text           Footer text.
+ * @property      ?string|null $icon_url       URL of an icon for the footer. Must be https.
+ * @property-read ?string|null $proxy_icon_url Proxied version of the icon URL.
  */
 class Footer extends Part
 {
     /**
-     * {@inheritDoc}
+     * @inheritDoc
      */
     protected $fillable = [
         'text',

--- a/src/Discord/Parts/Embed/Image.php
+++ b/src/Discord/Parts/Embed/Image.php
@@ -23,15 +23,15 @@ use Discord\Parts\Part;
  *
  * @since 4.0.3
  *
- * @property      string      $url       The source of the image. Must be https.
- * @property-read string|null $proxy_url A proxied version of the image.
- * @property-read int|null    $height    The height of the image.
- * @property-read int|null    $width     The width of the image.
+ * @property      string       $url       The source of the image. Must be https.
+ * @property-read ?string|null $proxy_url A proxied version of the image.
+ * @property-read ?int|null    $height    The height of the image.
+ * @property-read ?int|null    $width     The width of the image.
  */
 class Image extends Part
 {
     /**
-     * {@inheritDoc}
+     * @inheritDoc
      */
     protected $fillable = [
         'url',

--- a/src/Discord/Parts/Embed/Provider.php
+++ b/src/Discord/Parts/Embed/Provider.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is a part of the DiscordPHP project.
+ *
+ * Copyright (c) 2015-present David Cole <david.cole1340@gmail.com>
+ *
+ * This file is subject to the MIT license that is bundled
+ * with this source code in the LICENSE.md file.
+ */
+
+namespace Discord\Parts\Embed;
+
+use Discord\Parts\Part;
+
+/**
+ * The provider of an embed object.
+ *
+ * @link https://discord.com/developers/docs/resources/message#embed-object-embed-provider-structure
+ *
+ * @since 10.19.0
+ *
+ * @property ?string|null $name The name of the provider.
+ * @property ?string|null $url  The URL of the provider.
+ */
+class Provider extends Part
+{
+    /**
+     * @inheritDoc
+     */
+    protected $fillable = [
+        'name',
+        'url',
+    ];
+}

--- a/src/Discord/Parts/Embed/Thumbnail.php
+++ b/src/Discord/Parts/Embed/Thumbnail.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is a part of the DiscordPHP project.
+ *
+ * Copyright (c) 2015-present David Cole <david.cole1340@gmail.com>
+ *
+ * This file is subject to the MIT license that is bundled
+ * with this source code in the LICENSE.md file.
+ */
+
+namespace Discord\Parts\Embed;
+
+use Discord\Parts\Part;
+
+/**
+ * The thumbnail of an embed object.
+ *
+ * @link https://discord.com/developers/docs/resources/message#embed-object-embed-thumbnail-structure
+ *
+ * @since 10.19.0
+ *
+ * @property ?string|null $url        Source URL of thumbnail (only supports http(s) and attachments).
+ * @property ?string|null $proxy_url  A proxied URL of the thumbnail.
+ * @property ?int|null    $height     Height of thumbnail.
+ * @property ?int|null    $width      Width of thumbnail.
+ */
+class Thumbnail extends Part
+{
+    /**
+     * @inheritDoc
+     */
+    protected $fillable = [
+        'url',
+        'proxy_url',
+        'height',
+        'width',
+    ];
+}

--- a/src/Discord/Parts/Embed/Thumbnail.php
+++ b/src/Discord/Parts/Embed/Thumbnail.php
@@ -22,10 +22,10 @@ use Discord\Parts\Part;
  *
  * @since 10.19.0
  *
- * @property ?string|null $url        Source URL of thumbnail (only supports http(s) and attachments).
- * @property ?string|null $proxy_url  A proxied URL of the thumbnail.
- * @property ?int|null    $height     Height of thumbnail.
- * @property ?int|null    $width      Width of thumbnail.
+ * @property ?string|null $url       Source URL of thumbnail (only supports http(s) and attachments).
+ * @property ?string|null $proxy_url A proxied URL of the thumbnail.
+ * @property ?int|null    $height    Height of thumbnail.
+ * @property ?int|null    $width     Width of thumbnail.
  */
 class Thumbnail extends Part
 {

--- a/src/Discord/Parts/Embed/Video.php
+++ b/src/Discord/Parts/Embed/Video.php
@@ -22,15 +22,15 @@ use Discord\Parts\Part;
  *
  * @since 4.0.3
  *
- * @property      string|null $url       The source of the video.
- * @property-read string|null $proxy_url A proxied url of the video.
- * @property-read int|null    $height    The height of the video.
- * @property-read int|null    $width     The width of the video.
+ * @property      ?string|null $url       The source of the video.
+ * @property-read ?string|null $proxy_url A proxied url of the video.
+ * @property-read ?int|null    $height    The height of the video.
+ * @property-read ?int|null    $width     The width of the video.
  */
 class Video extends Part
 {
     /**
-     * {@inheritDoc}
+     * @inheritDoc
      */
     protected $fillable = [
         'url',


### PR DESCRIPTION
This pull request refactors and extends the embed system in the DiscordPHP project to support multiple embed types and improve type safety for embed attributes. It introduces dedicated classes for each embed type, updates property definitions for better nullability and documentation, and adds support for new embed structures like `Provider` and `Thumbnail`.

### Embed system refactoring and type support

* Added dedicated classes for each embed type (`EmbedRich`, `EmbedImage`, `EmbedVideo`, `EmbedGifv`, `EmbedArticle`, `EmbedLink`, `EmbedPollResult`) and a type mapping in `Embed::TYPES` to instantiate the correct class based on the embed's type. [[1]](diffhunk://#diff-825742194655a73fc909ddb6516b4e978a4cc174f34ec0dca6de332516ecefbcL27-R68) [[2]](diffhunk://#diff-c08586134c8577f334eee9fc6034a77ef23671d566e422c8fc8205d5c708b553R1-R19) [[3]](diffhunk://#diff-1fcbaf384b1826969ef149c219857927fa50fc3624e9b3343e58051c116d5437R1-R19) [[4]](diffhunk://#diff-7cc1fa0e051fd4175388e87987332f8f6967f1afa921b05442607a8840d54cccR1-R19) [[5]](diffhunk://#diff-461b59bdb88c75e7f349eeb259f4a7f3cbf0d4833711e702072c944fa8278afaR1-R19) [[6]](diffhunk://#diff-ae4ccc9ba2f26e7434ff513686d798b04c847d78311a171f169ea9fe0e50d46eR1-R19) [[7]](diffhunk://#diff-4334c3ac2097234f891d841409e44abf8579b9703feed474ef67c66268018cabR1-R19) [[8]](diffhunk://#diff-7dac85eca4c496eb73de640bc20ad283305d6a56b896047448ba2970e66e603bR1-R19) [[9]](diffhunk://#diff-3bc0952a87e08969969124672b2539443f4afa2fa67b5fdcddd94944c88eb1ddL632-R632)
* Updated the embed type handling in `Message.php` to use the new type mapping for instantiating embed objects.
* Added support for the new `poll_result` embed type in the embed types list.

### Attribute and property improvements

* Improved property nullability and documentation for embed-related classes (`Embed`, `Author`, `Footer`, `Field`, `Image`, `Video`) to use `?type|null` for optional properties and updated docblocks for accuracy. [[1]](diffhunk://#diff-825742194655a73fc909ddb6516b4e978a4cc174f34ec0dca6de332516ecefbcL27-R68) [[2]](diffhunk://#diff-6fb34e72e31a8ef25064cb9c626c9d01ba23a418a59101cf1ccb3f9af42b09deL26-R33) [[3]](diffhunk://#diff-1c65ceaff871f3cfb21618ee5b702a724a451242ec44763d9900c21e7fda45c7L26-R32) [[4]](diffhunk://#diff-1f4aca21865be9c370008931c537d96eaa1c7f24fa3e6dad4d982db4682eb82eL27-R32) [[5]](diffhunk://#diff-e606b2df1c3e1561e2b4c0bf027d4f256d230cc2dc7d9d6887d730c60af3632eL27-R34) [[6]](diffhunk://#diff-94b9d606941a4a7d169af479d2a936e7c27996a8cd6f9379415f5499481cbcafL25-R33)
* Changed the `thumbnail` attribute in `Embed` to use the new `Thumbnail` class instead of `Image`, and added a getter for the new `Provider` attribute. [[1]](diffhunk://#diff-825742194655a73fc909ddb6516b4e978a4cc174f34ec0dca6de332516ecefbcL112-R129) [[2]](diffhunk://#diff-825742194655a73fc909ddb6516b4e978a4cc174f34ec0dca6de332516ecefbcR142-R151)

### New embed structure classes

* Added new classes for `Provider` and `Thumbnail` to represent their respective embed structures, with appropriate fillable fields and documentation. [[1]](diffhunk://#diff-a04f4bb71467d709a3d7971f960fbff969941e905936c4bc88eb3c18eb5430f6R1-R37) [[2]](diffhunk://#diff-d0944c4058c2ea2077d28b7dd53ad37d0225cd7d12730171ca07e0671ee4b22eR1-R41)