### PR TITLE
Fix missing components in modals

### DIFF
--- a/src/Discord/Parts/Interactions/Interaction.php
+++ b/src/Discord/Parts/Interactions/Interaction.php
@@ -725,7 +725,7 @@ class Interaction extends Part
             }
 
             $components = Collection::for(RequestComponent::class);
-            foreach ($components as $container) {
+            foreach ($interaction->data->components as $container) {
                 if ($container->components) { // e.g. ActionRow
                     foreach ($container->components as $component) {
                         /** @var RequestComponent $component */


### PR DESCRIPTION
This pull request makes a minor update to how components are checked within the `createListener` method in `Interaction.php`. The change simplifies the property checks by directly accessing the properties instead of using `property_exists`. This should make the code cleaner and more reliable when handling the expected object structures.

- Simplified property checks in the `createListener` method of `Interaction.php` by replacing `property_exists` with direct property access for `components` and `component`.