### PR TITLE
Member::modifyCurrentMember

### DIFF
--- a/src/Discord/Parts/Embed/EmbedPollResult.php
+++ b/src/Discord/Parts/Embed/EmbedPollResult.php
@@ -32,13 +32,13 @@ use Discord\Helpers\ExCollectionInterface;
  * @property      ExCollectionInterface|Field[] $fields                                      A collection of embed fields (max of 25).
  * @property-read array                         $poll_fields                                 A collection of poll fields.
  * @property-read string|null                   $poll_fields['poll_question_text']           Question text from the original poll
- * @property-read  int|null                      $poll_fields['victor_answer_votes']          Number of votes for the answer(s) with the most votes
- * @property-read  int|null                      $poll_fields['total_votes']                  Total number of votes in the poll
- * @property-read  ?string|null                  $poll_fields['victor_answer_id']             ID for the winning answer (optional)
- * @property-read  ?string|null                  $poll_fields['victor_answer_text']           Text for the winning answer (optional)
- * @property-read  ?string|null                  $poll_fields['victor_answer_emoji_id']       ID for an emoji associated with the winning answer (optional)
- * @property-read  ?string|null                  $poll_fields['victor_answer_emoji_name']     Name of an emoji associated with the winning answer (optional)
- * @property-read  ?bool|null                    $poll_fields['victor_answer_emoji_animated'] If an emoji associated with the winning answer is animated (optional)
+ * @property-read int|null                      $poll_fields['victor_answer_votes']          Number of votes for the answer(s) with the most votes
+ * @property-read int|null                      $poll_fields['total_votes']                  Total number of votes in the poll
+ * @property-read ?string|null                  $poll_fields['victor_answer_id']             ID for the winning answer (optional)
+ * @property-read ?string|null                  $poll_fields['victor_answer_text']           Text for the winning answer (optional)
+ * @property-read ?string|null                  $poll_fields['victor_answer_emoji_id']       ID for an emoji associated with the winning answer (optional)
+ * @property-read ?string|null                  $poll_fields['victor_answer_emoji_name']     Name of an emoji associated with the winning answer (optional)
+ * @property-read ?bool|null                    $poll_fields['victor_answer_emoji_animated'] If an emoji associated with the winning answer is animated (optional)
  */
 class EmbedPollResult extends Embed
 {
@@ -54,7 +54,7 @@ class EmbedPollResult extends Embed
 
         $fields = array_filter(
             $this->attributes['fields'] ?? [],
-            fn($key) => !in_array($key, ['name', 'value', 'inline']),
+            fn ($key) => ! in_array($key, ['name', 'value', 'inline']),
             ARRAY_FILTER_USE_KEY
         );
 

--- a/src/Discord/Parts/User/Member.php
+++ b/src/Discord/Parts/User/Member.php
@@ -199,7 +199,7 @@ class Member extends Part implements Stringable
     }
 
     /**
-     * Modifies the current member.
+     * Modifies the current member (no validation).
      *
      * @link https://discord.com/developers/docs/resources/guild#modify-current-member-json-params
      *

--- a/src/Discord/Parts/User/Member.php
+++ b/src/Discord/Parts/User/Member.php
@@ -212,7 +212,7 @@ class Member extends Part implements Stringable
      * @param ?string|null $params['bio']    Guild member bio.
      * @param string|null  $reason           Reason for Audit Log.
      *
-     * @throws NoPermissionsException Missing manage_nicknames permission.
+     * @throws NoPermissionsException Member is not the current user.
      *
      * @return PromiseInterface<self>
      */
@@ -225,7 +225,7 @@ class Member extends Part implements Stringable
         $allowed = ['nick', 'banner', 'avatar', 'bio'];
         $params = array_filter(
             $params,
-            fn($key) => in_array($key, $allowed, true),
+            fn ($key) => in_array($key, $allowed, true),
             ARRAY_FILTER_USE_KEY
         );
 

--- a/src/Discord/Parts/User/Member.php
+++ b/src/Discord/Parts/User/Member.php
@@ -199,48 +199,6 @@ class Member extends Part implements Stringable
     }
 
     /**
-     * Sets the nickname of the member.
-     *
-     * @param ?string|null $nick   The nickname of the member.
-     * @param string|null  $reason Reason for Audit Log.
-     *
-     * @throws NoPermissionsException Missing manage_nicknames permission.
-     *
-     * @return PromiseInterface<self>
-     */
-    public function setNickname(?string $nick = null, ?string $reason = null): PromiseInterface
-    {
-        $payload = [
-            'nick' => $nick ?? '',
-        ];
-
-        $headers = [];
-        if (isset($reason)) {
-            $headers['X-Audit-Log-Reason'] = $reason;
-        }
-
-        // jake plz
-        if ($this->discord->id == $this->id) {
-            return $this->http->patch(Endpoint::bind(Endpoint::GUILD_MEMBER_SELF, $this->guild_id), $payload, $headers);
-        }
-
-        if ($guild = $this->guild) {
-            if ($botperms = $guild->getBotPermissions()) {
-                if (! $botperms->manage_nicknames) {
-                    return reject(new NoPermissionsException("You do not have permission to manage nicknames in the guild {$guild->id}."));
-                }
-            }
-        }
-
-        return $this->http->patch(Endpoint::bind(Endpoint::GUILD_MEMBER, $this->guild_id, $this->id), $payload, $headers)
-            ->then(function ($response) {
-                $this->nick = $response->nick;
-
-                return $this;
-            });
-    }
-
-    /**
      * Modifies the current member.
      *
      * @link https://discord.com/developers/docs/resources/guild#modify-current-member-json-params
@@ -281,6 +239,48 @@ class Member extends Part implements Stringable
         }
 
         return $this->http->patch(Endpoint::bind(Endpoint::GUILD_MEMBER_SELF, $this->guild_id), $params, $headers);
+    }
+
+    /**
+     * Sets the nickname of the member.
+     *
+     * @param ?string|null $nick   The nickname of the member.
+     * @param string|null  $reason Reason for Audit Log.
+     *
+     * @throws NoPermissionsException Missing manage_nicknames permission.
+     *
+     * @return PromiseInterface<self>
+     */
+    public function setNickname(?string $nick = null, ?string $reason = null): PromiseInterface
+    {
+        $payload = [
+            'nick' => $nick ?? '',
+        ];
+
+        $headers = [];
+        if (isset($reason)) {
+            $headers['X-Audit-Log-Reason'] = $reason;
+        }
+
+        // jake plz
+        if ($this->discord->id == $this->id) {
+            return $this->http->patch(Endpoint::bind(Endpoint::GUILD_MEMBER_SELF, $this->guild_id), $payload, $headers);
+        }
+
+        if ($guild = $this->guild) {
+            if ($botperms = $guild->getBotPermissions()) {
+                if (! $botperms->manage_nicknames) {
+                    return reject(new NoPermissionsException("You do not have permission to manage nicknames in the guild {$guild->id}."));
+                }
+            }
+        }
+
+        return $this->http->patch(Endpoint::bind(Endpoint::GUILD_MEMBER, $this->guild_id, $this->id), $payload, $headers)
+            ->then(function ($response) {
+                $this->nick = $response->nick;
+
+                return $this;
+            });
     }
 
     /**

--- a/src/Discord/Parts/User/Member.php
+++ b/src/Discord/Parts/User/Member.php
@@ -241,6 +241,49 @@ class Member extends Part implements Stringable
     }
 
     /**
+     * Modifies the current member.
+     *
+     * @link https://discord.com/developers/docs/resources/guild#modify-current-member-json-params
+     *
+     * @since 10.19.0
+     *
+     * @param array        $params           The parameters to modify.
+     * @param ?string|null $params['nick']   Value to set user's nickname to.
+     * @param ?string|null $params['banner'] Data URI base64 encoded banner image.
+     * @param ?string|null $params['avatar'] Data URL base64 encoded avatar image.
+     * @param ?string|null $params['bio']    Guild member bio.
+     * @param string|null  $reason           Reason for Audit Log.
+     *
+     * @throws NoPermissionsException Missing manage_nicknames permission.
+     *
+     * @return PromiseInterface<self>
+     */
+    public function modifyCurrentMember(array $params, ?string $reason = null): PromiseInterface
+    {
+        if ($this->discord->id != $this->id) {
+            return reject(new NoPermissionsException('You can only modify the current member.'));
+        }
+
+        $allowed = ['nick', 'banner', 'avatar', 'bio'];
+        $params = array_filter(
+            $params,
+            fn($key) => in_array($key, $allowed, true),
+            ARRAY_FILTER_USE_KEY
+        );
+
+        if (empty($params)) {
+            return reject(new \InvalidArgumentException('No valid parameters to modify.'));
+        }
+
+        $headers = [];
+        if (isset($reason)) {
+            $headers['X-Audit-Log-Reason'] = $reason;
+        }
+
+        return $this->http->patch(Endpoint::bind(Endpoint::GUILD_MEMBER_SELF, $this->guild_id), $params, $headers);
+    }
+
+    /**
      * Moves the member to another voice channel.
      *
      * @param Channel|?string $channel The channel to move the member to.


### PR DESCRIPTION
https://github.com/discord/discord-api-docs/pull/7807/files

This pull request introduces a new method to the `Member` class in `src/Discord/Parts/User/Member.php`, allowing modification of the current member's profile attributes. The addition enhances the Discord API integration by supporting updates to nickname, banner, avatar, and bio for the logged-in user, with validation and permission checks.