### PR TITLE
fix: Embed::addField off-by-one (26th field accepted) + centralised payload limits

### DIFF
--- a/src/Discord/Helpers/ValidatesDiscordLimits.php
+++ b/src/Discord/Helpers/ValidatesDiscordLimits.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is a part of the DiscordPHP project.
+ *
+ * Copyright (c) 2015-2022 David Cole <david.cole1340@gmail.com>
+ * Copyright (c) 2020-present Valithor Obsidion <valithor@discordphp.org>
+ *
+ * This file is subject to the MIT license that is bundled
+ * with this source code in the LICENSE.md file.
+ */
+
+namespace Discord\Helpers;
+
+/**
+ * Centralises Discord API payload size limits as shared constants.
+ *
+ * Classes that produce or validate Discord-bound payloads implement this
+ * interface to expose consistent limits in a single location. Grouping
+ * them prevents the "magic number" drift that happens when the same
+ * limit is repeated across builders and parts.
+ *
+ * @link https://docs.discord.com/developers/resources/message#embed-object-embed-limits
+ * @link https://docs.discord.com/developers/resources/message#create-message
+ *
+ * @since 10.48.0
+ */
+interface ValidatesDiscordLimits
+{
+    /** Maximum characters in an embed title. */
+    public const EMBED_TITLE_MAX = 256;
+
+    /** Maximum characters in an embed description. */
+    public const EMBED_DESCRIPTION_MAX = 4096;
+
+    /** Maximum characters in an embed author name. */
+    public const EMBED_AUTHOR_NAME_MAX = 256;
+
+    /** Maximum characters in an embed footer text. */
+    public const EMBED_FOOTER_TEXT_MAX = 2048;
+
+    /** Maximum characters in an embed field name. */
+    public const EMBED_FIELD_NAME_MAX = 256;
+
+    /** Maximum characters in an embed field value. */
+    public const EMBED_FIELD_VALUE_MAX = 1024;
+
+    /** Maximum number of fields in an embed. */
+    public const EMBED_FIELDS_MAX = 25;
+
+    /** Maximum combined characters across all embed text fields. */
+    public const EMBED_TOTAL_CHARS_MAX = 6000;
+
+    /** Maximum characters in a message content field. */
+    public const MESSAGE_CONTENT_MAX = 2000;
+
+    /** Maximum embeds attached to a single message. */
+    public const MESSAGE_EMBEDS_MAX = 10;
+
+    /** Maximum file attachments on a single message. */
+    public const MESSAGE_FILES_MAX = 10;
+}

--- a/src/Discord/Parts/Embed/Embed.php
+++ b/src/Discord/Parts/Embed/Embed.php
@@ -213,10 +213,10 @@ class Embed extends Part implements ValidatesDiscordLimits
         if (poly_strlen($description) === 0) {
             $this->attributes['description'] = null;
         } elseif (poly_strlen($description) > self::EMBED_DESCRIPTION_MAX) {
-            throw new \LengthException(sprintf('Embed description can not be longer than %d characters', self::EMBED_DESCRIPTION_MAX));
+            throw new \LengthException('Embed description can not be longer than 4096 characters');
         } else {
             if ($this->exceedsOverallLimit(poly_strlen($description))) {
-                throw new \LengthException(sprintf('Embed text values collectively can not exceed %d characters', self::EMBED_TOTAL_CHARS_MAX));
+                throw new \LengthException('Embed text values collectively can not exceed 6000 characters');
             }
 
             $this->attributes['description'] = $description;
@@ -255,9 +255,9 @@ class Embed extends Part implements ValidatesDiscordLimits
         if (poly_strlen($title) === 0) {
             $this->attributes['title'] = null;
         } elseif (poly_strlen($title) > self::EMBED_TITLE_MAX) {
-            throw new \LengthException(sprintf('Embed title can not be longer than %d characters', self::EMBED_TITLE_MAX));
+            throw new \LengthException('Embed title can not be longer than 256 characters');
         } elseif ($this->exceedsOverallLimit(poly_strlen($title))) {
-            throw new \LengthException(sprintf('Embed text values collectively can not exceed %d characters', self::EMBED_TOTAL_CHARS_MAX));
+            throw new \LengthException('Embed text values collectively can not exceed 6000 characters');
         } else {
             $this->attributes['title'] = $title;
         }
@@ -336,7 +336,7 @@ class Embed extends Part implements ValidatesDiscordLimits
     {
         foreach ($fields as $field) {
             if (count($this->fields) >= self::EMBED_FIELDS_MAX) {
-                throw new \OverflowException(sprintf('Embeds can not have more than %d fields.', self::EMBED_FIELDS_MAX));
+                throw new \OverflowException('Embeds can not have more than 25 fields.');
             }
 
             if ($field instanceof Field) {
@@ -347,15 +347,15 @@ class Embed extends Part implements ValidatesDiscordLimits
             $value = is_string($field['value'] ?? null) ? $field['value'] : '';
 
             if (poly_strlen($name) > self::EMBED_FIELD_NAME_MAX) {
-                throw new \LengthException(sprintf('Embed field name can not be longer than %d characters', self::EMBED_FIELD_NAME_MAX));
+                throw new \LengthException('Embed field name can not be longer than 256 characters');
             }
 
             if (poly_strlen($value) > self::EMBED_FIELD_VALUE_MAX) {
-                throw new \LengthException(sprintf('Embed field value can not be longer than %d characters', self::EMBED_FIELD_VALUE_MAX));
+                throw new \LengthException('Embed field value can not be longer than 1024 characters');
             }
 
             if ($this->exceedsOverallLimit(poly_strlen($name) + poly_strlen($value))) {
-                throw new \LengthException(sprintf('Embed text values collectively can not exceed %d characters', self::EMBED_TOTAL_CHARS_MAX));
+                throw new \LengthException('Embed text values collectively can not exceed 6000 characters');
             }
 
             $this->attributes['fields'][] = $field;
@@ -402,9 +402,9 @@ class Embed extends Part implements ValidatesDiscordLimits
         if ($length === 0) {
             $this->author = null;
         } elseif ($length > self::EMBED_AUTHOR_NAME_MAX) {
-            throw new \LengthException(sprintf('Author name can not be longer than %d characters.', self::EMBED_AUTHOR_NAME_MAX));
+            throw new \LengthException('Author name can not be longer than 256 characters.');
         } elseif ($this->exceedsOverallLimit($length)) {
-            throw new \LengthException(sprintf('Embed text values collectively can not exceed %d characters', self::EMBED_TOTAL_CHARS_MAX));
+            throw new \LengthException('Embed text values collectively can not exceed 6000 characters');
         }
 
         if ($iconurl instanceof Attachment) {
@@ -441,9 +441,9 @@ class Embed extends Part implements ValidatesDiscordLimits
         if ($length === 0) {
             $this->footer = null;
         } elseif ($length > self::EMBED_FOOTER_TEXT_MAX) {
-            throw new \LengthException(sprintf('Footer text can not be longer than %d characters.', self::EMBED_FOOTER_TEXT_MAX));
+            throw new \LengthException('Footer text can not be longer than 2048 characters.');
         } elseif ($this->exceedsOverallLimit($length)) {
-            throw new \LengthException(sprintf('Embed text values collectively can not exceed %d characters', self::EMBED_TOTAL_CHARS_MAX));
+            throw new \LengthException('Embed text values collectively can not exceed 6000 characters');
         }
 
         if ($iconurl instanceof Attachment) {

--- a/src/Discord/Parts/Embed/Embed.php
+++ b/src/Discord/Parts/Embed/Embed.php
@@ -16,6 +16,7 @@ namespace Discord\Parts\Embed;
 
 use Carbon\Carbon;
 use Discord\Helpers\ExCollectionInterface;
+use Discord\Helpers\ValidatesDiscordLimits;
 use Discord\Parts\Channel\Attachment;
 use Discord\Parts\Part;
 
@@ -44,7 +45,7 @@ use function Discord\poly_strlen;
  * @property      ?ExCollectionInterface<Field>|Field[] $fields      A collection of embed fields (max of 25).
  * @property      ?int|null                             $flags       Embedded flags combined as a bitfield.
  */
-class Embed extends Part
+class Embed extends Part implements ValidatesDiscordLimits
 {
     public const TYPES = [
         0 => Embed::class, // Fallback for unknown types
@@ -211,11 +212,11 @@ class Embed extends Part
     {
         if (poly_strlen($description) === 0) {
             $this->attributes['description'] = null;
-        } elseif (poly_strlen($description) > 4096) {
-            throw new \LengthException('Embed description can not be longer than 4096 characters');
+        } elseif (poly_strlen($description) > self::EMBED_DESCRIPTION_MAX) {
+            throw new \LengthException('Embed description can not be longer than '.self::EMBED_DESCRIPTION_MAX.' characters');
         } else {
             if ($this->exceedsOverallLimit(poly_strlen($description))) {
-                throw new \LengthException('Embed text values collectively can not exceed than 6000 characters');
+                throw new \LengthException('Embed text values collectively can not exceed '.self::EMBED_TOTAL_CHARS_MAX.' characters');
             }
 
             $this->attributes['description'] = $description;
@@ -253,10 +254,10 @@ class Embed extends Part
     {
         if (poly_strlen($title) === 0) {
             $this->attributes['title'] = null;
-        } elseif (poly_strlen($title) > 256) {
-            throw new \LengthException('Embed title can not be longer than 256 characters');
+        } elseif (poly_strlen($title) > self::EMBED_TITLE_MAX) {
+            throw new \LengthException('Embed title can not be longer than '.self::EMBED_TITLE_MAX.' characters');
         } elseif ($this->exceedsOverallLimit(poly_strlen($title))) {
-            throw new \LengthException('Embed text values collectively can not exceed than 6000 characters');
+            throw new \LengthException('Embed text values collectively can not exceed '.self::EMBED_TOTAL_CHARS_MAX.' characters');
         } else {
             $this->attributes['title'] = $title;
         }
@@ -334,12 +335,27 @@ class Embed extends Part
     public function addField(...$fields): self
     {
         foreach ($fields as $field) {
-            if (count($this->fields) > 25) {
-                throw new \OverflowException('Embeds can not have more than 25 fields.');
+            if (count($this->fields) >= self::EMBED_FIELDS_MAX) {
+                throw new \OverflowException('Embeds can not have more than '.self::EMBED_FIELDS_MAX.' fields.');
             }
 
             if ($field instanceof Field) {
                 $field = $field->getRawAttributes();
+            }
+
+            $name = is_string($field['name'] ?? null) ? $field['name'] : '';
+            $value = is_string($field['value'] ?? null) ? $field['value'] : '';
+
+            if (poly_strlen($name) > self::EMBED_FIELD_NAME_MAX) {
+                throw new \LengthException('Embed field name can not be longer than '.self::EMBED_FIELD_NAME_MAX.' characters');
+            }
+
+            if (poly_strlen($value) > self::EMBED_FIELD_VALUE_MAX) {
+                throw new \LengthException('Embed field value can not be longer than '.self::EMBED_FIELD_VALUE_MAX.' characters');
+            }
+
+            if ($this->exceedsOverallLimit(poly_strlen($name) + poly_strlen($value))) {
+                throw new \LengthException('Embed text values collectively can not exceed '.self::EMBED_TOTAL_CHARS_MAX.' characters');
             }
 
             $this->attributes['fields'][] = $field;
@@ -385,10 +401,10 @@ class Embed extends Part
         $length = poly_strlen($name);
         if ($length === 0) {
             $this->author = null;
-        } elseif ($length > 256) {
-            throw new \LengthException('Author name can not be longer than 256 characters.');
+        } elseif ($length > self::EMBED_AUTHOR_NAME_MAX) {
+            throw new \LengthException('Author name can not be longer than '.self::EMBED_AUTHOR_NAME_MAX.' characters.');
         } elseif ($this->exceedsOverallLimit($length)) {
-            throw new \LengthException('Embed text values collectively can not exceed than 6000 characters');
+            throw new \LengthException('Embed text values collectively can not exceed '.self::EMBED_TOTAL_CHARS_MAX.' characters');
         }
 
         if ($iconurl instanceof Attachment) {
@@ -424,10 +440,10 @@ class Embed extends Part
         $length = poly_strlen($text);
         if ($length === 0) {
             $this->footer = null;
-        } elseif ($length > 2048) {
-            throw new \LengthException('Footer text can not be longer than 2048 characters.');
+        } elseif ($length > self::EMBED_FOOTER_TEXT_MAX) {
+            throw new \LengthException('Footer text can not be longer than '.self::EMBED_FOOTER_TEXT_MAX.' characters.');
         } elseif ($this->exceedsOverallLimit($length)) {
-            throw new \LengthException('Embed text values collectively can not exceed than 6000 characters');
+            throw new \LengthException('Embed text values collectively can not exceed '.self::EMBED_TOTAL_CHARS_MAX.' characters');
         }
 
         if ($iconurl instanceof Attachment) {
@@ -556,7 +572,7 @@ class Embed extends Part
             $total += poly_strlen($field['value']);
         }
 
-        return ($total > 6000);
+        return ($total > self::EMBED_TOTAL_CHARS_MAX);
     }
 
     /**

--- a/src/Discord/Parts/Embed/Embed.php
+++ b/src/Discord/Parts/Embed/Embed.php
@@ -213,10 +213,10 @@ class Embed extends Part implements ValidatesDiscordLimits
         if (poly_strlen($description) === 0) {
             $this->attributes['description'] = null;
         } elseif (poly_strlen($description) > self::EMBED_DESCRIPTION_MAX) {
-            throw new \LengthException('Embed description can not be longer than '.self::EMBED_DESCRIPTION_MAX.' characters');
+            throw new \LengthException(sprintf('Embed description can not be longer than %d characters', self::EMBED_DESCRIPTION_MAX));
         } else {
             if ($this->exceedsOverallLimit(poly_strlen($description))) {
-                throw new \LengthException('Embed text values collectively can not exceed '.self::EMBED_TOTAL_CHARS_MAX.' characters');
+                throw new \LengthException(sprintf('Embed text values collectively can not exceed %d characters', self::EMBED_TOTAL_CHARS_MAX));
             }
 
             $this->attributes['description'] = $description;
@@ -255,9 +255,9 @@ class Embed extends Part implements ValidatesDiscordLimits
         if (poly_strlen($title) === 0) {
             $this->attributes['title'] = null;
         } elseif (poly_strlen($title) > self::EMBED_TITLE_MAX) {
-            throw new \LengthException('Embed title can not be longer than '.self::EMBED_TITLE_MAX.' characters');
+            throw new \LengthException(sprintf('Embed title can not be longer than %d characters', self::EMBED_TITLE_MAX));
         } elseif ($this->exceedsOverallLimit(poly_strlen($title))) {
-            throw new \LengthException('Embed text values collectively can not exceed '.self::EMBED_TOTAL_CHARS_MAX.' characters');
+            throw new \LengthException(sprintf('Embed text values collectively can not exceed %d characters', self::EMBED_TOTAL_CHARS_MAX));
         } else {
             $this->attributes['title'] = $title;
         }
@@ -336,7 +336,7 @@ class Embed extends Part implements ValidatesDiscordLimits
     {
         foreach ($fields as $field) {
             if (count($this->fields) >= self::EMBED_FIELDS_MAX) {
-                throw new \OverflowException('Embeds can not have more than '.self::EMBED_FIELDS_MAX.' fields.');
+                throw new \OverflowException(sprintf('Embeds can not have more than %d fields.', self::EMBED_FIELDS_MAX));
             }
 
             if ($field instanceof Field) {
@@ -347,15 +347,15 @@ class Embed extends Part implements ValidatesDiscordLimits
             $value = is_string($field['value'] ?? null) ? $field['value'] : '';
 
             if (poly_strlen($name) > self::EMBED_FIELD_NAME_MAX) {
-                throw new \LengthException('Embed field name can not be longer than '.self::EMBED_FIELD_NAME_MAX.' characters');
+                throw new \LengthException(sprintf('Embed field name can not be longer than %d characters', self::EMBED_FIELD_NAME_MAX));
             }
 
             if (poly_strlen($value) > self::EMBED_FIELD_VALUE_MAX) {
-                throw new \LengthException('Embed field value can not be longer than '.self::EMBED_FIELD_VALUE_MAX.' characters');
+                throw new \LengthException(sprintf('Embed field value can not be longer than %d characters', self::EMBED_FIELD_VALUE_MAX));
             }
 
             if ($this->exceedsOverallLimit(poly_strlen($name) + poly_strlen($value))) {
-                throw new \LengthException('Embed text values collectively can not exceed '.self::EMBED_TOTAL_CHARS_MAX.' characters');
+                throw new \LengthException(sprintf('Embed text values collectively can not exceed %d characters', self::EMBED_TOTAL_CHARS_MAX));
             }
 
             $this->attributes['fields'][] = $field;
@@ -402,9 +402,9 @@ class Embed extends Part implements ValidatesDiscordLimits
         if ($length === 0) {
             $this->author = null;
         } elseif ($length > self::EMBED_AUTHOR_NAME_MAX) {
-            throw new \LengthException('Author name can not be longer than '.self::EMBED_AUTHOR_NAME_MAX.' characters.');
+            throw new \LengthException(sprintf('Author name can not be longer than %d characters.', self::EMBED_AUTHOR_NAME_MAX));
         } elseif ($this->exceedsOverallLimit($length)) {
-            throw new \LengthException('Embed text values collectively can not exceed '.self::EMBED_TOTAL_CHARS_MAX.' characters');
+            throw new \LengthException(sprintf('Embed text values collectively can not exceed %d characters', self::EMBED_TOTAL_CHARS_MAX));
         }
 
         if ($iconurl instanceof Attachment) {
@@ -441,9 +441,9 @@ class Embed extends Part implements ValidatesDiscordLimits
         if ($length === 0) {
             $this->footer = null;
         } elseif ($length > self::EMBED_FOOTER_TEXT_MAX) {
-            throw new \LengthException('Footer text can not be longer than '.self::EMBED_FOOTER_TEXT_MAX.' characters.');
+            throw new \LengthException(sprintf('Footer text can not be longer than %d characters.', self::EMBED_FOOTER_TEXT_MAX));
         } elseif ($this->exceedsOverallLimit($length)) {
-            throw new \LengthException('Embed text values collectively can not exceed '.self::EMBED_TOTAL_CHARS_MAX.' characters');
+            throw new \LengthException(sprintf('Embed text values collectively can not exceed %d characters', self::EMBED_TOTAL_CHARS_MAX));
         }
 
         if ($iconurl instanceof Attachment) {


### PR DESCRIPTION
## Summary

- **Bug fix**: \`Embed::addField()\` rejects only when the embed already has *more than* 25 fields (\`count > 25\`), so a 26th field is accepted and Discord replies with HTTP 400. Tightened to \`>= EMBED_FIELDS_MAX\` so the 26th call throws up front.
- Added the per-field validations the docstring already promised: field name ≤ 256 chars, field value ≤ 1024 chars, combined embed text ≤ 6000 chars.
- Introduced \`Discord\\Helpers\\ValidatesDiscordLimits\` — an interface that centralises Discord's documented payload limits (embed + message) as constants, replacing hard-coded literals scattered across \`Embed.php\`. Other builders can adopt it incrementally.

## Test plan

- [x] \`./vendor/bin/pint --test\` — pass on modified files
- [x] \`./vendor/bin/phpstan --level=max\` — zero regression on touched files (59 → 59)
- [x] \`./vendor/bin/mago lint\` — zero regression vs baseline

## Note

Per the split-PRs review feedback, this PR contains **only the source fix**. A follow-up PR will add the regression + adversarial unit tests (16 tests, Infection MSI 86%) against \`Embed.php\` once this lands.