### PR TITLE
ThreadMetadata object

### DIFF
--- a/src/Discord/Parts/Channel/Channel.php
+++ b/src/Discord/Parts/Channel/Channel.php
@@ -51,30 +51,29 @@ use function React\Promise\resolve;
  * @since 2.0.0 Refactored as Part
  * @since 1.0.0
  *
- * @property      int|null                     $position                           The position of the channel on the sidebar.
- * @property      ?array                       $permission_overwrites              Explicit permission overwrites for members and roles
- * @property      OverwriteRepository          $overwrites                         Permission overwrites
- * @property      ?string|null                 $topic                              The topic of the channel (0-4096 characters for forum channels, 0-1024 characters for all others).
+ * @property      int|null                     $position                           Sorting position of the channel.
+ * @property      array                        $permission_overwrites              Explicit permission overwrites for members and roles.
+ * @property      ?string|null                 $topic                              The topic of the channel (0-4096 characters for forum/media, 0-1024 for others).
  * @property      bool|null                    $nsfw                               Whether the channel is NSFW.
- * @property      int|null                     $bitrate                            The bitrate of the channel. Only for voice channels.
- * @property      int|null                     $user_limit                         The user limit of the channel. Max 99 for voice channels and 10000 for stage channels (0 refers to no limit).
- * @property      ExCollectionInterface|User[] $recipients                         A collection of all the recipients in the channel. Only for DM or group channels.
- * @property-read User|null                    $recipient                          The first recipient of the channel. Only for DM or group channels.
- * @property-read string|null                  $recipient_id                       The ID of the recipient of the channel, if it is a DM channel.
- * @property      ?string|null                 $icon                               Icon hash.
- * @property      string|null                  $application_id                     ID of the group DM creator if it is a bot.
- * @property      bool|null                    $managed                            Whether the channel is managed by an application via the `gdm.join` OAuth2 scope. Only for group DM channels.
+ * @property      int|null                     $bitrate                            The bitrate (in bits) of the voice or stage channel; min 8000.
+ * @property      int|null                     $user_limit                         The user limit of the voice or stage channel, max 99 for voice channels and 10,000 for stage channels (0 refers to no limit).
+ * @property      ExCollectionInterface|User[] $recipients                         The recipients of the DM.
+ * @property-read User|null                    $recipient                          The first recipient of the DM (DM/group).
+ * @property-read string|null                  $recipient_id                       The ID of the recipient (DM).
+ * @property      ?string|null                 $icon                               Icon hash of the group DM.
+ * @property      string|null                  $application_id                     Application id of the group DM creator if bot-created.
+ * @property      bool|null                    $managed                            For group DM channels: whether the channel is managed by an application via the `gdm.join` OAuth2 scope.
  * @property      ?string|null                 $rtc_region                         Voice region id for the voice channel, automatic when set to null.
- * @property      int|null                     $video_quality_mode                 The camera video quality mode of the voice channel, 1 when not present.
- * @property      int|null                     $default_auto_archive_duration      Default duration for newly created threads, in minutes, to automatically archive the thread after recent activity, can be set to: 60, 1440, 4320, 10080.
- * @property      string|null                  $permissions                        Computed permissions for the invoking user in the channel, including overwrites, only included when part of the resolved data received on an application command interaction.
+ * @property      ?int|null                    $video_quality_mode                 The camera video quality mode of the voice channel, 1 when not present.
+ * @property      ?int|null                    $default_auto_archive_duration      Default duration for newly created threads, in minutes.
  * @property      int|null                     $flags                              Channel flags combined as a bitfield.
- * @property      ExCollectionInterface|Tag[]  $available_tags                     Set of tags that can be used in a forum channel, limited to 20.
- * @property      ?Reaction|null               $default_reaction_emoji             Emoji to show in the add reaction button on a thread in a forum channel.
- * @property      int|null                     $default_thread_rate_limit_per_user The initial rate_limit_per_user to set on newly created threads in a forum channel. This field is copied to the thread at creation time and does not live update.
- * @property      ?int|null                    $default_sort_order                 The default sort order type used to order posts in forum channels.
- * @property      int|null                     $default_forum_layout               The default layout type used to display posts in a forum channel. Defaults to `0`, which indicates a layout view has not been set by a channel admin.
+ * @property      ExCollectionInterface|Tag[]  $available_tags                     The set of tags that can be used in a `GUILD_FORUM` or a `GUILD_MEDIA` channel. Limited to 20.
+ * @property      ?Reaction|null               $default_reaction_emoji             The emoji to show in the add reaction button on a thread in a `GUILD_FORUM` or a `GUILD_MEDIA` channel.
+ * @property      int|null                     $default_thread_rate_limit_per_user The initial `rate_limit_per_user` to set on newly created threads in a channel. This field is copied to the thread at creation time and does not live update.
+ * @property      ?int|null                    $default_sort_order                 The default sort order type used to order posts in `GUILD_FORUM` and `GUILD_MEDIA` channels. Defaults to `null`, which indicates a preferred sort order hasn't been set by a channel admin.
+ * @property      int|null                     $default_forum_layout               The default forum layout view used to display posts in `GUILD_FORUM` channels. Defaults to `0`, which indicates a layout view has not been set by a channel admin.
  *
+ * @property OverwriteRepository     $overwrites      Permission overwrites.
  * @property WebhookRepository       $webhooks        Webhooks in the channel.
  * @property ThreadRepository        $threads         Threads that belong to the channel.
  * @property InviteRepository        $invites         Invites in the channel.

--- a/src/Discord/Parts/Channel/ThreadMetadata.php
+++ b/src/Discord/Parts/Channel/ThreadMetadata.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is a part of the DiscordPHP project.
+ *
+ * Copyright (c) 2015-present David Cole <david.cole1340@gmail.com>
+ *
+ * This file is subject to the MIT license that is bundled
+ * with this source code in the LICENSE.md file.
+ */
+
+namespace Discord\Parts\Channel;
+
+use Carbon\Carbon;
+use Discord\Parts\Part;
+
+/**
+ * The thread metadata object contains a number of thread-specific channel fields that are not needed by other channel types.
+ *
+ * @link https://discord.com/developers/docs/resources/channel#thread-metadata-object
+ *
+ * @since 10.22.0
+ *
+ * @property bool         $archived              Whether the thread is archived.
+ * @property int          $auto_archive_duration The thread will stop showing in the channel list after auto_archive_duration minutes of inactivity.
+ * @property string       $archive_timestamp     Timestamp when the thread's archive status was last changed (ISO8601).
+ * @property bool         $locked                Whether the thread is locked; only users with MANAGE_THREADS can unarchive it.
+ * @property ?bool|null   $invitable             Whether non-moderators can add other non-moderators to a thread; only available on private threads.
+ * @property ?Carbon|null $create_timestamp      Timestamp when the thread was created (ISO8601); only populated for threads created after 2022-01-09.
+ */
+class ThreadMetadata extends Part
+{
+    /**
+     * @inheritDoc
+     */
+    protected $fillable = [
+        'archived',
+        'auto_archive_duration',
+        'archive_timestamp',
+        'locked',
+        'invitable',
+        'create_timestamp',
+    ];
+
+    protected function getCreateTimestampAttribute(): ?Carbon
+    {
+        return $this->attributeCarbonHelper('create_timestamp');
+    }
+}

--- a/src/Discord/Parts/Thread/Thread.php
+++ b/src/Discord/Parts/Thread/Thread.php
@@ -17,6 +17,7 @@ use Carbon\Carbon;
 use Discord\Http\Endpoint;
 use Discord\Parts\Channel\Channel;
 use Discord\Parts\Channel\ChannelTrait;
+use Discord\Parts\Channel\ThreadMetadata;
 use Discord\Parts\Part;
 use Discord\Parts\Thread\Member as ThreadMember;
 use Discord\Parts\User\Member;
@@ -33,18 +34,18 @@ use Stringable;
  *
  * @since 7.0.0
  *
- * @property int           $message_count         Number of messages (not including the initial message or deleted messages) in a thread (if the thread was created before July 1, 2022, the message count is inaccurate when it's greater than 50).
- * @property int           $member_count          An approximate count of the number of members in the thread. Stops counting at 50.
- * @property object        $thread_metadata       Thread-specific fields not needed by other channels.
- * @property bool          $archived              Whether the thread has been archived.
- * @property int|null      $auto_archive_duration The number of minutes of inactivity until the thread is automatically archived.
- * @property Carbon        $archive_timestamp     The time that the thread's archive status was changed.
- * @property bool          $locked                Whether the thread has been locked.
- * @property bool|null     $invitable             Whether non-moderators can add other non-moderators to a thread; only available on private threads.
- * @property Carbon|null   $create_timestamp      Timestamp when the thread was created; only populated for threads created after 2022-01-09.
- * @property int|null      $total_message_sent    Number of messages ever sent in a thread, it's similar to `message_count` on message creation, but will not decrement the number when a message is deleted.
- * @property int|null      $flags                 Channel flags combined as a bitfield. PINNED can only be set for threads in forum channels.
- * @property string[]|null $applied_tags          The IDs of the set of tags that have been applied to a thread in a forum channel, limited to 5.
+ * @property int            $message_count         Number of messages (not including the initial message or deleted messages) in a thread (if the thread was created before July 1, 2022, the message count is inaccurate when it's greater than 50).
+ * @property int            $member_count          An approximate count of the number of members in the thread. Stops counting at 50.
+ * @property ThreadMetadata $thread_metadata       Thread-specific fields not needed by other channels.
+ * @property bool           $archived              Whether the thread has been archived.
+ * @property int|null       $auto_archive_duration The number of minutes of inactivity until the thread is automatically archived.
+ * @property Carbon         $archive_timestamp     The time that the thread's archive status was changed.
+ * @property bool           $locked                Whether the thread has been locked.
+ * @property bool|null      $invitable             Whether non-moderators can add other non-moderators to a thread; only available on private threads.
+ * @property Carbon|null    $create_timestamp      Timestamp when the thread was created; only populated for threads created after 2022-01-09.
+ * @property int|null       $total_message_sent    Number of messages ever sent in a thread, it's similar to `message_count` on message creation, but will not decrement the number when a message is deleted.
+ * @property int|null       $flags                 Channel flags combined as a bitfield. PINNED can only be set for threads in forum channels.
+ * @property string[]|null  $applied_tags          The IDs of the set of tags that have been applied to a thread in a forum channel, limited to 5.
  */
 class Thread extends Part implements Stringable
 {
@@ -106,6 +107,18 @@ class Thread extends Part implements Stringable
             $memberPart->created = &$this->created;
             $this->members->pushItem($memberPart);
         }
+    }
+
+    /**
+     * Returns the thread metadata.
+     *
+     * @return ThreadMetadata|null
+     *
+     * @since 10.22.0
+     */
+    protected function getThreadMetadataAttribute(): ?ThreadMetadata
+    {
+        return $this->attributePartHelper('thread_metadata', ThreadMetadata::class);
     }
 
     /**


### PR DESCRIPTION
This pull request enhances the type safety and documentation for thread-related channel properties and introduces a new `ThreadMetadata` part to better represent thread-specific metadata in the DiscordPHP codebase. The main focus is on improving how thread metadata is modeled and accessed, making it more consistent and easier to work with.

**Thread Metadata Improvements:**

* Added a new `ThreadMetadata` class in `src/Discord/Parts/Channel/ThreadMetadata.php` to encapsulate thread-specific metadata fields, with type-safe properties and helper methods.
* Updated the `Thread` part to use the new `ThreadMetadata` type for the `thread_metadata` property, replacing the previous generic object type.
* Added a getter method `getThreadMetadataAttribute()` in `Thread` to retrieve the metadata as a `ThreadMetadata` instance, improving access and type safety.
* Registered the new `ThreadMetadata` import in `Thread.php` to support the updated property and getter.

**Channel Property Documentation Updates:**

* Improved and clarified the documentation for several properties in `Channel.php`, including more accurate descriptions, type hints, and details for forum/media channels and thread-related properties.