### PR TITLE
Replace potentially slow code with calls to $discord->private_channels

### DIFF
--- a/src/Discord/Parts/Channel/Invite.php
+++ b/src/Discord/Parts/Channel/Invite.php
@@ -158,8 +158,7 @@ class Invite extends Part implements Stringable
                 }
             }
 
-            // @todo potentially slow code
-            if ($channel = $this->discord->getChannel($channelId)) {
+            if ($channel = $this->discord->private_channels->get('id', $channelId)) {
                 return $channel;
             }
         }

--- a/src/Discord/Parts/Channel/Message.php
+++ b/src/Discord/Parts/Channel/Message.php
@@ -467,8 +467,7 @@ class Message extends Part
             }
         }
 
-        // @todo potentially slow
-        if ($channel = $this->discord->getChannel($this->channel_id)) {
+        if ($channel = $this->discord->private_channels->get('id', $this->channel_id)) {
             return $channel;
         }
 
@@ -684,9 +683,8 @@ class Message extends Part
                     $channel = $guild->channels->get('id', $reference->channel_id);
                 }
 
-                // @todo potentially slow
                 if (! $channel && ! isset($this->attributes['referenced_message'])) {
-                    $channel = $this->discord->getChannel($reference->channel_id);
+                    $channel = $this->discord->private_channels->get('id', $reference->channel_id);
                 }
 
                 if ($channel) {

--- a/src/Discord/Parts/Channel/Message/MessageReference.php
+++ b/src/Discord/Parts/Channel/Message/MessageReference.php
@@ -99,8 +99,7 @@ class MessageReference extends Part
             }
         }
 
-        // @todo potentially slow
-        if ($channel = $this->discord->getChannel($this->channel_id)) {
+        if ($channel = $this->discord->private_channels->get('id', $this->channel_id)) {
             return $channel;
         }
 

--- a/src/Discord/Parts/Channel/Poll/PollAnswer.php
+++ b/src/Discord/Parts/Channel/Poll/PollAnswer.php
@@ -92,8 +92,7 @@ class PollAnswer extends Part
             }
         }
 
-        // @todo potentially slow
-        if ($channel = $this->discord->getChannel($this->channel_id)) {
+        if ($channel = $this->discord->private_channels->get('id', $this->channel_id)) {
             return $channel;
         }
 

--- a/src/Discord/Parts/Channel/Reaction.php
+++ b/src/Discord/Parts/Channel/Reaction.php
@@ -281,8 +281,7 @@ class Reaction extends Part
             }
         }
 
-        // @todo potentially slow
-        if ($channel = $this->discord->getChannel($this->channel_id)) {
+        if ($channel = $this->discord->private_channels->get('id', $this->channel_id)) {
             return $channel;
         }
 

--- a/src/Discord/Parts/OAuth/ActivityLocation.php
+++ b/src/Discord/Parts/OAuth/ActivityLocation.php
@@ -66,8 +66,7 @@ class ActivityLocation extends Part
             }
         }
 
-        // @todo potentially slow code
-        if ($channel = $this->discord->getChannel($this->attributes['channel_id'])) {
+        if ($channel = $this->discord->private_channels->get('id', $this->attributes['channel_id'])) {
             return $channel;
         }
 


### PR DESCRIPTION
This pull request refactors how channel lookups are performed throughout several classes, replacing potentially slow calls to `getChannel` with more efficient lookups in the `private_channels` collection. This should improve performance and consistency when resolving channel references, especially for private channels.

**Channel lookup improvements:**

* Updated channel resolution in `Invite`, `Message`, `MessageReference`, `PollAnswer`, `Reaction`, and `ActivityLocation` parts to use `private_channels->get('id', ...)` instead of the slower `getChannel` method. [[1]](diffhunk://#diff-5d2251c005b2ae0591670e794e724dfda058b60941d5c1ca6cfb29bb3e5d83f1L161-R161) [[2]](diffhunk://#diff-3bc0952a87e08969969124672b2539443f4afa2fa67b5fdcddd94944c88eb1ddL470-R470) [[3]](diffhunk://#diff-34b66cdc24be2d103d0e2e963fd7fa3c2e08bf3e6767ada92d56992847f797feL102-R102) [[4]](diffhunk://#diff-5f5b173184ce8c97e9b786465cd4f279f63b27ab3e08e30366fb887927143a35L95-R95) [[5]](diffhunk://#diff-4a261518148db6a3c10e172c9bfc6eb449877b914ef61903089c2260c5a3f8c9L284-R284) [[6]](diffhunk://#diff-a6a8021beb44e39b6891a19f14af174b490014e717bb2357ca5febae13921c0cL69-R69)
* Improved referenced message channel resolution in `Message` to use the `private_channels` collection for fallback lookups.