### PR TITLE
Reaction class should use Emoji Part rather than stdClass

### DIFF
--- a/src/Discord/Parts/Channel/Reaction.php
+++ b/src/Discord/Parts/Channel/Reaction.php
@@ -22,7 +22,6 @@ use Discord\Parts\Part;
 use Discord\Parts\Thread\Thread;
 use Discord\Parts\User\User;
 use React\Promise\PromiseInterface;
-use stdClass;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 use function Discord\normalizePartId;
@@ -105,7 +104,7 @@ class Reaction extends Part
     protected function setIdAttribute(string $value): void
     {
         if (! isset($this->attributes['emoji'])) {
-            $this->attributes['emoji'] = new stdClass();
+            $this->attributes['emoji'] = new Emoji($this->discord);
         }
 
         $colonDelimiter = explode(':', $value);

--- a/src/Discord/Parts/Channel/Reaction.php
+++ b/src/Discord/Parts/Channel/Reaction.php
@@ -103,7 +103,7 @@ class Reaction extends Part
      */
     protected function setIdAttribute(string $value): void
     {
-        if (! isset($this->attributes['emoji'])) {
+        if ($this->emoji === null) {
             $this->attributes['emoji'] = new Emoji($this->discord);
         }
 

--- a/src/Discord/Parts/Channel/Reaction.php
+++ b/src/Discord/Parts/Channel/Reaction.php
@@ -104,7 +104,7 @@ class Reaction extends Part
     protected function setIdAttribute(string $value): void
     {
         if ($this->emoji === null) {
-            $this->attributes['emoji'] = new Emoji($this->discord);
+            $this->attributes['emoji'] = $this->factory->part(Emoji::class, [], true);
         }
 
         $colonDelimiter = explode(':', $value);

--- a/src/Discord/Parts/Channel/Reaction.php
+++ b/src/Discord/Parts/Channel/Reaction.php
@@ -104,7 +104,7 @@ class Reaction extends Part
     protected function setIdAttribute(string $value): void
     {
         if ($this->emoji === null) {
-            $this->attributes['emoji'] = $this->factory->part(Emoji::class, [], true);
+            $this->attributes['emoji'] = $this->factory->part(Emoji::class, ['guild_id' => $this->guild_id], true);
         }
 
         $colonDelimiter = explode(':', $value);


### PR DESCRIPTION
This pull request makes a minor improvement to the `Reaction` class in the Discord package by initializing the `emoji` attribute with an `Emoji` object instead of a generic `stdClass`. This change enhances type safety and consistency when handling emoji data.

- Improved emoji initialization:
  * In the `setIdAttribute` method of `Reaction.php`, replaced the initialization of the `emoji` attribute from a `stdClass` to an `Emoji` object for better type safety and clarity.
  * Removed the unused `stdClass` import from `Reaction.php`.