### PR TITLE
SelectMenu magic functions for Type and add missing values

### DIFF
--- a/src/Discord/Parts/Channel/Message/ChannelSelect.php
+++ b/src/Discord/Parts/Channel/Message/ChannelSelect.php
@@ -55,5 +55,8 @@ class ChannelSelect extends SelectMenu
         'max_values',
         'disabled',
         'values',
+
+        // @internal
+        'component_type',
     ];
 }

--- a/src/Discord/Parts/Channel/Message/ChannelSelect.php
+++ b/src/Discord/Parts/Channel/Message/ChannelSelect.php
@@ -37,6 +37,7 @@ use Discord\Helpers\ExCollectionInterface;
  * @property int|null                                           $min_values     Minimum number of items that must be chosen (defaults to 1); min 0, max 25.
  * @property int|null                                           $max_values     Maximum number of items that can be chosen (defaults to 1); max 25.
  * @property bool|null                                          $disabled       Whether select menu is disabled (defaults to false).
+ * @property string[]|null                                      $values         IDs of the selected channels. (Only included in the response).
  */
 class ChannelSelect extends SelectMenu
 {
@@ -53,5 +54,6 @@ class ChannelSelect extends SelectMenu
         'min_values',
         'max_values',
         'disabled',
+        'values',
     ];
 }

--- a/src/Discord/Parts/Channel/Message/MentionableSelect.php
+++ b/src/Discord/Parts/Channel/Message/MentionableSelect.php
@@ -50,5 +50,8 @@ class MentionableSelect extends SelectMenu
         'max_values',
         'disabled',
         'values',
+
+        // @internal
+        'component_type',
     ];
 }

--- a/src/Discord/Parts/Channel/Message/MentionableSelect.php
+++ b/src/Discord/Parts/Channel/Message/MentionableSelect.php
@@ -33,6 +33,7 @@ namespace Discord\Parts\Channel\Message;
  * @property int|null                                           $min_values     Minimum number of items that must be chosen (defaults to 1); min 0, max 25.
  * @property int|null                                           $max_values     Maximum number of items that can be chosen (defaults to 1); max 25.
  * @property bool|null                                          $disabled       Whether select menu is disabled (defaults to false).
+ * @property string[]|null                                      $values         IDs of the selected mentionables. (Only included in the response).
  */
 class MentionableSelect extends SelectMenu
 {
@@ -48,5 +49,6 @@ class MentionableSelect extends SelectMenu
         'min_values',
         'max_values',
         'disabled',
+        'values',
     ];
 }

--- a/src/Discord/Parts/Channel/Message/RoleSelect.php
+++ b/src/Discord/Parts/Channel/Message/RoleSelect.php
@@ -50,5 +50,8 @@ class RoleSelect extends SelectMenu
         'max_values',
         'disabled',
         'values',
+
+        // @internal
+        'component_type',
     ];
 }

--- a/src/Discord/Parts/Channel/Message/RoleSelect.php
+++ b/src/Discord/Parts/Channel/Message/RoleSelect.php
@@ -33,6 +33,7 @@ namespace Discord\Parts\Channel\Message;
  * @property int|null                                           $min_values     Minimum number of items that must be chosen (defaults to 1); min 0, max 25.
  * @property int|null                                           $max_values     Maximum number of items that can be chosen (defaults to 1); max 25.
  * @property bool|null                                          $disabled       Whether select menu is disabled (defaults to false).
+ * @property string[]|null                                      $values         IDs of the selected roles. (Only included in the response).
  */
 class RoleSelect extends SelectMenu
 {
@@ -48,5 +49,6 @@ class RoleSelect extends SelectMenu
         'min_values',
         'max_values',
         'disabled',
+        'values',
     ];
 }

--- a/src/Discord/Parts/Channel/Message/SelectMenu.php
+++ b/src/Discord/Parts/Channel/Message/SelectMenu.php
@@ -28,6 +28,28 @@ use Discord\Helpers\ExCollectionInterface;
  */
 abstract class SelectMenu extends Interactive
 {
+    /** 
+     * Gets the type of the select menu.
+     * 
+     * In message interaction responses `component_type` will be returned and in modal interaction responses `type` will be returned.
+     * 
+     * @return int
+     */
+    protected function getTypeAttribute(): int
+    {
+        return $this->attributes['type'] ?? $this->attributes['component_type'];
+    }
+
+    /**
+     * Gets the values selected in a select menu. (Only for Message Component)
+     * 
+     * @return string[]|null
+     */
+    protected function getValuesAttribute(): ?array
+    {
+        return $this->attributes['values'] ?? null;
+    }
+
     protected function getDefaultValuesAttribute(): ExCollectionInterface
     {
         return $this->attributeCollectionHelper('default_values', DefaultValue::class);

--- a/src/Discord/Parts/Channel/Message/SelectMenu.php
+++ b/src/Discord/Parts/Channel/Message/SelectMenu.php
@@ -40,16 +40,6 @@ abstract class SelectMenu extends Interactive
         return $this->attributes['type'] ?? $this->attributes['component_type'];
     }
 
-    /**
-     * Gets the values selected in a select menu. (Only for Message Component)
-     * 
-     * @return string[]|null
-     */
-    protected function getValuesAttribute(): ?array
-    {
-        return $this->attributes['values'] ?? null;
-    }
-
     protected function getDefaultValuesAttribute(): ExCollectionInterface
     {
         return $this->attributeCollectionHelper('default_values', DefaultValue::class);

--- a/src/Discord/Parts/Channel/Message/SelectMenu.php
+++ b/src/Discord/Parts/Channel/Message/SelectMenu.php
@@ -28,11 +28,11 @@ use Discord\Helpers\ExCollectionInterface;
  */
 abstract class SelectMenu extends Interactive
 {
-    /** 
+    /**
      * Gets the type of the select menu.
-     * 
+     *
      * In message interaction responses `component_type` will be returned and in modal interaction responses `type` will be returned.
-     * 
+     *
      * @return int
      */
     protected function getTypeAttribute(): int

--- a/src/Discord/Parts/Channel/Message/StringSelect.php
+++ b/src/Discord/Parts/Channel/Message/StringSelect.php
@@ -36,6 +36,7 @@ use Discord\Helpers\ExCollectionInterface;
  * @property int|null                                                       $max_values  Maximum number of items that can be chosen (defaults to 1); max 25.
  * @property bool|null                                                      $required    Whether the string select is required to answer in a modal (defaults to true).
  * @property bool|null                                                      $disabled    Whether select menu is disabled (defaults to false). Using in a modal will result in an error.
+ * @property string[]|null                                                  $values      The text of the selected options. (Only included in the response).
  */
 class StringSelect extends SelectMenu
 {
@@ -52,6 +53,7 @@ class StringSelect extends SelectMenu
         'max_values',
         'required',
         'disabled',
+        'values', 
     ];
 
     /**

--- a/src/Discord/Parts/Channel/Message/StringSelect.php
+++ b/src/Discord/Parts/Channel/Message/StringSelect.php
@@ -53,7 +53,7 @@ class StringSelect extends SelectMenu
         'max_values',
         'required',
         'disabled',
-        'values', 
+        'values',
 
         // @internal
         'component_type',

--- a/src/Discord/Parts/Channel/Message/StringSelect.php
+++ b/src/Discord/Parts/Channel/Message/StringSelect.php
@@ -54,6 +54,9 @@ class StringSelect extends SelectMenu
         'required',
         'disabled',
         'values', 
+
+        // @internal
+        'component_type',
     ];
 
     /**

--- a/src/Discord/Parts/Channel/Message/UserSelect.php
+++ b/src/Discord/Parts/Channel/Message/UserSelect.php
@@ -35,6 +35,7 @@ use Discord\Helpers\ExCollectionInterface;
  * @property int|null                                           $min_values     Minimum number of items that must be chosen (defaults to 1); min 0, max 25.
  * @property int|null                                           $max_values     Maximum number of items that can be chosen (defaults to 1); max 25.
  * @property bool|null                                          $disabled       Whether select menu is disabled (defaults to false).
+ * @property string[]|null                                      $values         IDs of the selected users. (Only included in the response).
  */
 class UserSelect extends SelectMenu
 {
@@ -50,5 +51,6 @@ class UserSelect extends SelectMenu
         'min_values',
         'max_values',
         'disabled',
+        'values',
     ];
 }

--- a/src/Discord/Parts/Channel/Message/UserSelect.php
+++ b/src/Discord/Parts/Channel/Message/UserSelect.php
@@ -52,5 +52,8 @@ class UserSelect extends SelectMenu
         'max_values',
         'disabled',
         'values',
+
+        // @internal
+        'component_type',
     ];
 }

--- a/src/Discord/Parts/PartTrait.php
+++ b/src/Discord/Parts/PartTrait.php
@@ -538,7 +538,7 @@ trait PartTrait
 
         foreach ($this->attributes[$key] as &$part) {
             if (! $part instanceof $class) {
-                $part = $this->createOf($class::TYPES[$part->type ?? 0], $part);
+                $part = $this->createOf($class::TYPES[$part->type ?? $part->component_type ?? 0], $part);
             }
             $collection->pushItem($part);
         }


### PR DESCRIPTION
This pull request enhances the select menu components in the Discord PHP library to provide better support for interaction responses. The main improvements involve consistently exposing the selected values for each select menu type and improving handling of the select menu type attribute to support both message and modal interactions.

**Select menu value handling improvements:**

* Added a `values` property to `ChannelSelect`, `MentionableSelect`, `RoleSelect`, `StringSelect`, and `UserSelect` classes to expose the selected IDs or option texts in interaction responses. This makes it easier to access selected items from user interactions. [[1]](diffhunk://#diff-d012c30ed9476145cb084696678421013542d07e51024eecabb1de8bdb4555b0R40) [[2]](diffhunk://#diff-8dcc0be9aa1c206b4749e14cceb1b00764dbf8486ff3b8c624fd3a7e85c03007R36) [[3]](diffhunk://#diff-d957b71a6bce71cd8012bb552ede81a78f442f18dc3bbbc5a332cc930721ac01R36) [[4]](diffhunk://#diff-1643165363ab0dc3f091203032969b0576ad3f292ad56d74bcf6f91fad84b538R39) [[5]](diffhunk://#diff-9796528bc93ca6ab10e46166801fd5a88911e6a7104a6d5a30c8ca7303dc1106R38)
* Updated the `$fillable` arrays in all select menu classes to include the new `values` property and the internal `component_type` field, ensuring these attributes are correctly handled during hydration. [[1]](diffhunk://#diff-d012c30ed9476145cb084696678421013542d07e51024eecabb1de8bdb4555b0R57-R60) [[2]](diffhunk://#diff-8dcc0be9aa1c206b4749e14cceb1b00764dbf8486ff3b8c624fd3a7e85c03007R52-R55) [[3]](diffhunk://#diff-d957b71a6bce71cd8012bb552ede81a78f442f18dc3bbbc5a332cc930721ac01R52-R55) [[4]](diffhunk://#diff-1643165363ab0dc3f091203032969b0576ad3f292ad56d74bcf6f91fad84b538R56-R59) [[5]](diffhunk://#diff-9796528bc93ca6ab10e46166801fd5a88911e6a7104a6d5a30c8ca7303dc1106R54-R57)

**Type attribute and collection handling enhancements:**

* Added a `getTypeAttribute` method to the base `SelectMenu` class to correctly resolve the select menu type from either the `type` or `component_type` attribute, supporting both message and modal interaction responses.
* Improved the `attributeTypedCollectionHelper` method in `PartTrait` to check both `type` and `component_type` when determining the select menu type, increasing compatibility with different Discord interaction payloads.