### PR TITLE
File Upload Component

### DIFF
--- a/src/Discord/Builders/Components/Component.php
+++ b/src/Discord/Builders/Components/Component.php
@@ -47,6 +47,7 @@ abstract class Component extends Builder implements JsonSerializable
     public const TYPE_CONTAINER = 17;
 
     public const TYPE_LABEL = 18;
+    public const TYPE_FILE_UPLOAD = 19;
 
     /** @deprecated 7.4.0 Use `Component::TYPE_STRING_SELECT` */
     public const TYPE_SELECT_MENU = 3;

--- a/src/Discord/Builders/Components/FileUpload.php
+++ b/src/Discord/Builders/Components/FileUpload.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is a part of the DiscordPHP project.
+ *
+ * Copyright (c) 2015-present David Cole <david.cole1340@gmail.com>
+ *
+ * This file is subject to the MIT license that is bundled
+ * with this source code in the LICENSE.md file.
+ */
+
+namespace Discord\Builders\Components;
+
+/**
+ * TODO.
+ *
+ * @link TODO
+ *
+ * @since 10.21.0
+ *
+ * @property int        $type       19 for File Upload component.
+ * @property string     $custom_id  ID for the select menu; max 100 characters.
+ * @property ?int|null  $min_values Minimum number of items that must be chosen (defaults to 1); min 0, max 5.
+ * @property ?int|null  $max_values Maximum number of items that can be chosen (defaults to 1); max 5.
+ * @property ?bool|null $required   Whether this component is required to be filled (defaults to true).
+ */
+class FileUpload extends SelectMenu
+{
+    public const USAGE = ['Modal'];
+
+    /**
+     * Component type.
+     *
+     * @var int
+     */
+    protected $type = Component::TYPE_FILE_UPLOAD;
+
+    /**
+     * Set if this component is required to be filled, default false. (Modal only).
+     *
+     * @param bool|null $required
+     *
+     * @return $this
+     */
+    public function setRequired(?bool $required = null): self
+    {
+        $this->required = $required;
+
+        return $this;
+    }
+}

--- a/src/Discord/Parts/Channel/Message/FileUpload.php
+++ b/src/Discord/Parts/Channel/Message/FileUpload.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is a part of the DiscordPHP project.
+ *
+ * Copyright (c) 2015-present David Cole <david.cole1340@gmail.com>
+ *
+ * This file is subject to the MIT license that is bundled
+ * with this source code in the LICENSE.md file.
+ */
+
+namespace Discord\Parts\Channel\Message;
+
+/**
+ * TODO.
+ *
+ * @link TODO
+ *
+ * @since 10.21.0
+ *
+ * @property int        $type       19 for File Upload component.
+ * @property string     $custom_id  ID for the select menu; max 100 characters.
+ * @property ?int|null  $min_values Minimum number of items that must be chosen (defaults to 1); min 0, max 5.
+ * @property ?int|null  $max_values Maximum number of items that can be chosen (defaults to 1); max 5.
+ * @property ?bool|null $required   Whether this component is required to be filled (defaults to true).
+ */
+class FileUpload extends interactive
+{
+    /**
+     * @inheritDoc
+     */
+    protected $fillable = [
+        'id',
+        'custom_id',
+        'min_values',
+        'max_values',
+        'required',
+    ];
+}


### PR DESCRIPTION
This pull request introduces support for a new File Upload component to the DiscordPHP project. The main changes include the addition of a new component type constant, as well as new classes to represent and handle the File Upload component in both the builder and message parts of the codebase.

**New File Upload Component Support:**

* Added `TYPE_FILE_UPLOAD` constant (`19`) to the `Component` class to represent the new File Upload component type.
* Implemented the `FileUpload` class in `src/Discord/Builders/Components/FileUpload.php`, extending `SelectMenu` and providing properties and a setter for the `required` field.
* Added the `FileUpload` class in `src/Discord/Parts/Channel/Message/FileUpload.php` to handle File Upload components in messages, with appropriate fillable properties.