### PR TITLE
PartTrait::attributeHelper

### DIFF
--- a/src/Discord/Parts/Embed/Embed.php
+++ b/src/Discord/Parts/Embed/Embed.php
@@ -89,9 +89,9 @@ class Embed extends Part
     /**
      * Gets the footer attribute.
      *
-     * @return Footer The footer attribute.
+     * @return Footer|null The footer attribute.
      */
-    protected function getFooterAttribute(): Footer
+    protected function getFooterAttribute(): ?Footer
     {
         return $this->attributeHelper('footer', Footer::class);
     }
@@ -99,9 +99,9 @@ class Embed extends Part
     /**
      * Gets the image attribute.
      *
-     * @return Image The image attribute.
+     * @return Image|null The image attribute.
      */
-    protected function getImageAttribute(): Image
+    protected function getImageAttribute(): ?Image
     {
         return $this->attributeHelper('image', Image::class);
     }
@@ -109,9 +109,9 @@ class Embed extends Part
     /**
      * Gets the thumbnail attribute.
      *
-     * @return Image The thumbnail attribute.
+     * @return Image|null The thumbnail attribute.
      */
-    protected function getThumbnailAttribute(): Image
+    protected function getThumbnailAttribute(): ?Image
     {
         return $this->attributeHelper('thumbnail', Image::class);
     }
@@ -119,9 +119,9 @@ class Embed extends Part
     /**
      * Gets the video attribute.
      *
-     * @return Video The video attribute.
+     * @return Video|null The video attribute.
      */
-    protected function getVideoAttribute(): Video
+    protected function getVideoAttribute(): ?Video
     {
         return $this->attributeHelper('video', Video::class);
     }
@@ -129,9 +129,9 @@ class Embed extends Part
     /**
      * Gets the author attribute.
      *
-     * @return Author The author attribute.
+     * @return Author|null The author attribute.
      */
-    protected function getAuthorAttribute(): Author
+    protected function getAuthorAttribute(): ?Author
     {
         return $this->attributeHelper('author', Author::class);
     }

--- a/src/Discord/Parts/Part.php
+++ b/src/Discord/Parts/Part.php
@@ -28,6 +28,7 @@ use JsonSerializable;
 abstract class Part implements PartInterface, ArrayAccess, JsonSerializable
 {
     use PartTrait;
+
     /**
      * The HTTP client.
      *

--- a/src/Discord/Parts/PartTrait.php
+++ b/src/Discord/Parts/PartTrait.php
@@ -440,19 +440,17 @@ trait PartTrait
      *
      * @throws \Exception
      *
-     * @return mixed
+     * @return Part|null
      */
-    protected function attributeHelper($key, $class)
+    protected function attributeHelper($key, $class): ?Part
     {
         if (! array_key_exists($key, $this->attributes)) {
-            return $this->factory->create($class);
+            return null;
         }
 
-        if ($this->attributes[$key] instanceof $class) {
-            return $this->attributes[$key];
-        }
-
-        return $this->factory->create($class, $this->attributes[$key], true);
+        return ($this->attributes[$key] instanceof $class)
+            ? $this->attributes[$key]
+            : $this->attributes[$key] = $this->factory->part($class, $this->attributes[$key], $this->created);
     }
 
     /**


### PR DESCRIPTION
This pull request refactors the `attributeHelper` method in `PartTrait.php` to improve type safety and simplify the logic for attribute handling. The main change is to ensure the method consistently returns either a `Part` instance or `null`, and to streamline how attributes are created and managed.

Improvements to type safety and attribute handling:

* Changed the return type of `attributeHelper` to `Part|null` and updated its signature to reflect this.
* Simplified the method logic: now returns `null` if the attribute key does not exist, otherwise returns the existing instance if it matches the expected class, or creates and assigns a new `Part` using the factory if needed.