### PR TITLE
Invite::Profile & GuildTraitObject

### DIFF
--- a/src/Discord/Parts/Channel/Invite.php
+++ b/src/Discord/Parts/Channel/Invite.php
@@ -15,6 +15,7 @@ namespace Discord\Parts\Channel;
 
 use Carbon\Carbon;
 use Discord\Parts\Guild\Guild;
+use Discord\Parts\Guild\Profile;
 use Discord\Parts\Guild\ScheduledEvent;
 use Discord\Parts\OAuth\Application;
 use Discord\Parts\Part;
@@ -44,6 +45,7 @@ use Stringable;
  * @property Carbon              $expires_at                 The expiration date of this invite.
  * @property ScheduledEvent|null $guild_scheduled_event      Guild scheduled event data, only included if guild_scheduled_event_id contains a valid guild scheduled event id.
  * @property int                 $flags                      Guild invite flags for guild invites.
+ * @property Profile             $profile                    The guild profile.
  *
  * @property int|null    $uses       How many times the invite has been used.
  * @property int|null    $max_uses   How many times the invite can be used.
@@ -75,6 +77,8 @@ class Invite extends Part implements Stringable
         'approximate_member_count',
         'expires_at',
         'guild_scheduled_event',
+        'flags',
+        'profile',
 
         // Extra metadata
         'uses',
@@ -258,6 +262,16 @@ class Invite extends Part implements Stringable
         }
 
         return $this->factory->part(ScheduledEvent::class, (array) $this->attributes['guild_scheduled_event'], true);
+    }
+
+    /**
+     * Returns the guild profile for this invite.
+     *
+     * @return Profile The guild profile.
+     */
+    protected function getProfileAttribute(): Profile
+    {
+        return $this->attributePartHelper('profile', Profile::class);
     }
 
     /**

--- a/src/Discord/Parts/Guild/GuildTraitObject.php
+++ b/src/Discord/Parts/Guild/GuildTraitObject.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is a part of the DiscordPHP project.
+ *
+ * Copyright (c) 2015-present David Cole <david.cole1340@gmail.com>
+ *
+ * This file is subject to the MIT license that is bundled
+ * with this source code in the LICENSE.md file.
+ */
+
+namespace Discord\Parts\Guild;
+
+use Discord\Parts\Part;
+
+/**
+ * Guild Trait Object.
+ *
+ * @link https://discord.com/developers/docs/resources/guild#guild-trait-object
+ *
+ * @since 10.22.0
+ *
+ * @property string|null $emoji_id       The id of a guild's custom emoji.
+ * @property string|null $emoji_name     The unicode character of the emoji.
+ * @property bool|null   $emoji_animated Whether the emoji is animated.
+ * @property string|null $label          The label of the trait.
+ * @property int|null    $position       The position of the trait.
+ */
+class GuildTraitObject extends Part
+{
+    /**
+     * @inheritDoc
+     */
+    protected $fillable = [
+        'emoji_id',
+        'emoji_name',
+        'emoji_animated',
+        'label',
+        'position',
+    ];
+}

--- a/src/Discord/Parts/Guild/Profile.php
+++ b/src/Discord/Parts/Guild/Profile.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is a part of the DiscordPHP project.
+ *
+ * Copyright (c) 2015-present David Cole <david.cole1340@gmail.com>
+ *
+ * This file is subject to the MIT license that is bundled
+ * with this source code in the LICENSE.md file.
+ */
+
+namespace Discord\Parts\Guild;
+
+use Discord\Helpers\ExCollectionInterface;
+use Discord\Parts\Part;
+
+/**
+ * This object can only be retrieved through the `profile` field of the [GET Invite](/docs/resources/invite#get-invite) endpoint.
+ *
+ * @link https://discord.com/developers/docs/resources/guild#guild-profile-object
+ *
+ * @since 10.22.0
+ *
+ * @property string                                                     $id                         The unique identifier of the guild.
+ * @property int                                                        $badge                      Guild badge.
+ * @property string                                                     $badge_color_primary        Primary color for the guild badge.
+ * @property string                                                     $badge_color_secondary      Secondary color for the guild badge.
+ * @property string|null                                                $badge_hash                 Guild tag badge hash.
+ * @property string|null                                                $banner_hash                Server tag badge hash.
+ * @property string|null                                                $custom_banner_hash         Custom banner hash.
+ * @property string|null                                                $description                The description for the guild.
+ * @property array                                                      $features                   Enabled guild features.
+ * @property object                                                     $game_activity              Game activity data for the guild.
+ * @property array                                                      $game_application_ids       Application ids for games associated with the guild.
+ * @property string|null                                                $icon_hash                  Icon hash.
+ * @property int                                                        $member_count               Total number of members in the guild.
+ * @property string                                                     $name                       Guild name.
+ * @property int                                                        $online_count               Number of online members in the guild.
+ * @property int                                                        $premium_subscription_count The number of boosts this guild currently has.
+ * @property int                                                        $premium_tier               Premium tier (Server Boost level).
+ * @property string|null                                                $tag                        Tag of the guild.
+ * @property ExCollectionInterface<GuildTraitObject>|GuildTraitObject[] $traits                     Traits of the guild.
+ * @property int                                                        $visibility                 Visibility level of the guild.
+ */
+class Profile extends Part
+{
+    /**
+     * @inheritDoc
+     */
+    protected $fillable = [
+        'id',
+        'badge',
+        'badge_color_primary',
+        'badge_color_secondary',
+        'badge_hash',
+        'banner_hash',
+        'custom_banner_hash',
+        'description',
+        'features',
+        'game_activity',
+        'game_application_ids',
+        'icon_hash',
+        'member_count',
+        'name',
+        'online_count',
+        'premium_subscription_count',
+        'premium_tier',
+        'tag',
+        'traits',
+        'visibility',
+    ];
+
+    protected function getTraitsAttribute(): ExCollectionInterface
+    {
+        return $this->attributeCollectionHelper('traits', GuildTraitObject::class, 'emoji_id');
+    }
+}


### PR DESCRIPTION
https://github.com/discord/discord-api-docs/pull/7849/files#diff-b048a45b363d01dbbaeaf7409be45b8faec5386ce0cc3e889208c737c534855fR429-R449

This pull request introduces support for Discord guild profile objects and guild trait objects, primarily to enhance invite-related features. The most significant changes include the addition of new classes for `Profile` and `GuildTraitObject`, and the integration of the `profile` property into the `Invite` part. These updates enable handling of guild profile data returned from the Discord API's invite endpoint.

**Guild Profile and Trait Support:**

* Added new `Profile` class (`src/Discord/Parts/Guild/Profile.php`) to represent guild profile data, including properties for badge, banner, description, member counts, traits, and more. This class also provides a helper for accessing guild traits as a collection.
* Added new `GuildTraitObject` class (`src/Discord/Parts/Guild/GuildTraitObject.php`) to represent individual guild traits, including properties for emoji, label, and position.

**Invite Part Enhancements:**

* Imported the new `Profile` class in `Invite.php` to allow usage of guild profile data.
* Added a `profile` property to the `Invite` part, allowing access to guild profile information from invite objects. [[1]](diffhunk://#diff-5d2251c005b2ae0591670e794e724dfda058b60941d5c1ca6cfb29bb3e5d83f1R48) [[2]](diffhunk://#diff-5d2251c005b2ae0591670e794e724dfda058b60941d5c1ca6cfb29bb3e5d83f1R80-R81)
* Implemented the `getProfileAttribute` method in the `Invite` part to retrieve the guild profile using the new `Profile` class.