### PR TITLE
Add 'values' to the $fillable array in StringSelect.php

### DIFF
--- a/src/Discord/Parts/Channel/Message/StringSelect.php
+++ b/src/Discord/Parts/Channel/Message/StringSelect.php
@@ -52,6 +52,7 @@ class StringSelect extends SelectMenu
         'max_values',
         'required',
         'disabled',
+        'values',
     ];
 
     /**


### PR DESCRIPTION
Add 'values' to $fillable in StringSelect.php so that modal submission values survive hydration.

Without this, $component->values returns null because the fill() method silently drops keys not in $fillable.