### PR TITLE
Message enhancements

### DIFF
--- a/src/Discord/Parts/Channel/Message/Activity.php
+++ b/src/Discord/Parts/Channel/Message/Activity.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is a part of the DiscordPHP project.
+ *
+ * Copyright (c) 2015-present David Cole <david.cole1340@gmail.com>
+ *
+ * This file is subject to the MIT license that is bundled
+ * with this source code in the LICENSE.md file.
+ */
+
+namespace Discord\Parts\Channel\Message;
+
+use Discord\Parts\Part;
+
+/**
+ * Sent with Rich Presence-related chat embeds.
+ *
+ * @link https://discord.com/developers/docs/resources/message#message-object-message-activity-structure
+ *
+ * @since 10.22.0
+ *
+ * @property int         $type     Type of message activity
+ * @property string|null $party_id Party ID from a Rich Presence event
+ */
+class Activity extends Part
+{
+    public const TYPE_JOIN = 1;
+    public const TYPE_SPECTATE = 2;
+    public const TYPE_LISTEN = 3;
+    public const TYPE_JOIN_REQUEST = 5;
+
+    /**
+     * @inheritDoc
+     */
+    protected $fillable = [
+        'type',
+        'party_id',
+    ];
+}

--- a/src/Discord/Parts/Channel/Message/MessageSnapshot.php
+++ b/src/Discord/Parts/Channel/Message/MessageSnapshot.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is a part of the DiscordPHP project.
+ *
+ * Copyright (c) 2015-present David Cole <david.cole1340@gmail.com>
+ *
+ * This file is subject to the MIT license that is bundled
+ * with this source code in the LICENSE.md file.
+ */
+
+namespace Discord\Parts\Channel\Message;
+
+use Discord\Parts\Channel\Message;
+use Discord\Parts\Part;
+
+/**
+ * The message associated with the message_reference. This is a minimal subset of fields in a message (e.g. author is excluded.).
+ *
+ * The current subset of message fields consists of: type, content, embeds, attachments, timestamp, edited_timestamp, flags, mentions, mention_roles, stickers, sticker_items, and components.
+ *
+ * @link https://discord.com/developers/docs/resources/message#message-snapshot-object
+ *
+ * @since 10.22.0
+ *
+ * @property Message $message Minimal subset of fields in the forwarded message (partial).
+ */
+class MessageSnapshot extends Part
+{
+    /**
+     * @inheritDoc
+     */
+    protected $fillable = [
+        'message',
+    ];
+
+    /**
+     * Returns the message associated with the message_reference.
+     *
+     * @return ?Message
+     */
+    protected function getMessageAttribute(): ?Message
+    {
+        return $this->attributePartHelper('message', Message::class);
+    }
+}

--- a/src/Discord/Parts/Channel/Message/RoleSubscriptionData.php
+++ b/src/Discord/Parts/Channel/Message/RoleSubscriptionData.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is a part of the DiscordPHP project.
+ *
+ * Copyright (c) 2015-present David Cole <david.cole1340@gmail.com>
+ *
+ * This file is subject to the MIT license that is bundled
+ * with this source code in the LICENSE.md file.
+ */
+
+namespace Discord\Parts\Channel\Message;
+
+use Discord\Parts\Part;
+
+/**
+ * Data of the role subscription purchase or renewal that prompted this ROLE_SUBSCRIPTION_PURCHASE message.
+ *
+ * @link https://discord.com/developers/docs/resources/message#role-subscription-data-object
+ *
+ * @since 10.22.0
+ *
+ * @property string $role_subscription_listing_id The id of the sku and listing that the user is subscribed to.
+ * @property string $tier_name                    The name of the tier that the user is subscribed to.
+ * @property int    $total_months_subscribed      The cumulative number of months that the user has been subscribed for.
+ * @property bool   $is_renewal                   Whether this notification is for a renewal rather than a new purchase.
+ */
+class RoleSubscriptionData extends Part
+{
+    /**
+     * @inheritDoc
+     */
+    protected $fillable = [
+        'role_subscription_listing_id',
+        'tier_name',
+        'total_months_subscribed',
+        'is_renewal',
+    ];
+}


### PR DESCRIPTION
This pull request enhances the `Message` class in DiscordPHP by introducing new strongly-typed parts for message activities, message snapshots, and role subscription data. It replaces several generic object types with dedicated classes, improving type safety and code clarity. Additionally, new property accessors and supporting files have been added for these features.

**New message-related parts:**

* Added the `Activity` class for rich presence-related chat embeds, with corresponding property and accessor in `Message` (`src/Discord/Parts/Channel/Message/Activity.php`, [[1]](diffhunk://#diff-ab65edfa60b2c118027b79a99025693cf14dc34c52b2e7c9d9eb7bbbdb9d6383R1-R42); `getActivityAttribute`, [[2]](diffhunk://#diff-3bc0952a87e08969969124672b2539443f4afa2fa67b5fdcddd94944c88eb1ddR636-R651).
* Added the `MessageSnapshot` class to represent a minimal subset of forwarded messages, with support for both single and multiple snapshots in `Message` (`src/Discord/Parts/Channel/Message/MessageSnapshot.php`, [[1]](diffhunk://#diff-b460bb1ce6b6691b247a9a826ec4e059c4352966b2f6d893ca1590cc2b6c6139R1-R48); `getMessageSnapshotsAttribute`, [[2]](diffhunk://#diff-3bc0952a87e08969969124672b2539443f4afa2fa67b5fdcddd94944c88eb1ddR744-R754).

**Role subscription support:**

* Introduced the `RoleSubscriptionData` class and a strongly-typed property in `Message` for role subscription purchase/renewal data (`src/Discord/Parts/Channel/Message/RoleSubscriptionData.php`, [[1]](diffhunk://#diff-54266b930dbf2d945221b66a07f9ce30de8125ccd4e1d0beefa7b61d984c1ec9R1-R41); `getRoleSubscriptionDataAttribute`, [[2]](diffhunk://#diff-3bc0952a87e08969969124672b2539443f4afa2fa67b5fdcddd94944c88eb1ddR809-R818).

**Type safety and documentation improvements:**

* Updated property docblocks in `Message` to use typed collections and new part classes, replacing generic objects with specific types for properties such as `activity`, `application`, `message_snapshot(s)`, `role_subscription_data`, and others.
* Added missing `ReactionRepository` property to the docblock for improved documentation accuracy.

**Housekeeping and constants:**

* Moved activity type constants from `Message` to the new `Activity` class for better organization [[1]](diffhunk://#diff-3bc0952a87e08969969124672b2539443f4afa2fa67b5fdcddd94944c88eb1ddL180-L184) [[2]](diffhunk://#diff-ab65edfa60b2c118027b79a99025693cf14dc34c52b2e7c9d9eb7bbbdb9d6383R1-R42).