### PR TITLE
fix: role return type mismatch

### DIFF
--- a/src/Discord/Repository/Guild/RoleRepository.php
+++ b/src/Discord/Repository/Guild/RoleRepository.php
@@ -77,11 +77,13 @@ class RoleRepository extends AbstractRepository
             return null;
         }
 
-        $highestRole = $guild->roles
-            ->filter(fn(Role $role) => $botMember->roles->has($role->id))
-            ->sort(fn(Role $a, Role $b) => $b->comparePosition($a))
-            ->shift();
-        
-        return $shift[array_key_first($highestRole)] ?? null;
+        /** @var array<string, Role> */
+        $role = $guild->roles
+            ->filter(fn (Role $role) => $botMember->roles->has($role->id))
+            ->sort(fn (Role $a, Role $b) => $b->comparePosition($a))
+            ->shift() ?? [];
+
+        /** @var Role|null */
+        return array_shift($role);
     }
 }


### PR DESCRIPTION
## Motivation

Just found out that this method `getCurrentMemberHighestRole()` isn't returning the right type. Your `->shift()` impl returns an `array<mixed, Role>` when the method asks for `?Role`. 

This PR ensures that we will get the right type or just throw null on it. 

```php
    public function getCurrentMemberHighestRole(): ?Role
    {
        if (! $guild = $this->discord->guilds->get('id', $this->vars['guild_id'])) {
            return null;
        }

        if (! $botMember = $guild->members->get('id', $this->discord->id)) {
            return null;
        }

        $highestRole = $guild->roles
            ->filter(fn(Role $role) => $botMember->roles->has($role->id))
            ->sort(fn(Role $a, Role $b) => $b->comparePosition($a))
            ->shift();

        return $shift[array_key_first($highestRole)] ?? null;
    }
```

### Trace

> src/Discord/Parts/User/Member.php:306/350
```php

           if ($botHighestRole = $guild->roles->getCurrentMemberHighestRole()) {
                if ($botHighestRole->comparePosition($this) <= 0) {
                    return reject(new NoPermissionsException("The bot's highest role is not higher than the role {$this->id} in guild {$this->guild_id}."));
                }
            }


I didn't check it there's any easier method to add role to a member. Anyway, hope it helps!