### PR TITLE
Attribute part helper implementation

### DIFF
--- a/src/Discord/Builders/CommandAttributes.php
+++ b/src/Discord/Builders/CommandAttributes.php
@@ -30,20 +30,20 @@ use function Discord\poly_strlen;
  *
  * @since 7.1.0
  *
- * @property int                            $type                       The type of the command, defaults 1 if not set.
- * @property string                         $name                       1-32 character name of the command.
- * @property ?string[]|null                 $name_localizations         Localization dictionary for the name field. Values follow the same restrictions as name.
- * @property ?string                        $description                1-100 character description for CHAT_INPUT commands, empty string for USER and MESSAGE commands.
- * @property ?string[]|null                 $description_localizations  Localization dictionary for the description field. Values follow the same restrictions as description.
- * @property ExCollectionInterface|Option[] $options                    The parameters for the command, max 25. Only for Slash command (CHAT_INPUT).
- * @property ?string                        $default_member_permissions Set of permissions represented as a bit set.
- * @property bool|null                      $dm_permission              Deprecated (use contexts instead); Indicates whether the command is available in DMs with the app, only for globally-scoped commands. By default, commands are visible.
- * @property ?bool                          $default_permission         Whether the command is enabled by default when the app is added to a guild, defaults to true. SOON DEPRECATED.
- * @property ?int                           $guild_id                   The optional guild ID this command is for. If not set, the command is global.
- * @property bool|null                      $nsfw                       Indicates whether the command is age-restricted, defaults to `false`.
- * @property array                          $integration_types          Installation contexts where the command is available, only for globally-scoped commands. Defaults to your app's configured contexts
- * @property ExCollectionInterface|null     $contexts                   Interaction context(s) where the command can be used, only for globally-scoped commands.
- * @property int|null                       $handler                    Determines whether the interaction is handled by the app's interactions handler or by Discord
+ * @property int                                    $type                       The type of the command, defaults 1 if not set.
+ * @property string                                 $name                       1-32 character name of the command.
+ * @property ?string[]|null                         $name_localizations         Localization dictionary for the name field. Values follow the same restrictions as name.
+ * @property ?string                                $description                1-100 character description for CHAT_INPUT commands, empty string for USER and MESSAGE commands.
+ * @property ?string[]|null                         $description_localizations  Localization dictionary for the description field. Values follow the same restrictions as description.
+ * @property ExCollectionInterface<Option>|Option[] $options                    The parameters for the command, max 25. Only for Slash command (CHAT_INPUT).
+ * @property ?string                                $default_member_permissions Set of permissions represented as a bit set.
+ * @property bool|null                              $dm_permission              Deprecated (use contexts instead); Indicates whether the command is available in DMs with the app, only for globally-scoped commands. By default, commands are visible.
+ * @property ?bool                                  $default_permission         Whether the command is enabled by default when the app is added to a guild, defaults to true. SOON DEPRECATED.
+ * @property ?int                                   $guild_id                   The optional guild ID this command is for. If not set, the command is global.
+ * @property bool|null                              $nsfw                       Indicates whether the command is age-restricted, defaults to `false`.
+ * @property array                                  $integration_types          Installation contexts where the command is available, only for globally-scoped commands. Defaults to your app's configured contexts
+ * @property ExCollectionInterface|null             $contexts                   Interaction context(s) where the command can be used, only for globally-scoped commands.
+ * @property int|null                               $handler                    Determines whether the interaction is handled by the app's interactions handler or by Discord
  */
 trait CommandAttributes
 {

--- a/src/Discord/Builders/CommandBuilder.php
+++ b/src/Discord/Builders/CommandBuilder.php
@@ -68,14 +68,14 @@ class CommandBuilder extends Builder implements JsonSerializable
     /**
      * Interaction context(s) where the command can be used, only for globally-scoped commands.
      *
-     * @var Int[]|null
+     * @var int[]|null
      */
     protected $integration_types = null;
 
     /**
      * Interaction context(s) where the command can be used, only for globally-scoped commands.
      *
-     * @var ExCollectionInterface|Int[]|null
+     * @var ExCollectionInterface<int>|int[]|null
      */
     protected $contexts = null;
 

--- a/src/Discord/Discord.php
+++ b/src/Discord/Discord.php
@@ -107,7 +107,7 @@ class Discord
      *
      * @var string Version.
      */
-    public const VERSION = 'v10.24.0';
+    public const VERSION = 'v10.29.6';
 
     public const REFERRER = 'https://github.com/discord-php/DiscordPHP';
 

--- a/src/Discord/Helpers/RegisteredCommand.php
+++ b/src/Discord/Helpers/RegisteredCommand.php
@@ -85,8 +85,8 @@ class RegisteredCommand
      * Executes the command. Will search for a sub-command if given, otherwise
      * executes the callback, if given.
      *
-     * @param ExCollectionInterface|Option[] $options
-     * @param Interaction                    $interaction
+     * @param ExCollectionInterface<Option>|Option[] $options
+     * @param Interaction                            $interaction
      *
      * @return bool Whether the command successfully executed.
      */

--- a/src/Discord/Parts/Channel/Channel.php
+++ b/src/Discord/Parts/Channel/Channel.php
@@ -51,27 +51,27 @@ use function React\Promise\resolve;
  * @since 2.0.0 Refactored as Part
  * @since 1.0.0
  *
- * @property      int|null                     $position                           Sorting position of the channel.
- * @property      array                        $permission_overwrites              Explicit permission overwrites for members and roles.
- * @property      ?string|null                 $topic                              The topic of the channel (0-4096 characters for forum/media, 0-1024 for others).
- * @property      bool|null                    $nsfw                               Whether the channel is NSFW.
- * @property      int|null                     $bitrate                            The bitrate (in bits) of the voice or stage channel; min 8000.
- * @property      int|null                     $user_limit                         The user limit of the voice or stage channel, max 99 for voice channels and 10,000 for stage channels (0 refers to no limit).
- * @property      ExCollectionInterface|User[] $recipients                         The recipients of the DM.
- * @property-read User|null                    $recipient                          The first recipient of the DM (DM/group).
- * @property-read string|null                  $recipient_id                       The ID of the recipient (DM).
- * @property      ?string|null                 $icon                               Icon hash of the group DM.
- * @property      string|null                  $application_id                     Application id of the group DM creator if bot-created.
- * @property      bool|null                    $managed                            For group DM channels: whether the channel is managed by an application via the `gdm.join` OAuth2 scope.
- * @property      ?string|null                 $rtc_region                         Voice region id for the voice channel, automatic when set to null.
- * @property      ?int|null                    $video_quality_mode                 The camera video quality mode of the voice channel, 1 when not present.
- * @property      ?int|null                    $default_auto_archive_duration      Default duration for newly created threads, in minutes.
- * @property      int|null                     $flags                              Channel flags combined as a bitfield.
- * @property      ExCollectionInterface|Tag[]  $available_tags                     The set of tags that can be used in a `GUILD_FORUM` or a `GUILD_MEDIA` channel. Limited to 20.
- * @property      ?Reaction|null               $default_reaction_emoji             The emoji to show in the add reaction button on a thread in a `GUILD_FORUM` or a `GUILD_MEDIA` channel.
- * @property      int|null                     $default_thread_rate_limit_per_user The initial `rate_limit_per_user` to set on newly created threads in a channel. This field is copied to the thread at creation time and does not live update.
- * @property      ?int|null                    $default_sort_order                 The default sort order type used to order posts in `GUILD_FORUM` and `GUILD_MEDIA` channels. Defaults to `null`, which indicates a preferred sort order hasn't been set by a channel admin.
- * @property      int|null                     $default_forum_layout               The default forum layout view used to display posts in `GUILD_FORUM` channels. Defaults to `0`, which indicates a layout view has not been set by a channel admin.
+ * @property      int|null                           $position                           Sorting position of the channel.
+ * @property      array                              $permission_overwrites              Explicit permission overwrites for members and roles.
+ * @property      ?string|null                       $topic                              The topic of the channel (0-4096 characters for forum/media, 0-1024 for others).
+ * @property      bool|null                          $nsfw                               Whether the channel is NSFW.
+ * @property      int|null                           $bitrate                            The bitrate (in bits) of the voice or stage channel; min 8000.
+ * @property      int|null                           $user_limit                         The user limit of the voice or stage channel, max 99 for voice channels and 10,000 for stage channels (0 refers to no limit).
+ * @property      ExCollectionInterface<User>|User[] $recipients                         The recipients of the DM.
+ * @property-read User|null                          $recipient                          The first recipient of the DM (DM/group).
+ * @property-read string|null                        $recipient_id                       The ID of the recipient (DM).
+ * @property      ?string|null                       $icon                               Icon hash of the group DM.
+ * @property      string|null                        $application_id                     Application id of the group DM creator if bot-created.
+ * @property      bool|null                          $managed                            For group DM channels: whether the channel is managed by an application via the `gdm.join` OAuth2 scope.
+ * @property      ?string|null                       $rtc_region                         Voice region id for the voice channel, automatic when set to null.
+ * @property      ?int|null                          $video_quality_mode                 The camera video quality mode of the voice channel, 1 when not present.
+ * @property      ?int|null                          $default_auto_archive_duration      Default duration for newly created threads, in minutes.
+ * @property      int|null                           $flags                              Channel flags combined as a bitfield.
+ * @property      ExCollectionInterface<Tag>|Tag[]   $available_tags                     The set of tags that can be used in a `GUILD_FORUM` or a `GUILD_MEDIA` channel. Limited to 20.
+ * @property      ?Reaction|null                     $default_reaction_emoji             The emoji to show in the add reaction button on a thread in a `GUILD_FORUM` or a `GUILD_MEDIA` channel.
+ * @property      int|null                           $default_thread_rate_limit_per_user The initial `rate_limit_per_user` to set on newly created threads in a channel. This field is copied to the thread at creation time and does not live update.
+ * @property      ?int|null                          $default_sort_order                 The default sort order type used to order posts in `GUILD_FORUM` and `GUILD_MEDIA` channels. Defaults to `null`, which indicates a preferred sort order hasn't been set by a channel admin.
+ * @property      int|null                           $default_forum_layout               The default forum layout view used to display posts in `GUILD_FORUM` channels. Defaults to `0`, which indicates a layout view has not been set by a channel admin.
  *
  * @property OverwriteRepository     $overwrites      Permission overwrites.
  * @property WebhookRepository       $webhooks        Webhooks in the channel.
@@ -769,7 +769,7 @@ class Channel extends Part implements Stringable
     /**
      * Gets the available tags attribute.
      *
-     * @return ExCollectionInterface|Tag[] Available forum tags.
+     * @return ExCollectionInterface<Tag>|Tag[] Available forum tags.
      *
      * @since 7.4.0
      */

--- a/src/Discord/Parts/Channel/Invite.php
+++ b/src/Discord/Parts/Channel/Invite.php
@@ -261,7 +261,7 @@ class Invite extends Part implements Stringable
             }
         }
 
-        return $this->factory->part(ScheduledEvent::class, (array) $this->attributes['guild_scheduled_event'], true);
+        return $this->attributePartHelper('guild_scheduled_event', ScheduledEvent::class);
     }
 
     /**

--- a/src/Discord/Parts/Channel/Message.php
+++ b/src/Discord/Parts/Channel/Message.php
@@ -379,7 +379,7 @@ class Message extends Part
     /**
      * Gets the mention_channels attribute.
      *
-     * @return ExCollectionInterface|Channel[]
+     * @return ExCollectionInterface<Channel>|Channel[]
      */
     protected function getMentionChannelsAttribute(): ExCollectionInterface
     {
@@ -403,7 +403,7 @@ class Message extends Part
     /**
      * Returns any attached files.
      *
-     * @return ExCollectionInterface|Attachment[] Attachment objects.
+     * @return ExCollectionInterface<Attachment>|Attachment[] Attachment objects.
      */
     protected function getAttachmentsAttribute(): ExCollectionInterface
     {
@@ -553,7 +553,7 @@ class Message extends Part
     /**
      * Returns the mention attribute.
      *
-     * @return ExCollectionInterface|User[] The users that were mentioned.
+     * @return ExCollectionInterface<User>|User[] The users that were mentioned.
      */
     protected function getMentionsAttribute(): ExCollectionInterface
     {
@@ -797,7 +797,7 @@ class Message extends Part
     /**
      * Returns the sticker_items attribute.
      *
-     * @return ExCollectionInterface|Sticker[] Partial stickers.
+     * @return ExCollectionInterface<Sticker>|Sticker[] Partial stickers.
      */
     protected function getStickerItemsAttribute(): ExCollectionInterface
     {

--- a/src/Discord/Parts/Channel/Message.php
+++ b/src/Discord/Parts/Channel/Message.php
@@ -591,7 +591,7 @@ class Message extends Part
             return $user;
         }
 
-        return $this->factory->part(User::class, (array) $this->attributes['author'], true);
+        return $this->attributePartHelper('author', User::class);
     }
 
     /**
@@ -701,11 +701,7 @@ class Message extends Part
             }
         }
 
-        if (isset($this->attributes['referenced_message'])) {
-            return $this->factory->part(Message::class, (array) $this->attributes['referenced_message'], true);
-        }
-
-        return null;
+        return $this->attributePartHelper('referenced_message', Message::class);
     }
 
     protected function getMessageReferenceAttribute(): ?MessageReference
@@ -718,6 +714,8 @@ class Message extends Part
      * For forwarded messages, this contains a snapshot of the original message.
      *
      * @return Message|null
+     *
+     * @deprecated Use `getMessageSnapshotsAttribute()`.
      */
     protected function getMessageSnapshotAttribute(): ?Message
     {

--- a/src/Discord/Parts/Channel/Message/ActionRow.php
+++ b/src/Discord/Parts/Channel/Message/ActionRow.php
@@ -28,9 +28,9 @@ namespace Discord\Parts\Channel\Message;
  *
  * @since 10.11.0
  *
- * @property int                               $type       1 for action row component
- * @property string|null                       $id         Optional identifier for component
- * @property ExCollectionInterface|Component[] $components Up to 5 interactive button components or a single select component
+ * @property int                                          $type       1 for action row component
+ * @property string|null                                  $id         Optional identifier for component
+ * @property ExCollectionInterface<Component>|Component[] $components Up to 5 interactive button components or a single select component
  */
 class ActionRow extends Layout
 {

--- a/src/Discord/Parts/Channel/Message/ChannelSelect.php
+++ b/src/Discord/Parts/Channel/Message/ChannelSelect.php
@@ -27,15 +27,15 @@ use Discord\Helpers\ExCollectionInterface;
  *
  * @since 10.11.0
  *
- * @property int                                  $type           8 for channel select.
- * @property string|null                          $id             Optional identifier for component.
- * @property string                               $custom_id      Developer-defined identifier for the select menu; max 100 characters.
- * @property int[]|null                           $channel_types  List of channel types to include in the channel select component.
- * @property string|null                          $placeholder    Placeholder text if nothing is selected; max 150 characters.
- * @property ExCollectionInterface|DefaultValue[] $default_values List of default values for auto-populated select menu components; number of default values must be in the range defined by min_values and max_values.
- * @property int|null                             $min_values     Minimum number of items that must be chosen (defaults to 1); min 0, max 25.
- * @property int|null                             $max_values     Maximum number of items that can be chosen (defaults to 1); max 25.
- * @property bool|null                            $disabled       Whether select menu is disabled (defaults to false).
+ * @property int                                                $type           8 for channel select.
+ * @property string|null                                        $id             Optional identifier for component.
+ * @property string                                             $custom_id      Developer-defined identifier for the select menu; max 100 characters.
+ * @property int[]|null                                         $channel_types  List of channel types to include in the channel select component.
+ * @property string|null                                        $placeholder    Placeholder text if nothing is selected; max 150 characters.
+ * @property ExCollectionInterface<DefaultValue>|DefaultValue[] $default_values List of default values for auto-populated select menu components; number of default values must be in the range defined by min_values and max_values.
+ * @property int|null                                           $min_values     Minimum number of items that must be chosen (defaults to 1); min 0, max 25.
+ * @property int|null                                           $max_values     Maximum number of items that can be chosen (defaults to 1); max 25.
+ * @property bool|null                                          $disabled       Whether select menu is disabled (defaults to false).
  */
 class ChannelSelect extends SelectMenu
 {

--- a/src/Discord/Parts/Channel/Message/Component.php
+++ b/src/Discord/Parts/Channel/Message/Component.php
@@ -69,7 +69,7 @@ class Component extends Part
     ];
 
     /**
-     * Gets the components of the interaction.
+     * Gets the components.
      *
      * @return ExCollectionInterface|Component[] $components
      */
@@ -86,5 +86,13 @@ class Component extends Part
         }
 
         return $components;
+    }
+
+    /**
+     * Gets the component.
+     */
+    public function getComponentAttribute(): ?Component
+    {
+        return $this->attributePartHelper('component', Component::TYPES[$this->attributes['component']->type ?? 0]);
     }
 }

--- a/src/Discord/Parts/Channel/Message/Component.php
+++ b/src/Discord/Parts/Channel/Message/Component.php
@@ -71,7 +71,7 @@ class Component extends Part
     /**
      * Gets the components.
      *
-     * @return ExCollectionInterface|Component[] $components
+     * @return ExCollectionInterface><Component>|Component[] $components
      */
     protected function getComponentsAttribute(): ExCollectionInterface
     {

--- a/src/Discord/Parts/Channel/Message/Container.php
+++ b/src/Discord/Parts/Channel/Message/Container.php
@@ -22,11 +22,11 @@ namespace Discord\Parts\Channel\Message;
  *
  * @since 10.11.0
  *
- * @property int                               $type         17 for container component.
- * @property string|null                       $id           Optional identifier for component.
- * @property ExCollectionInterface|Component[] $components   Components of the type action row, text display, section, media gallery, separator, or file.
- * @property int|null                          $accent_color Color for the accent on the container as RGB from 0x000000 to 0xFFFFFF.
- * @property bool|null                         $spoiler      Whether the container should be a spoiler (or blurred out). Defaults to false.
+ * @property int                                          $type         17 for container component.
+ * @property string|null                                  $id           Optional identifier for component.
+ * @property ExCollectionInterface<Component>|Component[] $components   Components of the type action row, text display, section, media gallery, separator, or file.
+ * @property int|null                                     $accent_color Color for the accent on the container as RGB from 0x000000 to 0xFFFFFF.
+ * @property bool|null                                    $spoiler      Whether the container should be a spoiler (or blurred out). Defaults to false.
  */
 class Container extends Layout
 {

--- a/src/Discord/Parts/Channel/Message/File.php
+++ b/src/Discord/Parts/Channel/Message/File.php
@@ -41,6 +41,6 @@ class File extends Content
 
     protected function getFileAttribute(): UnfurledMediaItem
     {
-        return $this->createOf(UnfurledMediaItem::class, $this->attributes['file'], true);
+        return $this->attributePartHelper('file', UnfurledMediaItem::class, true);
     }
 }

--- a/src/Discord/Parts/Channel/Message/Label.php
+++ b/src/Discord/Parts/Channel/Message/Label.php
@@ -43,6 +43,6 @@ class Label extends Component
 
     public function getComponentAttribute(): Component
     {
-        return $this->createOf(Component::TYPES[$this->attributes['component']->type ?? 0], $this->attributes['component']);
+        return $this->attributePartHelper('component', Component::TYPES[$this->attributes['component']->type ?? 0]);
     }
 }

--- a/src/Discord/Parts/Channel/Message/MediaGallery.php
+++ b/src/Discord/Parts/Channel/Message/MediaGallery.php
@@ -25,9 +25,9 @@ use Discord\Helpers\ExCollectionInterface;
  *
  * @since 10.11.0
  *
- * @property int                                      $type  12 for media gallery component.
- * @property string|null                              $id    Optional identifier for component.
- * @property ExCollectionInterface|MediaGalleryItem[] $items 1 to 10 media gallery items.
+ * @property int                                                        $type  12 for media gallery component.
+ * @property string|null                                                $id    Optional identifier for component.
+ * @property ExCollectionInterface<MediaGalleryItem>|MediaGalleryItem[] $items 1 to 10 media gallery items.
  */
 class MediaGallery extends Content
 {
@@ -40,7 +40,7 @@ class MediaGallery extends Content
         'items',
     ];
 
-    /** @return ExCollectionInterface|MediaGalleryItem[] */
+    /** @return ExCollectionInterface<MediaGalleryItem>|MediaGalleryItem[] */
     protected function getItemsAttribute(): ExCollectionInterface
     {
         return $this->attributeCollectionHelper('items', MediaGalleryItem::class);

--- a/src/Discord/Parts/Channel/Message/MediaGalleryItem.php
+++ b/src/Discord/Parts/Channel/Message/MediaGalleryItem.php
@@ -37,6 +37,6 @@ class MediaGalleryItem extends Part
 
     protected function getMediaAttribute(): UnfurledMediaItem
     {
-        return $this->createOf(UnfurledMediaItem::class, $this->attributes['media'], true);
+        return $this->attributePartHelper('media', UnfurledMediaItem::class);
     }
 }

--- a/src/Discord/Parts/Channel/Message/MentionableSelect.php
+++ b/src/Discord/Parts/Channel/Message/MentionableSelect.php
@@ -24,14 +24,14 @@ namespace Discord\Parts\Channel\Message;
  *
  * @since 10.11.0
  *
- * @property int                                  $type           7 for mentionable select.
- * @property string|null                          $id             Optional identifier for component.
- * @property string                               $custom_id      ID for the select menu; max 100 characters
- * @property string|null                          $placeholder    Placeholder text if nothing is selected; max 150 characters.
- * @property ExCollectionInterface|DefaultValue[] $default_values List of default values for auto-populated select menu components; number of default values must be in the range defined by min_values and max_values
- * @property int|null                             $min_values     Minimum number of items that must be chosen (defaults to 1); min 0, max 25.
- * @property int|null                             $max_values     Maximum number of items that can be chosen (defaults to 1); max 25.
- * @property bool|null                            $disabled       Whether select menu is disabled (defaults to false).
+ * @property int                                                $type           7 for mentionable select.
+ * @property string|null                                        $id             Optional identifier for component.
+ * @property string                                             $custom_id      ID for the select menu; max 100 characters
+ * @property string|null                                        $placeholder    Placeholder text if nothing is selected; max 150 characters.
+ * @property ExCollectionInterface<DefaultValue>|DefaultValue[] $default_values List of default values for auto-populated select menu components; number of default values must be in the range defined by min_values and max_values
+ * @property int|null                                           $min_values     Minimum number of items that must be chosen (defaults to 1); min 0, max 25.
+ * @property int|null                                           $max_values     Maximum number of items that can be chosen (defaults to 1); max 25.
+ * @property bool|null                                          $disabled       Whether select menu is disabled (defaults to false).
  */
 class MentionableSelect extends SelectMenu
 {

--- a/src/Discord/Parts/Channel/Message/MessageCall.php
+++ b/src/Discord/Parts/Channel/Message/MessageCall.php
@@ -14,6 +14,8 @@ declare(strict_types=1);
 namespace Discord\Parts\Channel\Message;
 
 use Carbon\Carbon;
+use Discord\Helpers\Collection;
+use Discord\Helpers\ExCollectionInterface;
 use Discord\Parts\Part;
 use Discord\Parts\User\User;
 
@@ -27,7 +29,7 @@ use Discord\Parts\User\User;
  * @property array        $participants    Array of user object IDs that participated in the call.
  * @property ?Carbon|null $ended_timestamp Time when the call ended (ISO8601 timestamp), or null if ongoing.
  *
- * @property-read User[] $users Array of user objects that participated in the call.
+ * @property-read ExCollectionInterface<User>|User[] $users Array of user objects that participated in the call.
  */
 class MessageCall extends Part
 {
@@ -52,13 +54,13 @@ class MessageCall extends Part
     /**
      * Gets the users.
      *
-     * @return User[]
+     * @return ExCollectionInterface<User>|User[]
      */
-    protected function getUsersAttribute(): array
+    protected function getUsersAttribute(): ExCollectionInterface
     {
-        return array_map(
+        return Collection::for(User::class)->push(array_map(
             fn ($userData) => $this->discord->users->get('id', $userData) ?? $this->factory->part(User::class, ['id' => $userData], true),
             $this->attributes['participants']
-        );
+        ));
     }
 }

--- a/src/Discord/Parts/Channel/Message/MessageInteractionMetadata.php
+++ b/src/Discord/Parts/Channel/Message/MessageInteractionMetadata.php
@@ -80,7 +80,7 @@ class MessageInteractionMetadata extends Part
      */
     protected function getUserAttribute(): User
     {
-        return $this->factory->part(User::class, (array) $this->attributes['user'], true);
+        return $this->attributePartHelper('user', User::class);
     }
 
     /**

--- a/src/Discord/Parts/Channel/Message/MessagePin.php
+++ b/src/Discord/Parts/Channel/Message/MessagePin.php
@@ -44,6 +44,6 @@ class MessagePin extends Part
 
     protected function getMessageAttribute(): Message
     {
-        return $this->factory->create(Message::class, $this->attributes['message'], true);
+        return $this->attributePartHelper('message', Message::class);
     }
 }

--- a/src/Discord/Parts/Channel/Message/MessagePinData.php
+++ b/src/Discord/Parts/Channel/Message/MessagePinData.php
@@ -24,8 +24,8 @@ use Discord\Parts\Part;
  *
  * @since 10.19.0
  *
- * @property ExCollectionInterface|MessagePin[] $items
- * @property bool                               $has_more
+ * @property ExCollectionInterface<MessagePin>|MessagePin[] $items
+ * @property bool                                           $has_more
  */
 class MessagePinData extends Part
 {

--- a/src/Discord/Parts/Channel/Message/RoleSelect.php
+++ b/src/Discord/Parts/Channel/Message/RoleSelect.php
@@ -24,14 +24,14 @@ namespace Discord\Parts\Channel\Message;
  *
  * @since 10.11.0
  *
- * @property int                                  $type           6 for role select.
- * @property string|null                          $id             Optional identifier for component.
- * @property string                               $custom_id      ID for the select menu; max 100 characters
- * @property string|null                          $placeholder    Placeholder text if nothing is selected; max 150 characters.
- * @property ExCollectionInterface|DefaultValue[] $default_values List of default values for auto-populated select menu components; number of default values must be in the range defined by min_values and max_values
- * @property int|null                             $min_values     Minimum number of items that must be chosen (defaults to 1); min 0, max 25.
- * @property int|null                             $max_values     Maximum number of items that can be chosen (defaults to 1); max 25.
- * @property bool|null                            $disabled       Whether select menu is disabled (defaults to false).
+ * @property int                                                $type           6 for role select.
+ * @property string|null                                        $id             Optional identifier for component.
+ * @property string                                             $custom_id      ID for the select menu; max 100 characters
+ * @property string|null                                        $placeholder    Placeholder text if nothing is selected; max 150 characters.
+ * @property ExCollectionInterface<DefaultValue>|DefaultValue[] $default_values List of default values for auto-populated select menu components; number of default values must be in the range defined by min_values and max_values
+ * @property int|null                                           $min_values     Minimum number of items that must be chosen (defaults to 1); min 0, max 25.
+ * @property int|null                                           $max_values     Maximum number of items that can be chosen (defaults to 1); max 25.
+ * @property bool|null                                          $disabled       Whether select menu is disabled (defaults to false).
  */
 class RoleSelect extends SelectMenu
 {

--- a/src/Discord/Parts/Channel/Message/Section.php
+++ b/src/Discord/Parts/Channel/Message/Section.php
@@ -22,10 +22,10 @@ namespace Discord\Parts\Channel\Message;
  *
  * @since 10.11.0
  *
- * @property int                                 $type       9 for section component.
- * @property int|null                            $id         Optional identifier for component.
- * @property ExCollectionInterface|TextDisplay[] $components One to three text components.
- * @property Thumbnail|Button                    $accessory  A thumbnail or a button component, with a future possibility of adding more compatible components.
+ * @property int                                              $type       9 for section component.
+ * @property int|null                                         $id         Optional identifier for component.
+ * @property ExCollectionInterface<TextDisplay>|TextDisplay[] $components One to three text components.
+ * @property Thumbnail|Button                                 $accessory  A thumbnail or a button component, with a future possibility of adding more compatible components.
  */
 class Section extends Layout
 {

--- a/src/Discord/Parts/Channel/Message/Section.php
+++ b/src/Discord/Parts/Channel/Message/Section.php
@@ -42,6 +42,6 @@ class Section extends Layout
     /** @return Thumbnail|Button */
     protected function getAccessoryAttribute(): Component
     {
-        return $this->createOf(Component::TYPES[$this->attributes['accessory']['type'] ?? 0], $this->attributes['accessory']);
+        return $this->attributePartHelper('accessory', Component::TYPES[$this->attributes['accessory']['type'] ?? 0]);
     }
 }

--- a/src/Discord/Parts/Channel/Message/StringSelect.php
+++ b/src/Discord/Parts/Channel/Message/StringSelect.php
@@ -26,14 +26,14 @@ use Discord\Helpers\ExCollectionInterface;
  *
  * @since 10.11.0
  *
- * @property int                                        $type        3 for string select.
- * @property string|null                                $id          Optional identifier for component.
- * @property string                                     $custom_id   ID for the select menu; max 100 characters
- * @property ExCollectionInterface|StringSelectOption[] $options     Specified choices in a select menu; max 25.
- * @property string|null                                $placeholder Placeholder text if nothing is selected or default; max 150 characters
- * @property int|null                                   $min_values  Minimum number of items that must be chosen (defaults to 1); min 0, max 25.
- * @property int|null                                   $max_values  Maximum number of items that can be chosen (defaults to 1); max 25.
- * @property bool|null                                  $disabled    Whether select menu is disabled (defaults to false).
+ * @property int                                                            $type        3 for string select.
+ * @property string|null                                                    $id          Optional identifier for component.
+ * @property string                                                         $custom_id   ID for the select menu; max 100 characters
+ * @property ExCollectionInterface<StringSelectOption>|StringSelectOption[] $options     Specified choices in a select menu; max 25.
+ * @property string|null                                                    $placeholder Placeholder text if nothing is selected or default; max 150 characters
+ * @property int|null                                                       $min_values  Minimum number of items that must be chosen (defaults to 1); min 0, max 25.
+ * @property int|null                                                       $max_values  Maximum number of items that can be chosen (defaults to 1); max 25.
+ * @property bool|null                                                      $disabled    Whether select menu is disabled (defaults to false).
  */
 class StringSelect extends SelectMenu
 {
@@ -54,7 +54,7 @@ class StringSelect extends SelectMenu
     /**
      * Gets the partial options attribute.
      *
-     * @return ExCollectionInterface|StringSelectOption[]
+     * @return ExCollectionInterface<StringSelectOption>|StringSelectOption[]
      */
     protected function getOptionsAttribute(): ExCollectionInterface
     {

--- a/src/Discord/Parts/Channel/Message/StringSelectOption.php
+++ b/src/Discord/Parts/Channel/Message/StringSelectOption.php
@@ -44,6 +44,6 @@ class StringSelectOption extends Part
 
     protected function getEmojiAttribute(): Emoji
     {
-        return $this->createOf(Emoji::class, $this->attributes['emoji'], true);
+        return $this->attributePartHelper('emoji', Emoji::class);
     }
 }

--- a/src/Discord/Parts/Channel/Message/Thumbnail.php
+++ b/src/Discord/Parts/Channel/Message/Thumbnail.php
@@ -43,6 +43,6 @@ class Thumbnail extends Content
 
     protected function getMediaAttribute(): UnfurledMediaItem
     {
-        return $this->createOf(UnfurledMediaItem::class, $this->attributes['media'], true);
+        return $this->attributePartHelper('media', UnfurledMediaItem::class);
     }
 }

--- a/src/Discord/Parts/Channel/Message/UserSelect.php
+++ b/src/Discord/Parts/Channel/Message/UserSelect.php
@@ -26,14 +26,14 @@ use Discord\Helpers\ExCollectionInterface;
  *
  * @since 10.11.0
  *
- * @property int                                  $type           5 for user select.
- * @property string|null                          $id             Optional identifier for component.
- * @property string                               $custom_id      ID for the select menu; max 100 characters
- * @property string|null                          $placeholder    Placeholder text if nothing is selected; max 150 characters.
- * @property ExCollectionInterface|DefaultValue[] $default_values List of default values for auto-populated select menu components; number of default values must be in the range defined by min_values and max_values
- * @property int|null                             $min_values     Minimum number of items that must be chosen (defaults to 1); min 0, max 25.
- * @property int|null                             $max_values     Maximum number of items that can be chosen (defaults to 1); max 25.
- * @property bool|null                            $disabled       Whether select menu is disabled (defaults to false).
+ * @property int                                                $type           5 for user select.
+ * @property string|null                                        $id             Optional identifier for component.
+ * @property string                                             $custom_id      ID for the select menu; max 100 characters
+ * @property string|null                                        $placeholder    Placeholder text if nothing is selected; max 150 characters.
+ * @property ExCollectionInterface<DefaultValue>|DefaultValue[] $default_values List of default values for auto-populated select menu components; number of default values must be in the range defined by min_values and max_values
+ * @property int|null                                           $min_values     Minimum number of items that must be chosen (defaults to 1); min 0, max 25.
+ * @property int|null                                           $max_values     Maximum number of items that can be chosen (defaults to 1); max 25.
+ * @property bool|null                                          $disabled       Whether select menu is disabled (defaults to false).
  */
 class UserSelect extends SelectMenu
 {

--- a/src/Discord/Parts/Channel/Overwrite.php
+++ b/src/Discord/Parts/Channel/Overwrite.php
@@ -63,6 +63,16 @@ class Overwrite extends Part
     }
 
     /**
+     * Gets the allow attribute of the role.
+     *
+     * @return ChannelPermission
+     */
+    protected function getAllowAttribute(): ChannelPermission
+    {
+        return $this->attributePartHelper('allow', ChannelPermission::class);
+    }
+
+    /**
      * Sets the deny attribute of the role.
      *
      * @param ChannelPermission|int $deny
@@ -74,6 +84,16 @@ class Overwrite extends Part
         }
 
         $this->attributes['deny'] = $deny;
+    }
+
+    /**
+     * Gets the deny attribute of the role.
+     *
+     * @return ChannelPermission
+     */
+    protected function getDenyAttribute(): ChannelPermission
+    {
+        return $this->attributePartHelper('deny', ChannelPermission::class);
     }
 
     /**

--- a/src/Discord/Parts/Channel/Poll.php
+++ b/src/Discord/Parts/Channel/Poll.php
@@ -73,7 +73,7 @@ class Poll extends Part
      */
     protected function getQuestionAttribute(): PollMedia
     {
-        return $this->factory->part(PollMedia::class, (array) $this->attributes['question'], true);
+        return $this->attributePartHelper('question', PollMedia::class);
     }
 
     /**

--- a/src/Discord/Parts/Channel/Poll/PollAnswer.php
+++ b/src/Discord/Parts/Channel/Poll/PollAnswer.php
@@ -142,7 +142,7 @@ class PollAnswer extends Part
      *
      * @throws \OutOfRangeException
      *
-     * @return PromiseInterface<Collection|User[]>
+     * @return PromiseInterface<ExCollectionInterface<User>|User[]>
      */
     public function getVoters(array $options = []): PromiseInterface
     {

--- a/src/Discord/Parts/Channel/Poll/PollResults.php
+++ b/src/Discord/Parts/Channel/Poll/PollResults.php
@@ -24,8 +24,8 @@ use Discord\Parts\Part;
  *
  * @since 10.0.0
  *
- * @property bool                                    $is_finalized  Whether the votes have been precisely counted
- * @property ExCollectionInterface|PollAnswerCount[] $answer_counts The counts for each answer
+ * @property bool                                                     $is_finalized  Whether the votes have been precisely counted
+ * @property ExCollectionInterface<PollAnswerCount>|PollAnswerCount[] $answer_counts The counts for each answer
  */
 class PollResults extends Part
 {

--- a/src/Discord/Parts/Channel/Reaction.php
+++ b/src/Discord/Parts/Channel/Reaction.php
@@ -142,7 +142,7 @@ class Reaction extends Part
      *
      * @link https://discord.com/developers/docs/resources/channel#get-reactions
      *
-     * @return PromiseInterface<Collection|User[]>
+     * @return PromiseInterface<ExCollectionInterface<User>|User[]>
      */
     public function getUsers(array $options = []): PromiseInterface
     {
@@ -185,7 +185,7 @@ class Reaction extends Part
      *
      * @see Message::getUsers()
      *
-     * @return PromiseInterface<Collection|User[]>
+     * @return PromiseInterface<ExCollectionInterface<User>|User[]>
      */
     public function getAllUsers(): PromiseInterface
     {

--- a/src/Discord/Parts/Channel/Webhook.php
+++ b/src/Discord/Parts/Channel/Webhook.php
@@ -299,7 +299,7 @@ class Webhook extends Part
             return $user;
         }
 
-        return $this->factory->part(User::class, (array) $this->attributes['user'], true);
+        return $this->attributePartHelper('user', User::class);
     }
 
     /**

--- a/src/Discord/Parts/Embed/EmbedPollResult.php
+++ b/src/Discord/Parts/Embed/EmbedPollResult.php
@@ -17,28 +17,28 @@ use Discord\Helpers\Collection;
 use Discord\Helpers\ExCollectionInterface;
 
 /**
- * @property      ?string|null                  $title                                       The title of the embed.
- * @property-read ?string|null                  $type                                        The type of the embed (always "rich" for webhook embeds).
- * @property      ?string|null                  $description                                 A description of the embed.
- * @property      ?string|null                  $url                                         The URL of the embed.
- * @property      ?Carbon|null                  $timestamp                                   A timestamp of the embed.
- * @property      ?int|null                     $color                                       The color of the embed.
- * @property      ?Footer|null                  $footer                                      The footer of the embed.
- * @property      ?Image|null                   $image                                       The image of the embed.
- * @property      ?Thumbnail|null               $thumbnail                                   The thumbnail of the embed.
- * @property-read ?Video|null                   $video                                       The video of the embed.
- * @property-read ?Provider|null                $provider                                    The provider of the embed.
- * @property      ?Author|null                  $author                                      The author of the embed.
- * @property      ExCollectionInterface|Field[] $fields                                      A collection of embed fields (max of 25).
- * @property-read array                         $poll_fields                                 A collection of poll fields.
- * @property-read string|null                   $poll_fields['poll_question_text']           Question text from the original poll
- * @property-read int|null                      $poll_fields['victor_answer_votes']          Number of votes for the answer(s) with the most votes
- * @property-read int|null                      $poll_fields['total_votes']                  Total number of votes in the poll
- * @property-read ?string|null                  $poll_fields['victor_answer_id']             ID for the winning answer (optional)
- * @property-read ?string|null                  $poll_fields['victor_answer_text']           Text for the winning answer (optional)
- * @property-read ?string|null                  $poll_fields['victor_answer_emoji_id']       ID for an emoji associated with the winning answer (optional)
- * @property-read ?string|null                  $poll_fields['victor_answer_emoji_name']     Name of an emoji associated with the winning answer (optional)
- * @property-read ?bool|null                    $poll_fields['victor_answer_emoji_animated'] If an emoji associated with the winning answer is animated (optional)
+ * @property      ?string|null                         $title                                       The title of the embed.
+ * @property-read ?string|null                         $type                                        The type of the embed (always "rich" for webhook embeds).
+ * @property      ?string|null                         $description                                 A description of the embed.
+ * @property      ?string|null                         $url                                         The URL of the embed.
+ * @property      ?Carbon|null                         $timestamp                                   A timestamp of the embed.
+ * @property      ?int|null                            $color                                       The color of the embed.
+ * @property      ?Footer|null                         $footer                                      The footer of the embed.
+ * @property      ?Image|null                          $image                                       The image of the embed.
+ * @property      ?Thumbnail|null                      $thumbnail                                   The thumbnail of the embed.
+ * @property-read ?Video|null                          $video                                       The video of the embed.
+ * @property-read ?Provider|null                       $provider                                    The provider of the embed.
+ * @property      ?Author|null                         $author                                      The author of the embed.
+ * @property      ExCollectionInterface<Field>|Field[] $fields                                      A collection of embed fields (max of 25).
+ * @property-read array                                $poll_fields                                 A collection of poll fields.
+ * @property-read string|null                          $poll_fields['poll_question_text']           Question text from the original poll
+ * @property-read int|null                             $poll_fields['victor_answer_votes']          Number of votes for the answer(s) with the most votes
+ * @property-read int|null                             $poll_fields['total_votes']                  Total number of votes in the poll
+ * @property-read ?string|null                         $poll_fields['victor_answer_id']             ID for the winning answer (optional)
+ * @property-read ?string|null                         $poll_fields['victor_answer_text']           Text for the winning answer (optional)
+ * @property-read ?string|null                         $poll_fields['victor_answer_emoji_id']       ID for an emoji associated with the winning answer (optional)
+ * @property-read ?string|null                         $poll_fields['victor_answer_emoji_name']     Name of an emoji associated with the winning answer (optional)
+ * @property-read ?bool|null                           $poll_fields['victor_answer_emoji_animated'] If an emoji associated with the winning answer is animated (optional)
  */
 class EmbedPollResult extends Embed
 {

--- a/src/Discord/Parts/Gateway/GetGatewayBot.php
+++ b/src/Discord/Parts/Gateway/GetGatewayBot.php
@@ -42,6 +42,6 @@ class GetGatewayBot extends Part
 
     public function getSessionStartLimitAttribute(): SessionStartLimit
     {
-        return $this->factory->part(SessionStartLimit::class, (array) $this->attributes['session_start_limit']);
+        return $this->attributePartHelper('session_start_limit', SessionStartLimit::class);
     }
 }

--- a/src/Discord/Parts/Guild/AuditLog/AuditLog.php
+++ b/src/Discord/Parts/Guild/AuditLog/AuditLog.php
@@ -33,14 +33,14 @@ use ReflectionClass;
  *
  * @since 5.1.0
  *
- * @property ExCollectionInterface|Command[]        $application_commands   List of application commands referenced in the audit log.
- * @property ExCollectionInterface|Entry[]          $audit_log_entries      List of audit log entries.
- * @property ExCollectionInterface|Rule[]           $auto_moderation_rules  List of auto moderation rules referenced in the audit log.
- * @property ExCollectionInterface|ScheduledEvent[] $guild_scheduled_events List of guild scheduled events referenced in the audit log.
- * @property ExCollectionInterface|Integration[]    $integrations           List of partial integration objects.
- * @property ExCollectionInterface|Thread[]         $threads                List of threads referenced in the audit log.
- * @property ExCollectionInterface|User[]           $users                  List of users referenced in the audit log.
- * @property ExCollectionInterface|Webhook[]        $webhooks               List of webhooks referenced in the audit log.
+ * @property ExCollectionInterface<Command>|Command[]               $application_commands   List of application commands referenced in the audit log.
+ * @property ExCollectionInterface<Entry>|Entry[]                   $audit_log_entries      List of audit log entries.
+ * @property ExCollectionInterface<Rule>|Rule[]                     $auto_moderation_rules  List of auto moderation rules referenced in the audit log.
+ * @property ExCollectionInterface<ScheduledEvent>|ScheduledEvent[] $guild_scheduled_events List of guild scheduled events referenced in the audit log.
+ * @property ExCollectionInterface<Integration>|Integration[]       $integrations           List of partial integration objects.
+ * @property ExCollectionInterface<Thread>|Thread[]                 $threads                List of threads referenced in the audit log.
+ * @property ExCollectionInterface<User>|User[]                     $users                  List of users referenced in the audit log.
+ * @property ExCollectionInterface<Webhook>|Webhook[]               $webhooks               List of webhooks referenced in the audit log.
  *
  * @property      string     $guild_id
  * @property-read Guild|null $guild
@@ -77,7 +77,7 @@ class AuditLog extends Part
     /**
      * Returns a collection of application commands found in the audit log.
      *
-     * @return ExCollectionInterface|Command[]
+     * @return ExCollectionInterface<Command>|Command[]
      */
     protected function getApplicationCommandsAttribute(): ExCollectionInterface
     {
@@ -87,7 +87,7 @@ class AuditLog extends Part
     /**
      * Returns a collection of audit log entries.
      *
-     * @return ExCollectionInterface|Entry[]
+     * @return ExCollectionInterface<Entry>|Entry[]
      */
     protected function getAuditLogEntriesAttribute(): ExCollectionInterface
     {
@@ -97,7 +97,7 @@ class AuditLog extends Part
     /**
      * Returns a collection of auto moderation rules found in the audit log.
      *
-     * @return ExCollectionInterface|Rule[]
+     * @return ExCollectionInterface<Rule>|Rule[]
      */
     protected function getAutoModerationRulesAttribute(): ExCollectionInterface
     {
@@ -107,7 +107,7 @@ class AuditLog extends Part
     /**
      * Returns a collection of guild scheduled events found in the audit log.
      *
-     * @return ExCollectionInterface|ScheduledEvent[]
+     * @return ExCollectionInterface<ScheduledEvent>|ScheduledEvent[]
      */
     protected function getGuildScheduledEventsAttribute(): ExCollectionInterface
     {
@@ -119,7 +119,7 @@ class AuditLog extends Part
      *
      * @link https://discord.com/developers/docs/resources/audit-log#audit-log-object-example-partial-integration-object
      *
-     * @return ExCollectionInterface|Integration[]
+     * @return ExCollectionInterface<Integration>|Integration[]
      */
     protected function getIntegrationsAttribute(): ExCollectionInterface
     {
@@ -129,7 +129,7 @@ class AuditLog extends Part
     /**
      * Returns a collection of threads found in the audit log.
      *
-     * @return ExCollectionInterface|Thread[]
+     * @return ExCollectionInterface<Thread>|Thread[]
      */
     protected function getThreadsAttribute(): ExCollectionInterface
     {
@@ -139,7 +139,7 @@ class AuditLog extends Part
     /**
      * Returns a collection of users found in the audit log.
      *
-     * @return ExCollectionInterface|User[]
+     * @return ExCollectionInterface<User>|User[]
      */
     protected function getUsersAttribute(): ExCollectionInterface
     {
@@ -155,7 +155,7 @@ class AuditLog extends Part
     /**
      * Returns a collection of webhooks found in the audit log.
      *
-     * @return ExCollectionInterface|Webhook[]
+     * @return ExCollectionInterface<Webhook>|Webhook[]
      */
     protected function getWebhooksAttribute(): ExCollectionInterface
     {
@@ -169,7 +169,7 @@ class AuditLog extends Part
      *
      * @throws \InvalidArgumentException
      *
-     * @return ExCollectionInterface|Entry[]
+     * @return ExCollectionInterface<Entry>|Entry[]
      */
     public function searchByType(int $action_type): ExCollectionInterface
     {

--- a/src/Discord/Parts/Guild/AuditLog/Entry.php
+++ b/src/Discord/Parts/Guild/AuditLog/Entry.php
@@ -25,14 +25,14 @@ use Discord\Parts\User\User;
  *
  * @link https://discord.com/developers/docs/resources/audit-log#audit-log-entry-object
  *
- * @property      ?string             $target_id   ID of the affected entity (webhook, user, role, etc.).
- * @property      CollectionInterface $changes     Changes made to the target_id.
- * @property      ?string             $user_id     User or app that made the changes.
- * @property-read User|null           $user
- * @property      string              $id          ID of the entry.
- * @property      int                 $action_type Type of action that occurred.
- * @property      ?Options|null       $options     Additional info for certain action types.
- * @property      ?string|null        $reason      Reason for the change (1-512 characters).
+ * @property      ?string               $target_id   ID of the affected entity (webhook, user, role, etc.).
+ * @property      ExCollectionInterface $changes     Changes made to the target_id.
+ * @property      ?string               $user_id     User or app that made the changes.
+ * @property-read User|null             $user
+ * @property      string                $id          ID of the entry.
+ * @property      int                   $action_type Type of action that occurred.
+ * @property      ?Options|null         $options     Additional info for certain action types.
+ * @property      ?string|null          $reason      Reason for the change (1-512 characters).
  */
 class Entry extends Part
 {
@@ -216,6 +216,6 @@ class Entry extends Part
      */
     protected function getOptionsAttribute(): Options
     {
-        return $this->createOf(Options::class, $this->attributes['options'] ?? []);
+        return $this->attributePartHelper('options', Options::class);
     }
 }

--- a/src/Discord/Parts/Guild/AutoModeration/Rule.php
+++ b/src/Discord/Parts/Guild/AutoModeration/Rule.php
@@ -33,19 +33,19 @@ use Discord\Parts\User\User;
  *
  * @since 7.1.0
  *
- * @property      string                           $id               The id of this rule.
- * @property      string                           $guild_id         The id of the guild which this rule belongs to.
- * @property-read Guild|null                       $guild            The guild which this rule belongs to.
- * @property      string                           $name             The rule name.
- * @property      string                           $creator_id       The id of the user which first created this rule.
- * @property-read User|null                        $creator          The user which first created this rule.
- * @property      int                              $event_type       The rule event type.
- * @property      int                              $trigger_type     The rule trigger type.
- * @property      TriggerMetadata                  $trigger_metadata The rule trigger metadata (may contain `keyword_filter`, `regex_patterns`, `presets`, `allow_list`, `mention_total_limit` and `mention_raid_protection_enabled`).
- * @property      ExCollectionInterface|Action[]   $actions          The actions which will execute when the rule is triggered.
- * @property      bool                             $enabled          Whether the rule is enabled.
- * @property      ExCollectionInterface|?Role[]    $exempt_roles     The role ids that should not be affected by the rule (Maximum of 20).
- * @property      ExCollectionInterface|?Channel[] $exempt_channels  The channel ids that should not be affected by the rule (Maximum of 50).
+ * @property      string                                   $id               The id of this rule.
+ * @property      string                                   $guild_id         The id of the guild which this rule belongs to.
+ * @property-read Guild|null                               $guild            The guild which this rule belongs to.
+ * @property      string                                   $name             The rule name.
+ * @property      string                                   $creator_id       The id of the user which first created this rule.
+ * @property-read User|null                                $creator          The user which first created this rule.
+ * @property      int                                      $event_type       The rule event type.
+ * @property      int                                      $trigger_type     The rule trigger type.
+ * @property      TriggerMetadata                          $trigger_metadata The rule trigger metadata (may contain `keyword_filter`, `regex_patterns`, `presets`, `allow_list`, `mention_total_limit` and `mention_raid_protection_enabled`).
+ * @property      ExCollectionInterface<Action>|Action[]   $actions          The actions which will execute when the rule is triggered.
+ * @property      bool                                     $enabled          Whether the rule is enabled.
+ * @property      ExCollectionInterface<Role>|Role[]       $exempt_roles     The role ids that should not be affected by the rule (Maximum of 20).
+ * @property      ExCollectionInterface<Channel>|Channel[] $exempt_channels  The channel ids that should not be affected by the rule (Maximum of 50).
  */
 class Rule extends Part
 {
@@ -111,7 +111,7 @@ class Rule extends Part
     /**
      * Returns the actions attribute.
      *
-     * @return ExCollectionInterface|Action[] A collection of actions.
+     * @return ExCollectionInterface<Action>|Action[] A collection of actions.
      */
     protected function getActionsAttribute(): ExCollectionInterface
     {

--- a/src/Discord/Parts/Guild/AutoModeration/Rule.php
+++ b/src/Discord/Parts/Guild/AutoModeration/Rule.php
@@ -121,7 +121,7 @@ class Rule extends Part
     /**
      * Returns the exempt roles attribute.
      *
-     * @return ExCollectionInterface|?Role[] A collection of roles exempt from the rule.
+     * @return ExCollectionInterface<Role>|?Role[] A collection of roles exempt from the rule.
      */
     protected function getExemptRolesAttribute(): ExCollectionInterface
     {
@@ -145,7 +145,7 @@ class Rule extends Part
     /**
      * Returns the exempt channels attribute.
      *
-     * @return ExCollectionInterface|?Channel[] A collection of channels exempt from the rule.
+     * @return ExCollectionInterface<Channel>|?Channel[] A collection of channels exempt from the rule.
      */
     protected function getExemptChannelsAttribute(): ExCollectionInterface
     {

--- a/src/Discord/Parts/Guild/Ban.php
+++ b/src/Discord/Parts/Guild/Ban.php
@@ -85,7 +85,7 @@ class Ban extends Part
             return $user;
         }
 
-        return $this->factory->part(User::class, (array) $this->attributes['user'], true);
+        return $this->attributePartHelper('user', User::class);
     }
 
     /**

--- a/src/Discord/Parts/Guild/CommandPermissions.php
+++ b/src/Discord/Parts/Guild/CommandPermissions.php
@@ -27,11 +27,11 @@ use Discord\Parts\Part;
  * @since 10.0.0 Refactored from Interactions\Command\Overwrite to Guild\CommandPermissions
  * @since 7.0.0
  *
- * @property      string                             $id             The id of the command or the application ID if no overwrites.
- * @property      string                             $application_id The id of the application the command belongs to.
- * @property      string                             $guild_id       The id of the guild.
- * @property-read Guild|null                         $guild
- * @property      ExCollectionInterface|Permission[] $permissions    The permissions for the command in the guild.
+ * @property      string                                         $id             The id of the command or the application ID if no overwrites.
+ * @property      string                                         $application_id The id of the application the command belongs to.
+ * @property      string                                         $guild_id       The id of the guild.
+ * @property-read Guild|null                                     $guild
+ * @property      ExCollectionInterface<Permission>|Permission[] $permissions    The permissions for the command in the guild.
  */
 class CommandPermissions extends Part
 {
@@ -58,7 +58,7 @@ class CommandPermissions extends Part
     /**
      * Gets the permissions attribute.
      *
-     * @return ExCollectionInterface|Permission[] A collection of permissions.
+     * @return ExCollectionInterface<Permission>|Permission[] A collection of permissions.
      */
     protected function getPermissionsAttribute(): ExCollectionInterface
     {

--- a/src/Discord/Parts/Guild/Emoji.php
+++ b/src/Discord/Parts/Guild/Emoji.php
@@ -26,14 +26,14 @@ use Stringable;
  *
  * @since 4.0.2
  *
- * @property ?string                      $id             The identifier for the emoji.
- * @property string                       $name           The name of the emoji.
- * @property ExCollectionInterface|Role[] $roles          The roles that are allowed to use the emoji.
- * @property User|null                    $user           User that created this emoji.
- * @property bool|null                    $require_colons Whether the emoji requires colons to be triggered.
- * @property bool|null                    $managed        Whether this emoji is managed by a role.
- * @property bool|null                    $animated       Whether the emoji is animated.
- * @property bool|null                    $available      Whether this emoji can be used, may be false due to loss of Server Boosts.
+ * @property ?string                            $id             The identifier for the emoji.
+ * @property string                             $name           The name of the emoji.
+ * @property ExCollectionInterface<Role>|Role[] $roles          The roles that are allowed to use the emoji.
+ * @property User|null                          $user           User that created this emoji.
+ * @property bool|null                          $require_colons Whether the emoji requires colons to be triggered.
+ * @property bool|null                          $managed        Whether this emoji is managed by a role.
+ * @property bool|null                          $animated       Whether the emoji is animated.
+ * @property bool|null                          $available      Whether this emoji can be used, may be false due to loss of Server Boosts.
  *
  * @property      string|null $guild_id The identifier of the guild that owns the emoji.
  * @property-read Guild|null  $guild    The guild that owns the emoji.

--- a/src/Discord/Parts/Guild/Guild.php
+++ b/src/Discord/Parts/Guild/Guild.php
@@ -377,7 +377,7 @@ class Guild extends Part
     /**
      * Sets the roles attribute.
      *
-     * @param ExCollectionInterface|array|null $roles
+     * @param ExCollectionInterface<Role>|Role[]|null $roles
      */
     protected function setRolesAttribute($roles): void
     {
@@ -480,7 +480,7 @@ class Guild extends Part
      *
      * @throws NoPermissionsException Missing manage_guild permission.
      *
-     * @return PromiseInterface<Collection|Invite[]>
+     * @return PromiseInterface<ExCollectionInterface<Invite>|Invite[]>
      */
     public function getInvites(): PromiseInterface
     {
@@ -549,7 +549,7 @@ class Guild extends Part
      *
      * @deprecated 10.0.0 Use `$channel->stage_instances`
      *
-     * @return ExCollectionInterface|StageInstance[]
+     * @return ExCollectionInterface<StageInstance>|StageInstance[]
      */
     protected function getStageInstancesAttribute(): ExCollectionInterface
     {
@@ -1085,7 +1085,7 @@ class Guild extends Part
      * @param string|null $options['query'] Query string to match username(s) and nickname(s) against
      * @param int|null    $options['limit'] How many entries are returned (default 1, minimum 1, maximum 1000)
      *
-     * @return PromiseInterface<Collection|Member[]>
+     * @return PromiseInterface<ExCollectionInterface<Member>|Member[]>
      */
     public function searchMembers(array $options): PromiseInterface
     {

--- a/src/Discord/Parts/Guild/Guild.php
+++ b/src/Discord/Parts/Guild/Guild.php
@@ -1255,7 +1255,7 @@ class Guild extends Part
         return $this->http->get(Endpoint::bind(Endpoint::GUILD_WELCOME_SCREEN, $this->id))->then(function ($response) {
             $this->attributes['welcome_screen'] = $response;
 
-            return $this->factory->part(WelcomeScreen::class, (array) $response, true);
+            return $this->attributePartHelper('welcome_screen', WelcomeScreen::class);
         });
     }
 
@@ -1314,7 +1314,7 @@ class Guild extends Part
         return $this->http->patch(Endpoint::bind(Endpoint::GUILD_WELCOME_SCREEN, $this->id), $options)->then(function ($response) {
             $this->attributes['welcome_screen'] = $response;
 
-            return $this->factory->part(WelcomeScreen::class, (array) $response, true);
+            return $this->attributePartHelper('welcome_screen', WelcomeScreen::class);
         });
     }
 

--- a/src/Discord/Parts/Guild/GuildSearch.php
+++ b/src/Discord/Parts/Guild/GuildSearch.php
@@ -51,7 +51,7 @@ class GuildSearch extends Part
     /**
      * Returns a collection of messages found in the search.
      *
-     * @return ExCollectionInterface|Message[]
+     * @return ExCollectionInterface<Message>|Message[]
      */
     protected function getMessagesAttribute(): ExCollectionInterface
     {
@@ -77,7 +77,7 @@ class GuildSearch extends Part
     /**
      * Returns a collection of members found in the search.
      *
-     * @return ExCollectionInterface|Member[]
+     * @return ExCollectionInterface<Member>|Member[]
      */
     protected function getMembersAttribute(): ExCollectionInterface
     {
@@ -104,7 +104,7 @@ class GuildSearch extends Part
     /**
      * Returns a collection of threads found in the search.
      *
-     * @return ExCollectionInterface|Thread[]
+     * @return ExCollectionInterface<Thread>|Thread[]
      */
     protected function getThreadsAttribute(): ExCollectionInterface
     {

--- a/src/Discord/Parts/Guild/GuildTemplate.php
+++ b/src/Discord/Parts/Guild/GuildTemplate.php
@@ -82,7 +82,7 @@ class GuildTemplate extends Part implements Stringable
             return $guild;
         }
 
-        return $this->createOf(Guild::class, $this->attributes['serialized_source_guild']);
+        return $this->attributePartHelper('serialized_source_guild', Guild::class);
     }
 
     /**
@@ -92,7 +92,7 @@ class GuildTemplate extends Part implements Stringable
      */
     protected function getSerializedSourceGuildAttribute(): Guild
     {
-        return $this->createOf(Guild::class, $this->attributes['serialized_source_guild']);
+        return $this->attributePartHelper('serialized_source_guild', Guild::class);
     }
 
     /**
@@ -106,7 +106,7 @@ class GuildTemplate extends Part implements Stringable
             return $creator;
         }
 
-        return $this->factory->part(User::class, (array) $this->attributes['creator'], true);
+        return $this->attributePartHelper('creator', User::class);
     }
 
     /**

--- a/src/Discord/Parts/Guild/Integration.php
+++ b/src/Discord/Parts/Guild/Integration.php
@@ -88,7 +88,7 @@ class Integration extends Part
             return $user;
         }
 
-        return $this->factory->part(User::class, (array) $this->attributes['user'], true);
+        return $this->attributePartHelper('user', User::class);
     }
 
     /**
@@ -132,7 +132,7 @@ class Integration extends Part
             return $botApplication;
         }
 
-        return $this->factory->part(Application::class, (array) $this->attributes['application'], true);
+        return $this->attributePartHelper('application', Application::class);
     }
 
     /**

--- a/src/Discord/Parts/Guild/Role.php
+++ b/src/Discord/Parts/Guild/Role.php
@@ -89,7 +89,7 @@ class Role extends Part implements Stringable
      *
      * @since 10.0.0 Replaced setPermissionsAttribute() to save up memory.
      */
-    protected function getPermissionsAttribute(): Part
+    protected function getPermissionsAttribute(): RolePermission
     {
         return $this->createOf(RolePermission::class, ['bitwise' => $this->attributes['permissions']]);
     }

--- a/src/Discord/Parts/Guild/ScheduledEvent.php
+++ b/src/Discord/Parts/Guild/ScheduledEvent.php
@@ -261,11 +261,9 @@ class ScheduledEvent extends Part
             if ($user = $this->discord->users->get('id', $this->attributes['creator']->id)) {
                 return $user;
             }
-
-            return $this->factory->part(User::class, (array) $this->attributes['creator'], true);
         }
 
-        return null;
+        return $this->attributePartHelper('creator', User::class);
     }
 
     /**

--- a/src/Discord/Parts/Guild/Sound.php
+++ b/src/Discord/Parts/Guild/Sound.php
@@ -79,7 +79,7 @@ class Sound extends Part implements Stringable
             return $user;
         }
 
-        return $this->factory->part(User::class, (array) $this->attributes['user'], true);
+        return $this->attributePartHelper('user', User::class);
     }
 
     /**

--- a/src/Discord/Parts/Guild/Sticker.php
+++ b/src/Discord/Parts/Guild/Sticker.php
@@ -108,7 +108,7 @@ class Sticker extends Part implements Stringable
             return $user;
         }
 
-        return $this->factory->part(User::class, (array) $this->attributes['user'], true);
+        return $this->attributePartHelper('user', User::class);
     }
 
     /**

--- a/src/Discord/Parts/Guild/WelcomeScreen.php
+++ b/src/Discord/Parts/Guild/WelcomeScreen.php
@@ -23,8 +23,8 @@ use Discord\Parts\Part;
  *
  * @since 7.0.0
  *
- * @property ?string                                $description      The server description shown in the welcome screen.
- * @property ExCollectionInterface|WelcomeChannel[] $welcome_channels The channels shown in the welcome screen, up to 5.
+ * @property ?string                                                $description      The server description shown in the welcome screen.
+ * @property ExCollectionInterface<WelcomeChannel>|WelcomeChannel[] $welcome_channels The channels shown in the welcome screen, up to 5.
  */
 class WelcomeScreen extends Part
 {
@@ -39,7 +39,7 @@ class WelcomeScreen extends Part
     /**
      * Returns the Welcome Channels of the Welcome Screen.
      *
-     * @return ExCollectionInterface|WelcomeChannel[] The channels of welcome screen.
+     * @return ExCollectionInterface<WelcomeChannel>|WelcomeChannel[] The channels of welcome screen.
      */
     protected function getWelcomeChannelsAttribute(): ExCollectionInterface
     {

--- a/src/Discord/Parts/Interactions/Command/Command.php
+++ b/src/Discord/Parts/Interactions/Command/Command.php
@@ -94,7 +94,7 @@ class Command extends Part implements Stringable
     /**
      * Gets the options attribute.
      *
-     * @return ExCollectionInterface|Option[] A collection of options.
+     * @return ExCollectionInterface<Option>|Option[] A collection of options.
      */
     protected function getOptionsAttribute(): ExCollectionInterface
     {

--- a/src/Discord/Parts/Interactions/Command/Option.php
+++ b/src/Discord/Parts/Interactions/Command/Option.php
@@ -25,20 +25,20 @@ use function Discord\poly_strlen;
  *
  * @since 7.0.0
  *
- * @property int                            $type                      Type of the option.
- * @property string                         $name                      Name of the option.
- * @property ?string[]|null                 $name_localizations        Localization dictionary for the name field. Values follow the same restrictions as name.
- * @property string                         $description               1-100 character description.
- * @property ?string[]|null                 $description_localizations Localization dictionary for the description field. Values follow the same restrictions as description.
- * @property bool|null                      $required                  If the parameter is required or optional--default false.
- * @property ExCollectionInterface|Choice[] $choices                   Choices for STRING, INTEGER, and NUMBER types for the user to pick from, max 25. Only for slash commands.
- * @property ExCollectionInterface|Option[] $options                   Sub-options if applicable.
- * @property array|null                     $channel_types             If the option is a channel type, the channels shown will be restricted to these types.
- * @property int|float|null                 $min_value                 If the option is an INTEGER or NUMBER type, the minimum value permitted.
- * @property int|float|null                 $max_value                 If the option is an INTEGER or NUMBER type, the maximum value permitted.
- * @property int|null                       $min_length                For option type `STRING`, the minimum allowed length (minimum of `0`, maximum of `6000`).
- * @property int|null                       $max_length                For option type `STRING`, the maximum allowed length (minimum of `1`, maximum of `6000`).
- * @property bool|null                      $autocomplete              Enable autocomplete interactions for this option.
+ * @property int                                    $type                      Type of the option.
+ * @property string                                 $name                      Name of the option.
+ * @property ?string[]|null                         $name_localizations        Localization dictionary for the name field. Values follow the same restrictions as name.
+ * @property string                                 $description               1-100 character description.
+ * @property ?string[]|null                         $description_localizations Localization dictionary for the description field. Values follow the same restrictions as description.
+ * @property bool|null                              $required                  If the parameter is required or optional--default false.
+ * @property ExCollectionInterface<Choice>|Choice[] $choices                   Choices for STRING, INTEGER, and NUMBER types for the user to pick from, max 25. Only for slash commands.
+ * @property ExCollectionInterface<Option>|Option[] $options                   Sub-options if applicable.
+ * @property array|null                             $channel_types             If the option is a channel type, the channels shown will be restricted to these types.
+ * @property int|float|null                         $min_value                 If the option is an INTEGER or NUMBER type, the minimum value permitted.
+ * @property int|float|null                         $max_value                 If the option is an INTEGER or NUMBER type, the maximum value permitted.
+ * @property int|null                               $min_length                For option type `STRING`, the minimum allowed length (minimum of `0`, maximum of `6000`).
+ * @property int|null                               $max_length                For option type `STRING`, the maximum allowed length (minimum of `1`, maximum of `6000`).
+ * @property bool|null                              $autocomplete              Enable autocomplete interactions for this option.
  */
 class Option extends Part
 {
@@ -77,7 +77,7 @@ class Option extends Part
     /**
      * Gets the choices attribute.
      *
-     * @return ExCollectionInterface|Choice[] A collection of choices.
+     * @return ExCollectionInterface<Choice>|Choice[] A collection of choices.
      */
     protected function getChoicesAttribute(): ExCollectionInterface
     {
@@ -87,7 +87,7 @@ class Option extends Part
     /**
      * Gets the options attribute.
      *
-     * @return ExCollectionInterface|Option[] A collection of options.
+     * @return ExCollectionInterface<Option>|Option[] A collection of options.
      */
     protected function getOptionsAttribute(): ExCollectionInterface
     {

--- a/src/Discord/Parts/Interactions/Interaction.php
+++ b/src/Discord/Parts/Interactions/Interaction.php
@@ -177,11 +177,7 @@ class Interaction extends Part
             return $guild;
         }
 
-        if (isset($this->attributes['guild'])) {
-            return $this->factory->part(Guild::class, (array) $this->attributes['guild'], true);
-        }
-
-        return null;
+        return $this->attributePartHelper('guild', Guild::class);
     }
 
     /**
@@ -211,11 +207,7 @@ class Interaction extends Part
             return $channel;
         }
 
-        if (isset($this->attributes['channel'])) {
-            return $this->factory->part(Channel::class, (array) $this->attributes['channel'], true);
-        }
-
-        return null;
+        return $this->attributePartHelper('channel', Channel::class);
     }
 
     /**
@@ -235,7 +227,7 @@ class Interaction extends Part
                 }
             }
 
-            return $this->factory->part(Member::class, (array) $this->attributes['member'] + ['guild_id' => $this->guild_id], true);
+            return $this->attributePartHelper('member', Member::class, ['guild_id' => $this->guild_id]);
         }
 
         return null;

--- a/src/Discord/Parts/Interactions/Request/ApplicationCommandData.php
+++ b/src/Discord/Parts/Interactions/Request/ApplicationCommandData.php
@@ -22,13 +22,13 @@ use Discord\Helpers\ExCollectionInterface;
  *
  * @since 10.19.0
  *
- * @property string                          $id        ID of the invoked command.
- * @property string                          $name      Name of the invoked command.
- * @property int                             $type      Type of the invoked command.
- * @property ?Resolved|null                  $resolved  Converted users, roles, channels, attachments.
- * @property ?ExCollectionInterface|Option[] $options   Params and values from the user.
- * @property ?string|null                    $guild_id  ID of the guild the command is registered to.
- * @property ?string|null                    $target_id ID of the user or message targeted by a user or message command.
+ * @property string                                  $id        ID of the invoked command.
+ * @property string                                  $name      Name of the invoked command.
+ * @property int                                     $type      Type of the invoked command.
+ * @property ?Resolved|null                          $resolved  Converted users, roles, channels, attachments.
+ * @property ?ExCollectionInterface<Option>|Option[] $options   Params and values from the user.
+ * @property ?string|null                            $guild_id  ID of the guild the command is registered to.
+ * @property ?string|null                            $target_id ID of the user or message targeted by a user or message command.
  */
 class ApplicationCommandData extends InteractionData
 {

--- a/src/Discord/Parts/Interactions/Request/ApplicationCommandInteractionDataOption.php
+++ b/src/Discord/Parts/Interactions/Request/ApplicationCommandInteractionDataOption.php
@@ -22,11 +22,11 @@ use Discord\Helpers\ExCollectionInterface;
  *
  * @since 10.19.0
  *
- * @property string                          $name    Name of the parameter.
- * @property int                             $type    Value of application command option type.
- * @property ?string|int|float|bool|null     $value   Value of the option resulting from user input.
- * @property ?ExCollectionInterface|Option[] $options Present if this option is a group or subcommand.
- * @property ?bool|null                      $focused True if this option is the currently focused option for autocomplete.
+ * @property string                                  $name    Name of the parameter.
+ * @property int                                     $type    Value of application command option type.
+ * @property ?string|int|float|bool|null             $value   Value of the option resulting from user input.
+ * @property ?ExCollectionInterface<Option>|Option[] $options Present if this option is a group or subcommand.
+ * @property ?bool|null                              $focused True if this option is the currently focused option for autocomplete.
  */
 class ApplicationCommandInteractionDataOption extends InteractionData
 {

--- a/src/Discord/Parts/Interactions/Request/Component.php
+++ b/src/Discord/Parts/Interactions/Request/Component.php
@@ -28,22 +28,22 @@ use Discord\Parts\Part;
  * @deprecated 10.11.0 Use \Discord\Parts\Channel\Message\Component` instead.
  * @see \Discord\Parts\Channel\Message\Component
  *
- * @property int                               $type        Component type.
- * @property string|null                       $custom_id   Developer-defined identifier for the component; max 100 characters. (Buttons, Select Menus)
- * @property bool|null                         $disabled    Whether the component is disabled; defaults to `false`. (Buttons, Select Menus)
- * @property int|null                          $style       A button style. (Buttons)
- * @property string|null                       $label       Text that appears on the button; max 80 characters. (Buttons)
- * @property Emoji|null                        $emoji       Name, id, and animated. (Buttons)
- * @property string|null                       $url         URL for link-style buttons. (Buttons)
- * @property object[]|null                     $options     The choices in the select; max 25. (Select Menus)
- * @property string|null                       $placeholder Custom placeholder text if nothing is selected; max 150 characters. (Select Menus, Text Inputs)
- * @property int|null                          $min_values  The minimum number of items that must be chosen; default 1, min 0, max 25. (Select Menus)
- * @property int|null                          $max_values  The maximum number of items that can be chosen; default 1, max 25. (Select Menus)
- * @property ExCollectionInterface|Component[] $components  A list of child components. (Action Rows)
- * @property int|null                          $min_length  Minimum input length for a text input. (Text Inputs)
- * @property int|null                          $max_length  Maximum input length for a text input. (Text Inputs)
- * @property bool|null                         $required    Whether this component is required to be filled; defaults to `true` (Text Inputs)
- * @property string|null                       $value       Value for this component. (Text Inputs)
+ * @property int                                          $type        Component type.
+ * @property string|null                                  $custom_id   Developer-defined identifier for the component; max 100 characters. (Buttons, Select Menus)
+ * @property bool|null                                    $disabled    Whether the component is disabled; defaults to `false`. (Buttons, Select Menus)
+ * @property int|null                                     $style       A button style. (Buttons)
+ * @property string|null                                  $label       Text that appears on the button; max 80 characters. (Buttons)
+ * @property Emoji|null                                   $emoji       Name, id, and animated. (Buttons)
+ * @property string|null                                  $url         URL for link-style buttons. (Buttons)
+ * @property object[]|null                                $options     The choices in the select; max 25. (Select Menus)
+ * @property string|null                                  $placeholder Custom placeholder text if nothing is selected; max 150 characters. (Select Menus, Text Inputs)
+ * @property int|null                                     $min_values  The minimum number of items that must be chosen; default 1, min 0, max 25. (Select Menus)
+ * @property int|null                                     $max_values  The maximum number of items that can be chosen; default 1, max 25. (Select Menus)
+ * @property ExCollectionInterface<Component>|Component[] $components  A list of child components. (Action Rows)
+ * @property int|null                                     $min_length  Minimum input length for a text input. (Text Inputs)
+ * @property int|null                                     $max_length  Maximum input length for a text input. (Text Inputs)
+ * @property bool|null                                    $required    Whether this component is required to be filled; defaults to `true` (Text Inputs)
+ * @property string|null                                  $value       Value for this component. (Text Inputs)
  */
 class Component extends Part
 {
@@ -72,7 +72,7 @@ class Component extends Part
     /**
      * Gets the sub-components of the component.
      *
-     * @return ExCollectionInterface|Component[] $components
+     * @return ExCollectionInterface<Component>|Component[] $components
      */
     protected function getComponentsAttribute(): ExCollectionInterface
     {

--- a/src/Discord/Parts/Interactions/Request/InteractionData.php
+++ b/src/Discord/Parts/Interactions/Request/InteractionData.php
@@ -26,17 +26,17 @@ use Discord\Parts\Part;
  *
  * @since 7.0.0
  *
- * @property string                            $id             ID of the invoked command.
- * @property string                            $name           Name of the invoked command.
- * @property int                               $type           The type of the invoked command.
- * @property Resolved|null                     $resolved       Resolved users, members, roles and channels that are relevant.
- * @property ExCollectionInterface|Option[]    $options        Parameters and values from the user.
- * @property string|null                       $guild_id       ID of the guild internally passed from Interaction or ID of the guild the command belongs to.
- * @property string|null                       $target_id      ID the of user or message targeted by a user or message command.
- * @property string|null                       $custom_id      Custom ID the component was created for. (Only for Message Component & Modal)
- * @property int|null                          $component_type Type of the component. (Only for Message Component)
- * @property string[]|null                     $values         Values selected in a select menu. (Only for Message Component)
- * @property ExCollectionInterface|Component[] $components     The values submitted by the user. (Only for Modal)
+ * @property string                                       $id             ID of the invoked command.
+ * @property string                                       $name           Name of the invoked command.
+ * @property int                                          $type           The type of the invoked command.
+ * @property Resolved|null                                $resolved       Resolved users, members, roles and channels that are relevant.
+ * @property ExCollectionInterface<Option>|Option[]       $options        Parameters and values from the user.
+ * @property string|null                                  $guild_id       ID of the guild internally passed from Interaction or ID of the guild the command belongs to.
+ * @property string|null                                  $target_id      ID the of user or message targeted by a user or message command.
+ * @property string|null                                  $custom_id      Custom ID the component was created for. (Only for Message Component & Modal)
+ * @property int|null                                     $component_type Type of the component. (Only for Message Component)
+ * @property string[]|null                                $values         Values selected in a select menu. (Only for Message Component)
+ * @property ExCollectionInterface<Component>|Component[] $components     The values submitted by the user. (Only for Modal)
  *
  * @deprecated 10.19.0 Use either `ApplicationCommandData`,`MessageComponentData`, or `ModalSubmitData`
  */

--- a/src/Discord/Parts/Interactions/Request/InteractionData.php
+++ b/src/Discord/Parts/Interactions/Request/InteractionData.php
@@ -66,7 +66,7 @@ class InteractionData extends Part
     /**
      * Gets the options of the interaction.
      *
-     * @return ExCollectionInterface|Option[] $options
+     * @return ExCollectionInterface<Option>|Option[] $options
      */
     protected function getOptionsAttribute(): ExCollectionInterface
     {
@@ -76,7 +76,7 @@ class InteractionData extends Part
     /**
      * Gets the components of the interaction.
      *
-     * @return ExCollectionInterface|Component[] $components
+     * @return ExCollectionInterface<Component>|Component[] $components
      */
     protected function getComponentsAttribute(): ExCollectionInterface
     {

--- a/src/Discord/Parts/Interactions/Request/ModalSubmitData.php
+++ b/src/Discord/Parts/Interactions/Request/ModalSubmitData.php
@@ -23,9 +23,9 @@ use Discord\Parts\Channel\Message\Component;
  *
  * @since 10.19.0
  *
- * @property string                            $custom_id  Custom ID the component was created for.
- * @property ExCollectionInterface|Component[] $components Values submitted by the user.
- * @property ?Resolved|null                    $resolved   Resolved entities from selected options.
+ * @property string                                       $custom_id  Custom ID the component was created for.
+ * @property ExCollectionInterface<Component>|Component[] $components Values submitted by the user.
+ * @property ?Resolved|null                               $resolved   Resolved entities from selected options.
  */
 class ModalSubmitData extends InteractionData
 {

--- a/src/Discord/Parts/Interactions/Request/Option.php
+++ b/src/Discord/Parts/Interactions/Request/Option.php
@@ -23,11 +23,11 @@ use Discord\Parts\Part;
  *
  * @since 7.0.0
  *
- * @property string                         $name    Name of the parameter.
- * @property int                            $type    Type of the option.
- * @property string|int|float|bool|null     $value   Value of the option resulting from user input.
- * @property ExCollectionInterface|Option[] $options Present if this option is a group or subcommand.
- * @property bool|null                      $focused `true` if this option is the currently focused option for autocomplete.
+ * @property string                                 $name    Name of the parameter.
+ * @property int                                    $type    Type of the option.
+ * @property string|int|float|bool|null             $value   Value of the option resulting from user input.
+ * @property ExCollectionInterface<Option>|Option[] $options Present if this option is a group or subcommand.
+ * @property bool|null                              $focused `true` if this option is the currently focused option for autocomplete.
  */
 class Option extends Part
 {

--- a/src/Discord/Parts/Interactions/Request/Option.php
+++ b/src/Discord/Parts/Interactions/Request/Option.php
@@ -45,7 +45,7 @@ class Option extends Part
     /**
      * Gets the options of the interaction.
      *
-     * @return ExCollectionInterface|Option[] $options
+     * @return ExCollectionInterface<Option>|Option[] $options
      */
     protected function getOptionsAttribute(): ExCollectionInterface
     {

--- a/src/Discord/Parts/Interactions/Request/Resolved.php
+++ b/src/Discord/Parts/Interactions/Request/Resolved.php
@@ -67,7 +67,7 @@ class Resolved extends Part
     /**
      * Returns a collection of resolved users.
      *
-     * @return ExCollectionInterface|User[] Map of Snowflakes to user objects
+     * @return ExCollectionInterface<User>|User[] Map of Snowflakes to user objects
      */
     protected function getUsersAttribute(): ExCollectionInterface
     {
@@ -89,7 +89,7 @@ class Resolved extends Part
      *
      * Partial Member objects are missing user, deaf and mute fields
      *
-     * @return ExCollectionInterface|Member[] Map of Snowflakes to partial member objects
+     * @return ExCollectionInterface<Member>|Member[] Map of Snowflakes to partial member objects
      */
     protected function getMembersAttribute(): ExCollectionInterface
     {
@@ -118,7 +118,7 @@ class Resolved extends Part
     /**
      * Returns a collection of resolved roles.
      *
-     * @return ExCollectionInterface|Role[] Map of Snowflakes to role objects
+     * @return ExCollectionInterface<Role>|Role[] Map of Snowflakes to role objects
      */
     protected function getRolesAttribute(): ExCollectionInterface
     {
@@ -148,7 +148,7 @@ class Resolved extends Part
      *
      * Partial Channel objects only have id, name, type and permissions fields. Threads will also have thread_metadata and parent_id fields.
      *
-     * @return ExCollectionInterface|Channel[]|Thread[] Map of Snowflakes to partial channel objects
+     * @return ExCollectionInterface<Channel|Thread>|Channel[]|Thread[] Map of Snowflakes to partial channel objects
      */
     protected function getChannelsAttribute(): ExCollectionInterface
     {
@@ -180,7 +180,7 @@ class Resolved extends Part
     /**
      * Returns a collection of resolved messages.
      *
-     * @return ExCollectionInterface|Message[] Map of Snowflakes to partial messages objects
+     * @return ExCollectionInterface<Message>|Message[] Map of Snowflakes to partial messages objects
      */
     protected function getMessagesAttribute(): ExCollectionInterface
     {
@@ -206,7 +206,7 @@ class Resolved extends Part
     /**
      * Returns a collection of resolved attachments.
      *
-     * @return ExCollectionInterface|Attachment[] Map of Snowflakes to attachments objects
+     * @return ExCollectionInterface<Attachment>|Attachment[] Map of Snowflakes to attachments objects
      */
     protected function getAttachmentsAttribute(): ExCollectionInterface
     {

--- a/src/Discord/Parts/Interactions/Request/Resolved.php
+++ b/src/Discord/Parts/Interactions/Request/Resolved.php
@@ -32,12 +32,12 @@ use Discord\Parts\User\User;
  *
  * @since 7.0.0
  *
- * @property ExCollectionInterface|User[]             $users       The ids and User objects.
- * @property ExCollectionInterface|Member[]           $members     The ids and partial Member objects.
- * @property ExCollectionInterface|Role[]             $roles       The ids and Role objects.
- * @property ExCollectionInterface|Channel[]|Thread[] $channels    The ids and partial Channel objects.
- * @property ExCollectionInterface|Message[]          $messages    The ids and partial Message objects.
- * @property ExCollectionInterface|Attachment[]       $attachments The ids and partial Attachment objects.
+ * @property ExCollectionInterface<User>|User[]                $users       The ids and User objects.
+ * @property ExCollectionInterface<Member>|Member[]            $members     The ids and partial Member objects.
+ * @property ExCollectionInterface<Role>|Role[]                $roles       The ids and Role objects.
+ * @property ExCollectionInterface<Channel>|Channel[]|Thread[] $channels    The ids and partial Channel objects.
+ * @property ExCollectionInterface<Message>|Message[]          $messages    The ids and partial Message objects.
+ * @property ExCollectionInterface<Attachment>|Attachment[]    $attachments The ids and partial Attachment objects.
  *
  * @property      string|null $guild_id ID of the guild internally passed from Interaction.
  * @property-read ?Guild|null $guild    The guild the interaction was sent in.

--- a/src/Discord/Parts/OAuth/ActivityInstance.php
+++ b/src/Discord/Parts/OAuth/ActivityInstance.php
@@ -25,11 +25,11 @@ use Discord\Parts\User\User;
  *
  * @since 10.17.0
  *
- * @property string                       $application_id Application ID.
- * @property string                       $instance_id    Activity Instance ID.
- * @property string                       $launch_id      Unique identifier for the launch.
- * @property ActivityLocation             $location       Location the instance is running in.
- * @property ExCollectionInterface|User[] $users          IDs of the Users currently connected to the instance.
+ * @property string                             $application_id Application ID.
+ * @property string                             $instance_id    Activity Instance ID.
+ * @property string                             $launch_id      Unique identifier for the launch.
+ * @property ActivityLocation                   $location       Location the instance is running in.
+ * @property ExCollectionInterface<User>|User[] $users          IDs of the Users currently connected to the instance.
  */
 class ActivityInstance extends Part
 {
@@ -54,7 +54,7 @@ class ActivityInstance extends Part
     /**
      * Returns a collection of users currently connected to the instance.
      *
-     * @return ExCollectionInterface|User[]
+     * @return ExCollectionInterface<User>|User[]
      */
     protected function getUsersAttribute(): ExCollectionInterface
     {

--- a/src/Discord/Parts/OAuth/ActivityLocation.php
+++ b/src/Discord/Parts/OAuth/ActivityLocation.php
@@ -71,7 +71,7 @@ class ActivityLocation extends Part
             return $channel;
         }
 
-        return $this->factory->part(Channel::class, ['id' => $this->attributes['channel_id']] + ['guild_id' => $this->attributes['guild_id'] ?? null], true);
+        return $this->attributePartHelper('channel', Channel::class, ['guild_id' => $this->attributes['guild_id'] ?? null]);
     }
 
     /**

--- a/src/Discord/Parts/OAuth/Application.php
+++ b/src/Discord/Parts/OAuth/Application.php
@@ -286,7 +286,7 @@ class Application extends Part
             return $owner;
         }
 
-        return $this->factory->part(User::class, (array) $this->attributes['owner'], true);
+        return $this->attributePartHelper('owner', User::class);
     }
 
     /**

--- a/src/Discord/Parts/OAuth/ApplicationRoleConnectionMetadata.php
+++ b/src/Discord/Parts/OAuth/ApplicationRoleConnectionMetadata.php
@@ -25,12 +25,12 @@ use Discord\Parts\Part;
  *
  * @since 10.29.0
  *
- * @property int                $type                                  Type of metadata value (see ApplicationRoleConnectionMetadataType).
- * @property string             $key                                   Dictionary key for the metadata field (a-z, 0-9, or _; 1-50 characters).
- * @property string             $name                                  Name of the metadata field (1-100 characters).
- * @property array|null         $name_localizations                    Translations of the name (dictionary with keys in available locales).
- * @property string             $description                           Description of the metadata field (1-200 characters).
- * @property array|null         $description_localizations             Translations of the description (dictionary with keys in available locales).
+ * @property int        $type                      Type of metadata value (see ApplicationRoleConnectionMetadataType).
+ * @property string     $key                       Dictionary key for the metadata field (a-z, 0-9, or _; 1-50 characters).
+ * @property string     $name                      Name of the metadata field (1-100 characters).
+ * @property array|null $name_localizations        Translations of the name (dictionary with keys in available locales).
+ * @property string     $description               Description of the metadata field (1-200 characters).
+ * @property array|null $description_localizations Translations of the description (dictionary with keys in available locales).
  */
 class ApplicationRoleConnectionMetadata extends Part
 {

--- a/src/Discord/Parts/User/Member.php
+++ b/src/Discord/Parts/User/Member.php
@@ -354,7 +354,7 @@ class Member extends Part implements Stringable
      *
      * @link https://discord.com/developers/docs/resources/guild#modify-guild-member
      *
-     * @param ExCollectionInterface|Role[]|string[] $roles  The roles to set to the member.
+     * @param ExCollectionInterface<Role|string>|Role[]|string[] $roles  The roles to set to the member.
      * @param string|null                           $reason Reason for Audit Log.
      *
      * @throws NoPermissionsException Missing manage_roles permission.

--- a/src/Discord/Parts/User/Member.php
+++ b/src/Discord/Parts/User/Member.php
@@ -45,29 +45,29 @@ use function React\Promise\reject;
  *
  * @since 2.0.0
  *
- * @property      User|null                    $user                         The user part of the member.
- * @property-read string|null                  $username                     The username of the member.
- * @property      ?string|null                 $nick                         The nickname of the member.
- * @property-read string                       $displayname                  The nickname or display name with optional discriminator of the member.
- * @property      ?string|null                 $avatar                       The avatar URL of the member or null if member has no guild avatar.
- * @property      ?string|null                 $avatar_hash                  The avatar hash of the member or null if member has no guild avatar.
- * @property      ExCollectionInterface|Role[] $roles                        A collection of Roles that the member has.
- * @property      Carbon|null                  $joined_at                    A timestamp of when the member joined the guild.
- * @property      Carbon|null                  $premium_since                When the user started boosting the server.
- * @property      bool                         $deaf                         Whether the member is deaf.
- * @property      bool                         $mute                         Whether the member is mute.
- * @property      bool|null                    $pending                      Whether the user has not yet passed the guild's Membership Screening requirements.
- * @property      RolePermission|null          $permissions                  Total permissions of the member in the channel, including overwrites, returned when in the interaction object.
- * @property      Carbon|null                  $communication_disabled_until When the user's timeout will expire and the user will be able to communicate in the guild again, null or a time in the past if the user is not timed out.
- * @property      int                          $flags                        Guild member flags represented as a bit set, defaults to `0`.
- * @property      string|null                  $guild_id                     The unique identifier of the guild that the member belongs to.
- * @property-read Guild|null                   $guild                        The guild that the member belongs to.
+ * @property      User|null                          $user                         The user part of the member.
+ * @property-read string|null                        $username                     The username of the member.
+ * @property      ?string|null                       $nick                         The nickname of the member.
+ * @property-read string                             $displayname                  The nickname or display name with optional discriminator of the member.
+ * @property      ?string|null                       $avatar                       The avatar URL of the member or null if member has no guild avatar.
+ * @property      ?string|null                       $avatar_hash                  The avatar hash of the member or null if member has no guild avatar.
+ * @property      ExCollectionInterface<Role>|Role[] $roles                        A collection of Roles that the member has.
+ * @property      Carbon|null                        $joined_at                    A timestamp of when the member joined the guild.
+ * @property      Carbon|null                        $premium_since                When the user started boosting the server.
+ * @property      bool                               $deaf                         Whether the member is deaf.
+ * @property      bool                               $mute                         Whether the member is mute.
+ * @property      bool|null                          $pending                      Whether the user has not yet passed the guild's Membership Screening requirements.
+ * @property      RolePermission|null                $permissions                  Total permissions of the member in the channel, including overwrites, returned when in the interaction object.
+ * @property      Carbon|null                        $communication_disabled_until When the user's timeout will expire and the user will be able to communicate in the guild again, null or a time in the past if the user is not timed out.
+ * @property      int                                $flags                        Guild member flags represented as a bit set, defaults to `0`.
+ * @property      string|null                        $guild_id                     The unique identifier of the guild that the member belongs to.
+ * @property-read Guild|null                         $guild                        The guild that the member belongs to.
  *
- * @property      string                           $id            The unique identifier of the member.
- * @property      string                           $status        The status of the member.
- * @property-read Activity                         $game          The game the member is playing.
- * @property      ExCollectionInterface|Activity[] $activities    User's current activities.
- * @property      ClientStatus                     $client_status Current client status.
+ * @property      string                                     $id            The unique identifier of the member.
+ * @property      string                                     $status        The status of the member.
+ * @property-read Activity                                   $game          The game the member is playing.
+ * @property      ExCollectionInterface<Activity>|Activity[] $activities    User's current activities.
+ * @property      ClientStatus                               $client_status Current client status.
  *
  * @method PromiseInterface<Message> sendMessage(MessageBuilder $builder)
  */
@@ -639,7 +639,7 @@ class Member extends Part implements Stringable
     /**
      * Gets the activities attribute.
      *
-     * @return ExCollectionInterface|Activity[]
+     * @return ExCollectionInterface<Activity>|Activity[]
      */
     protected function getActivitiesAttribute(): ExCollectionInterface
     {

--- a/src/Discord/Parts/WebSockets/AutoModerationActionExecution.php
+++ b/src/Discord/Parts/WebSockets/AutoModerationActionExecution.php
@@ -83,7 +83,7 @@ class AutoModerationActionExecution extends Part
      */
     protected function getActionAttribute(): Action
     {
-        return $this->createOf(Action::class, $this->attributes['action']);
+        return $this->attributePartHelper('action', Action::class);
     }
 
     /**

--- a/src/Discord/Parts/WebSockets/MessageInteraction.php
+++ b/src/Discord/Parts/WebSockets/MessageInteraction.php
@@ -65,7 +65,7 @@ class MessageInteraction extends Part
             return $user;
         }
 
-        return $this->factory->part(User::class, (array) $this->attributes['user'], true);
+        return $this->attributePartHelper('user', User::class);
     }
 
     /**
@@ -82,9 +82,7 @@ class MessageInteraction extends Part
                 }
             }
 
-            if (isset($this->attributes['member'])) {
-                return $this->factory->part(Member::class, (array) $this->attributes['member'] + ['guild_id' => $this->guild_id], true);
-            }
+            return $this->attributePartHelper('member', Member::class, ['guild_id' => $this->guild_id]);
         }
 
         return null;

--- a/src/Discord/Parts/WebSockets/MessageReaction.php
+++ b/src/Discord/Parts/WebSockets/MessageReaction.php
@@ -172,7 +172,7 @@ class MessageReaction extends Part
             }
         }
 
-        return $this->attributes['message'] ?? null;
+        return $this->attributePartHelper('message', Message::class);
     }
 
     /**
@@ -202,11 +202,7 @@ class MessageReaction extends Part
             }
         }
 
-        if (isset($this->attributes['member'])) {
-            return $this->factory->part(Member::class, (array) $this->attributes['member'] + ['guild_id' => $this->guild_id], true);
-        }
-
-        return null;
+        return $this->attributePartHelper('member', Member::class, ['guild_id' => $this->guild_id]);
     }
 
     /**

--- a/src/Discord/Parts/WebSockets/PresenceUpdate.php
+++ b/src/Discord/Parts/WebSockets/PresenceUpdate.php
@@ -43,8 +43,8 @@ use Discord\Parts\User\ClientStatus;
  * @property      string|null                                $mobile_status  Status of the user on their mobile client. Null if they are not active on mobile.
  * @property      string|null                                $web_status     Status of the user on their web client. Null if they are not active on web.
  *
- * @property-read Member                       $member The member that the presence update affects.
- * @property-read ExCollectionInterface|Role[] $roles  Roles that the user has in the guild.
+ * @property-read Member                             $member The member that the presence update affects.
+ * @property-read ExCollectionInterface<Role>|Role[] $roles  Roles that the user has in the guild.
  */
 class PresenceUpdate extends Part
 {
@@ -171,7 +171,7 @@ class PresenceUpdate extends Part
     /**
      * Returns the users roles.
      *
-     * @return ExCollectionInterface|Role[]
+     * @return ExCollectionInterface<Role>|Role[]
      */
     protected function getRolesAttribute(): ExCollectionInterface
     {

--- a/src/Discord/Parts/WebSockets/PresenceUpdate.php
+++ b/src/Discord/Parts/WebSockets/PresenceUpdate.php
@@ -32,16 +32,16 @@ use Discord\Parts\User\ClientStatus;
  *
  * @link https://discord.com/developers/docs/topics/gateway-events#presence
  *
- * @property      User                             $user           The user that the presence update affects.
- * @property      string                           $guild_id       The unique identifier of the guild that the presence update affects.
- * @property-read Guild|null                       $guild          The guild that the presence update affects.
- * @property      string                           $status         The updated status of the user.
- * @property      ExCollectionInterface|Activity[] $activities     The activities of the user.
- * @property-read Activity                         $game           The updated game of the user.
- * @property      ClientStatus                     $client_status  Status of the client.
- * @property      string|null                      $desktop_status Status of the user on their desktop client. Null if they are not active on desktop.
- * @property      string|null                      $mobile_status  Status of the user on their mobile client. Null if they are not active on mobile.
- * @property      string|null                      $web_status     Status of the user on their web client. Null if they are not active on web.
+ * @property      User                                       $user           The user that the presence update affects.
+ * @property      string                                     $guild_id       The unique identifier of the guild that the presence update affects.
+ * @property-read Guild|null                                 $guild          The guild that the presence update affects.
+ * @property      string                                     $status         The updated status of the user.
+ * @property      ExCollectionInterface<Activity>|Activity[] $activities     The activities of the user.
+ * @property-read Activity                                   $game           The updated game of the user.
+ * @property      ClientStatus                               $client_status  Status of the client.
+ * @property      string|null                                $desktop_status Status of the user on their desktop client. Null if they are not active on desktop.
+ * @property      string|null                                $mobile_status  Status of the user on their mobile client. Null if they are not active on mobile.
+ * @property      string|null                                $web_status     Status of the user on their web client. Null if they are not active on web.
  *
  * @property-read Member                       $member The member that the presence update affects.
  * @property-read ExCollectionInterface|Role[] $roles  Roles that the user has in the guild.
@@ -81,7 +81,7 @@ class PresenceUpdate extends Part
             return $user;
         }
 
-        return $this->factory->part(User::class, (array) $this->attributes['user'], true);
+        return $this->attributePartHelper('user', User::class);
     }
 
     /**
@@ -97,7 +97,7 @@ class PresenceUpdate extends Part
     /**
      * Gets the activities attribute.
      *
-     * @return ExCollectionInterface|Activity[]
+     * @return ExCollectionInterface<Activity>|Activity[]
      */
     protected function getActivitiesAttribute(): ExCollectionInterface
     {
@@ -121,7 +121,7 @@ class PresenceUpdate extends Part
      */
     protected function getClientStatusAttribute(): ClientStatus
     {
-        return $this->factory->part(ClientStatus::class, (array) ($this->attributes['client_status'] ?? []), true);
+        return $this->attributePartHelper('client_status', ClientStatus::class);
     }
 
     /**

--- a/src/Discord/Parts/WebSockets/TypingStart.php
+++ b/src/Discord/Parts/WebSockets/TypingStart.php
@@ -133,10 +133,6 @@ class TypingStart extends Part
             }
         }
 
-        if (isset($this->attributes['member'])) {
-            return $this->factory->part(Member::class, (array) $this->attributes['member'] + ['guild_id' => $this->guild_id], true);
-        }
-
-        return null;
+        return $this->attributePartHelper('member', Member::class, ['guild_id' => $this->guild_id]);
     }
 }

--- a/src/Discord/Parts/WebSockets/VoiceStateUpdate.php
+++ b/src/Discord/Parts/WebSockets/VoiceStateUpdate.php
@@ -124,11 +124,7 @@ class VoiceStateUpdate extends Part
             }
         }
 
-        if (isset($this->attributes['member'])) {
-            return $this->factory->part(Member::class, (array) $this->attributes['member'] + ['guild_id' => $this->guild_id], true);
-        }
-
-        return null;
+        return $this->attributePartHelper('member', Member::class, ['guild_id' => $this->guild_id]);
     }
 
     /**

--- a/src/Discord/Repository/Channel/ThreadRepository.php
+++ b/src/Discord/Repository/Channel/ThreadRepository.php
@@ -153,7 +153,7 @@ class ThreadRepository extends AbstractRepository
      *
      * @param object $response
      *
-     * @return ExCollectionInterface|Thread[]
+     * @return ExCollectionInterface<Thread>|Thread[]
      */
     private function handleThreadPaginationResponse(object $response): ExCollectionInterface
     {


### PR DESCRIPTION
This pull request refactors various attribute getter methods across the codebase to consistently use the new `attributePartHelper` utility, replacing previous direct calls to `factory->part`, `createOf`, and similar methods. This change improves maintainability, reduces code duplication, and standardizes how related objects are instantiated from attributes. Additionally, several type hints and docblocks have been updated for improved clarity and accuracy, and some new helper methods have been introduced.

### Refactoring attribute getters to use `attributePartHelper`

* Replaced direct calls to `factory->part`, `createOf`, and similar methods with `attributePartHelper` in multiple attribute getter methods, including those for `author`, `referenced_message`, `user`, `media`, `file`, `emoji`, `accessory`, `component`, `question`, and `message` across various classes such as `Message`, `Invite`, `Webhook`, `MessageInteractionMetadata`, `File`, `MediaGalleryItem`, `Thumbnail`, `StringSelectOption`, `Section`, `Label`, `Poll`, `Overwrite`, `GetGatewayBot`, and `AuditLog Entry`. [[1]](diffhunk://#diff-5d2251c005b2ae0591670e794e724dfda058b60941d5c1ca6cfb29bb3e5d83f1L264-R264) [[2]](diffhunk://#diff-3bc0952a87e08969969124672b2539443f4afa2fa67b5fdcddd94944c88eb1ddL594-R594) [[3]](diffhunk://#diff-3bc0952a87e08969969124672b2539443f4afa2fa67b5fdcddd94944c88eb1ddL704-R704) [[4]](diffhunk://#diff-fe3fa9820fe9ee2ba759ea5fb1bee7047e49ef043eb92a22216d575cadeb565fL83-R83) [[5]](diffhunk://#diff-cc952701f0175dfa87957fa4c7cd7a67f6d509ab4a82045004ba182e32a4936bL44-R44) [[6]](diffhunk://#diff-fb317bacdd17bf0e92c7b68532d391b39fe27b4a9a14aae9db6bc847f6f928c9L40-R40) [[7]](diffhunk://#diff-157cbff872cda661353d18b7961655435fb6f0b108921e7092888b1a93b831b8L46-R46) [[8]](diffhunk://#diff-fcc066e6cd50912aba35287815355af546675215f42278fdb6f06d9a895aba02L47-R47) [[9]](diffhunk://#diff-ab7d01a20c277af90b8c8555abf8724b5f2041e282a36afe4ba8b990f063dc49L45-R45) [[10]](diffhunk://#diff-98f17f33b01f5dc7d16f46fe6e0ea27e818bf1cc375e38999af57461cab81ef8L46-R46) [[11]](diffhunk://#diff-6dfa8519926288b869c67d9d3fca0b37d3f9e846b3c68077bba248e1d075f8feL76-R76) [[12]](diffhunk://#diff-db162fcf07afe760466cdb97e45a3b766b5a4c2fde90c0a7ca0a4e9f483bbba0L47-R47) [[13]](diffhunk://#diff-5fcfa5326a5190074ba61666507df6ddfeadda60c7928a65ee8dd3ae8b232785R65-R74) [[14]](diffhunk://#diff-5fcfa5326a5190074ba61666507df6ddfeadda60c7928a65ee8dd3ae8b232785R89-R98) [[15]](diffhunk://#diff-aae0cf48b5918ab85cf5558308cb3dd17b4c2996e655820eca3888678bb0ff59L45-R45) [[16]](diffhunk://#diff-325aad549da5d8a500624555110f78c9ac927b88f658af73202d7d45904b197aL219-R219) [[17]](diffhunk://#diff-1e70758cba0fd7edd20c12c6abd0a26803b75df3584164f497662cf1d0c9081fL88-R88)

### Improved type hints and docblocks

* Updated return types and docblocks for collection attributes and methods, such as `users` in `MessageCall`, `changes` in `AuditLog Entry`, `exempt roles` and `exempt channels` in `AutoModeration Rule`, to use `ExCollectionInterface` with proper generic annotations for better type safety and clarity. [[1]](diffhunk://#diff-09ab05abe7f2ce4354830baaa79785389f47ca20cb43bce3b4d729efdab28bb0L30-R32) [[2]](diffhunk://#diff-325aad549da5d8a500624555110f78c9ac927b88f658af73202d7d45904b197aL29-R29) [[3]](diffhunk://#diff-d05326c6de2462d958334ae5cf646f05f7d2769789eab621475b5545c41b6a69L124-R124) [[4]](diffhunk://#diff-d05326c6de2462d958334ae5cf646f05f7d2769789eab621475b5545c41b6a69L148-R148)

### New helper and attribute methods

* Added new attribute getter methods for `allow` and `deny` in `Overwrite` to retrieve `ChannelPermission` objects using `attributePartHelper`. [[1]](diffhunk://#diff-5fcfa5326a5190074ba61666507df6ddfeadda60c7928a65ee8dd3ae8b232785R65-R74) [[2]](diffhunk://#diff-5fcfa5326a5190074ba61666507df6ddfeadda60c7928a65ee8dd3ae8b232785R89-R98)
* Added a getter for the singular `component` attribute in `Component`, using the helper for instantiation.
* Deprecated the `getMessageSnapshotAttribute()` method in favor of a new method, updating its docblock to reflect this.

### Minor improvements and version bump

* Updated the version constant in the `Discord` class to `v10.29.6`.
* Minor docblock and comment improvements for clarity, such as in the `Component` class.
* Added missing imports for collection interfaces in `MessageCall`.