### PR TITLE
MessageRepository::build

### DIFF
--- a/src/Discord/Repository/Channel/MessageRepository.php
+++ b/src/Discord/Repository/Channel/MessageRepository.php
@@ -80,7 +80,7 @@ class MessageRepository extends AbstractRepository
     public function build($channel, MessageBuilder $message): PromiseInterface
     {
         if (! is_string($channel)) {
-            if (! $channel instanceof Channel || $channel instanceof Thread) {
+            if (! $channel instanceof Channel || ! $channel instanceof Thread) {
                 return reject(new \InvalidArgumentException('The $channel parameter must be a Channel or Thread instance or a string channel ID.'));
             }
             $botperms = $channel->getBotPermissions();

--- a/src/Discord/Repository/Channel/MessageRepository.php
+++ b/src/Discord/Repository/Channel/MessageRepository.php
@@ -72,7 +72,7 @@ class MessageRepository extends AbstractRepository
      *
      * @link https://discord.com/developers/docs/resources/message#create-message
      *
-     * @param Channel|string $channel Channel ID or Channel object.
+     * @param Channel|string $channel Channel or Thread object, or channel ID.
      * @param MessageBuilder $message MessageBuilder instance.
 
      * @return PromiseInterface<Message>

--- a/src/Discord/Repository/Channel/MessageRepository.php
+++ b/src/Discord/Repository/Channel/MessageRepository.php
@@ -81,7 +81,7 @@ class MessageRepository extends AbstractRepository
     {
         if (! is_string($channel)) {
             if (! $channel instanceof Channel || ! $channel instanceof Thread) {
-                return reject(new \InvalidArgumentException('The $channel parameter must be a Channel or Thread instance or a string channel ID.'));
+                return reject(new \InvalidArgumentException('Channel must be a Channel or Thread instance or a string channel ID.'));
             }
             $botperms = $channel->getBotPermissions();
             if ($botperms && ! $botperms->send_messages) {


### PR DESCRIPTION
This pull request adds a new method to the `MessageRepository` class to streamline message creation in Discord channels, including permission checks and support for multipart messages. The update also introduces relevant imports and utility functions to support the new functionality.

**New message creation method and supporting changes:**

* Added a `build` method to `MessageRepository` that allows sending messages to a channel using a `MessageBuilder` instance, with built-in permission checks and support for both JSON and multipart message formats. The method returns a `PromiseInterface<Message>` and optionally accepts an audit log reason.
* Imported `MessageBuilder`, `NoPermissionsException`, `Channel`, and `PromiseInterface` to support the new method. Also imported the `reject` function from React\Promise for handling permission errors.