### PR TITLE
Discord's application commands should be stored in a Collection

### DIFF
--- a/src/Discord/Discord.php
+++ b/src/Discord/Discord.php
@@ -356,7 +356,7 @@ class Discord
     /**
      * An array of registered slash commands.
      *
-     * @var RegisteredCommand[]
+     * @var ExCollectionInterface<RegisteredCommand>|RegisteredCommand[]
      */
     protected $application_commands;
 
@@ -401,6 +401,7 @@ class Discord
         $this->token = $options['token'];
         $this->loop = $options['loop'];
         $this->logger = $options['logger'];
+        $this->application_commands = Collection::for(RegisteredCommand::class, 'name');
 
         if (! in_array(php_sapi_name(), ['cli', 'micro'])) {
             $this->logger->critical('DiscordPHP will not run on a webserver. Please use PHP CLI to run a DiscordPHP bot.');


### PR DESCRIPTION
This pull request makes improvements to the way registered slash commands are managed within the `Discord` class. The main changes involve updating the type annotation for the `$application_commands` property and initializing it with a proper collection in the constructor.

**Improvements to slash command management:**

* Updated the type annotation for the `$application_commands` property in the `Discord` class to specify it can be an `ExCollectionInterface<RegisteredCommand>` or an array of `RegisteredCommand` objects, providing better clarity and type safety.
* Initialized the `$application_commands` property in the `Discord` class constructor using `Collection::for(RegisteredCommand::class, 'name')`, ensuring it is always a properly structured collection.