### PR TITLE
Add AI Skills Infrastructure

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,313 @@
+# DiscordPHP Agent Guide
+
+This file is the repo operating manual for AI agents. Use it together with `SKILLS.md`.
+
+- `SKILLS.md` tells you **which specialist mindset to load** for a task.
+- `AGENTS.md` tells you **how to work inside this repository without breaking its design**.
+
+If a change crosses layers, load multiple skills and use the playbooks in this file to keep boundaries clean.
+
+## Start here
+
+Before changing anything:
+
+1. Identify the layer you are touching.
+2. Read the base abstraction for that layer before copying a concrete class.
+3. Read one representative concrete implementation from the same family.
+4. Trace how that layer connects to adjacent layers.
+5. Make the change in the narrowest layer that can own it.
+6. Update companion surfaces that define the same contract.
+
+In this repo, companion surfaces usually matter as much as the line you edit.
+
+## Non-negotiable truths
+
+1. **CLI-only runtime.** DiscordPHP is a long-running process built on ReactPHP. Do not design around web requests, controllers, middleware stacks, or per-request state.
+2. **Async first.** Production I/O is Promise-based. Blocking helpers belong in tests only.
+3. **Parts are canonical domain objects.** They model Discord resources and expose typed magic properties.
+4. **Repositories are persistence and cache boundaries.** They are not generic service classes.
+5. **Gateway handlers keep caches coherent.** They do more than relay notifications.
+6. **Builders own outbound payload rules.** If a payload has meaningful shape or validation, it usually deserves a builder.
+7. **Docblocks are runtime-adjacent documentation.** They are not optional decoration.
+8. **Traits are preferred over deep inheritance or broad interface hierarchies for shared behavior.**
+9. **Type maps are central dispatch points.** If a Discord payload is polymorphic, there is usually one place that decides the concrete subtype.
+
+## Architecture map
+
+| Layer | Owns | Primary files | What to preserve |
+| --- | --- | --- | --- |
+| Runtime | process lifecycle, options, loop, gateway, HTTP, root repos | `src/Discord/Discord.php` | `__construct()` wires dependencies and connects; `run()` only starts loop |
+| Factory | part/repository instantiation | `src/Discord/Factory/Factory.php` | callers should not construct repo families ad hoc |
+| Parts | domain objects, mutators, typed nested data, high-level operations | `src/Discord/Parts/Part.php`, `src/Discord/Parts/PartTrait.php`, `src/Discord/Parts/**/*` | `$fillable`, mutators, PHPDoc, `save()` semantics, `created` lifecycle |
+| Repositories | typed collections, cache, REST endpoints, CRUD | `src/Discord/Repository/AbstractRepository.php`, `src/Discord/Repository/**/*` | `$class`, `$endpoints`, `$vars`, cache writes, Promise-based API |
+| Builders | outbound payload construction and validation | `src/Discord/Builders/**/*` | fluent setters, validation, `jsonSerialize()`, `fromPart()` symmetry |
+| Gateway events | payload hydration, cache mutation, emitted return shapes | `src/Discord/WebSockets/Handlers.php`, `src/Discord/WebSockets/Event.php`, `src/Discord/WebSockets/Events/*` | typed part creation, related cache updates, event contract shape |
+| Optional command layer | message-prefix command UX | `src/Discord/DiscordCommandClient.php`, `src/Discord/CommandClient/Command.php` | keep it layered on top of core client, not inside it |
+| Tests and docs | behavioral contract | `tests/*`, `guide/*`, `README.md`, `docs/*` | async testing patterns, public guidance, docblock reference surface |
+
+## Repo worldview
+
+### Runtime to domain flow
+
+`Discord` owns bootstrapping. Gateway dispatch goes through `Handlers` into a dedicated event class. Event classes translate payloads into typed parts and update repositories. Repositories provide cache and REST persistence. Parts expose that state through magic properties and typed helpers. Builders assemble outbound payloads for operations that would otherwise become fragile arrays.
+
+### Why the split matters
+
+- If you put transport logic in parts, parts stop being stable domain objects.
+- If you put domain validation in repositories, repository APIs stop being predictable.
+- If you skip builders, payload rules spread across unrelated methods.
+- If gateway handlers do not update caches correctly, every downstream relation becomes stale.
+
+## Common class patterns
+
+### Parts
+
+Expect these elements on real resource models:
+
+- large class-level `@property` and `@property-read` docblocks
+- `protected $fillable = [...]`
+- optional `protected $repositories = [...]`
+- constants mirroring Discord enums or flags
+- `getXAttribute()` and `setXAttribute()` mutators
+- overrides for `getCreatableAttributes()`, `getUpdatableAttributes()`, `getRepository()`, `save()`, `fetch()`, or `getRepositoryAttributes()` when the part is persistable
+
+Semantic rules:
+
+- raw attribute names stay snake_case to match Discord payloads
+- convenience relations (`guild`, `channel`, `owner`, `member`) are usually computed, not directly stored
+- nested typed data should become a `Part`, typed collection, or `Carbon` value through helper methods
+- permission checks for high-level mutations belong on the part before repository delegation
+- `created` tells you whether the object already exists remotely
+
+### Repositories
+
+Expect these elements:
+
+- `extends AbstractRepository`
+- `protected $class = SomePart::class`
+- `protected $endpoints = [...]`
+- optional constructor normalization for route vars
+- occasional domain-specific convenience methods
+
+Semantic rules:
+
+- repositories are typed collections plus REST/cache wrappers
+- `create()` builds a local part; `save()` persists it
+- `$vars` carries parent route context like `guild_id` or `channel_id`
+- cache writes must stay aligned with REST writes and gateway updates
+- special methods should still return typed parts or repositories, not loose payloads
+
+### Builders
+
+Expect these elements:
+
+- `extends Builder`
+- `implements JsonSerializable`
+- fluent `setX()` / `getX()` methods
+- eager validation in setters or adders
+- `new()` factory method on most builders
+- `create($repository)` helper on newer builders
+
+Semantic rules:
+
+- builders are not parts and should not own persistence or cache logic
+- validation belongs here when it describes outgoing payload shape
+- `jsonSerialize()` should omit unset optionals when Discord distinguishes missing from explicit null
+- `fromPart()` should make edit flows symmetrical
+
+### Gateway events
+
+Expect these elements:
+
+- one class per event type under `src/Discord/WebSockets/Events`
+- matching constant in `src/Discord/WebSockets/Event.php`
+- matching registration in `src/Discord/WebSockets/Handlers.php`
+- `handle($data)` method returning typed semantic values
+
+Semantic rules:
+
+- event handlers should hydrate the right subtype on first read
+- event handlers are responsible for repository/cache coherence
+- update events often return both new and old state
+- delete events often return cached removed state, not only the raw payload id
+- related user/member caches usually need updating too
+
+## Cross-layer rules
+
+### 1. Parts delegate persistence; repositories own REST
+
+If a part can be saved:
+
+- the part decides **whether** the action is allowed and which repository owns it
+- the repository decides **how** to call Discord and update cache
+
+Smell: a part method manually building endpoints and PATCH payloads when a repository already exists for that family.
+
+### 2. Parts own semantics; builders own payload ergonomics
+
+If userland needs to construct a non-trivial outbound payload:
+
+- add or extend a builder
+- keep raw-array construction as an implementation detail only when a builder would be needless overhead
+
+Smell: multiple methods assembling the same nested array by hand.
+
+### 3. Gateway events own reactive cache updates
+
+If Discord can tell us something through gateway dispatch:
+
+- prefer updating cache from the event instead of forcing later REST refetches
+- keep parent/child repository relationships coherent at the same time
+
+Smell: event handler creates a part but does not update the repository that should own it.
+
+### 4. Traits carry horizontal behavior
+
+The codebase prefers traits for shared capabilities across sibling models.
+
+Examples:
+
+- `PartTrait` for universal part mechanics
+- `ChannelTrait` for channel/thread behavior
+- `GuildTrait` for guild asset and feature helpers
+- `DynamicPropertyMutatorTrait` for builder/property mutators
+
+Smell: new abstract intermediate base class that only exists to share a few methods between peers that already have a common root.
+
+### 5. Type maps beat repeated branching
+
+When a Discord discriminator chooses a subtype:
+
+- extend the relevant `TYPES` map
+- update all materialization sites that depend on that family
+
+Smell: one event handler special-cases a new subtype but the central type map still does not know it.
+
+## Common companion surfaces
+
+If you touch one of these, inspect the companions too:
+
+| Touching | Also inspect |
+| --- | --- |
+| `src/Discord/Parts/Part.php` or `PartTrait.php` | representative parts, `PartInterface`, generated docblocks |
+| a concrete `Part` | owning repository, related trait, event handlers, tests, docs |
+| a nested repository relationship | parent part `$repositories`, `getRepositoryAttributes()`, repository constructor vars |
+| `src/Discord/Repository/AbstractRepository*` | representative repos, cache wrapper behavior, part save/fetch overrides |
+| a gateway event class | `Event.php`, `Handlers.php`, related part/repository, tests |
+| a builder | matching part, callers, tests, docs/examples |
+| `Channel::TYPES`, `Interaction::TYPES`, component/ embed maps | event handlers, typed collection helpers, builder mirrors |
+| `DiscordCommandClient` | `CommandClient/Command.php`, examples/docs |
+| public magic properties | class PHPDoc, guide docs if user-facing behavior changed |
+
+## Change playbooks
+
+### Playbook: editing a Part
+
+1. Update `$fillable`.
+2. Add or adjust mutators for typed nested data, computed properties, or normalization.
+3. Update class docblocks.
+4. Update `$repositories` if a new child repository is exposed.
+5. Update `getRepositoryAttributes()` if child route vars changed.
+6. Update `getCreatableAttributes()` / `getUpdatableAttributes()` if persistence shape changed.
+7. Update `getRepository()` or `save()` if ownership or permission rules changed.
+8. Check gateway events and repositories that hydrate or cache the part.
+9. Add or update tests.
+
+### Playbook: editing a Repository
+
+1. Confirm `$class`, `$discrim`, and `$endpoints` still describe the family correctly.
+2. Confirm parent route vars are complete and in the correct shape.
+3. Keep REST writes and cache writes in sync.
+4. Return typed values.
+5. Check owning parts for `getRepository()` and `getRepositoryAttributes()` assumptions.
+6. Update tests and docs if public behavior changed.
+
+### Playbook: editing a Builder
+
+1. Put payload validation in setters/adders.
+2. Keep fluent chaining style.
+3. Keep `jsonSerialize()` aligned with Discord docs and existing payload semantics.
+4. Keep `fromPart()` edit symmetry in mind.
+5. Update tests for validation limits and payload shape.
+6. Update docs/examples if the preferred public construction path changed.
+
+### Playbook: editing a gateway event
+
+1. Add or update the event constant in `Event.php` if needed.
+2. Add or update the handler registration in `Handlers.php`.
+3. Hydrate the correct subtype.
+4. Update every affected repository and relation cache.
+5. Preserve event return shape expected by userland listeners.
+6. Cache related users/members if the payload supplies them.
+7. Re-check any intent-gated or partial-data behavior.
+
+### Playbook: editing interactions or commands
+
+1. Keep application-command and prefix-command layers separate.
+2. Keep interaction typing and resolved-data hydration intact.
+3. Keep builders as the outbound authoring path for commands, components, and modals.
+4. Avoid slow interaction-time work that can delay a response.
+5. Update both inbound event handling and outbound builder/docs surfaces if public behavior shifts.
+
+## Design tripwires
+
+If you see one of these, slow down:
+
+- a new raw nested array where a typed part already exists
+- a repository method returning raw decoded payload instead of a part
+- a part saving itself with hand-built endpoints even though an owning repository exists
+- a new subtype without a `TYPES` map entry
+- a magic property added in code but not in docblocks
+- a gateway handler that updates one cache but leaves related repositories stale
+- a synchronous wait or loop-stop trick outside tests
+- a new abstraction layer that duplicates what parts, repositories, events, or builders already do
+- web-framework terminology creeping into core runtime code
+
+## Preferred reference files
+
+When you need an example worth imitating, start here:
+
+- Runtime orchestration: `src/Discord/Discord.php`
+- Base part mechanics: `src/Discord/Parts/Part.php`, `src/Discord/Parts/PartTrait.php`
+- Rich part model: `src/Discord/Parts/Guild/Guild.php`
+- Channel/resource semantics: `src/Discord/Parts/Channel/Channel.php`
+- Message semantics and repository binding: `src/Discord/Parts/Channel/Message.php`
+- Repository baseline: `src/Discord/Repository/AbstractRepository.php`, `src/Discord/Repository/AbstractRepositoryTrait.php`
+- Simple repo specialization: `src/Discord/Repository/Channel/MessageRepository.php`
+- Rich repo specialization: `src/Discord/Repository/GuildRepository.php`
+- Outbound builder style: `src/Discord/Builders/MessageBuilder.php`
+- Interaction typing: `src/Discord/Parts/Interactions/Interaction.php`
+- Gateway cache mutation: `src/Discord/WebSockets/Events/MessageCreate.php`, `src/Discord/WebSockets/Events/GuildCreate.php`
+- Optional command layer: `src/Discord/DiscordCommandClient.php`, `src/Discord/CommandClient/Command.php`
+
+## Testing and docs workflow
+
+### Tests
+
+- Prefer plain `PHPUnit\Framework\TestCase` when logic is isolated.
+- Use `DiscordTestCase` only when real Discord integration matters.
+- Use `wait()` from `tests/functions.php` to bridge promises into test assertions.
+- Keep semantic tests focused on behavior, not on incidental implementation details.
+
+### Docs
+
+- Public magic properties, repositories, and helpers should be reflected in PHPDoc.
+- Long-form guides live in `guide/`.
+- Gatsby docs live in `docs/`.
+- Keep docs in sync when preferred usage or public contracts change.
+
+## Useful commands
+
+| Purpose | Command |
+| --- | --- |
+| main PHPUnit suite | `composer unit` |
+| static analysis | `composer run-script mago-lint` |
+| formatter contributors run | `composer run-script cs` |
+| non-mutating Pint check | `./vendor/bin/pint --test --config ./pint.json ./src` |
+| docs build | `cd docs && yarn install && yarn build` |
+
+Integration tests expect `.env` values for `DISCORD_TOKEN`, `TEST_CHANNEL`, and `TEST_CHANNEL_NAME`.
+
+## Final rule
+
+When unsure where code belongs, choose the layer that already owns the same kind of knowledge elsewhere in the repo. Matching the existing ownership model matters more than shaving a few lines off one class.

--- a/SKILLS.md
+++ b/SKILLS.md
@@ -1,0 +1,555 @@
+# DiscordPHP Maintenance Skills
+
+This file defines reusable maintenance skills for AI agents working in this repository. These skills are about preserving the repo's semantic design, not merely matching formatting. Load the skills that match the change. Combine them when a task crosses layers.
+
+## Shared doctrine
+
+Before loading any specific skill, anchor on these rules:
+
+1. **This is a CLI-only, long-running, async library.** Do not redesign code around request/response web lifecycles, controllers, per-request state, or blocking flows. `Discord` is a process runtime, not a web handler.
+2. **Preserve layer boundaries.**
+   - `Discord` runtime wires loop, logger, cache, HTTP, gateway, handlers, and root repositories.
+   - `Parts` model Discord resources and expose typed magic attributes.
+   - `Repositories` are typed collections plus REST/cache wrappers.
+   - `Builders` own outbound payload construction and validation.
+   - `WebSockets/Events` translate gateway payloads into cached objects and repository updates.
+   - `DiscordCommandClient` is an optional higher-level feature layered on top of core `Discord`.
+3. **Prefer existing abstractions over raw arrays and ad hoc helpers.** New Discord object data should usually become a `Part`, new collections should usually be a `Repository`, and new outbound payloads should usually be a `Builder`.
+4. **Keep async semantics intact.** Production I/O stays Promise-based. Only tests use `wait()` to bridge async behavior into PHPUnit.
+5. **Docblocks are part of API surface.** `@property`, `@property-read`, `@method`, `@since`, and `@link` blocks are relied on by generated docs and by developers navigating the magic property model.
+6. **Use current library idioms.** Prefer `Factory::part()` / `Factory::repository()`, prefer `$part->save($reason)` over repository `save($part)` in user-facing paths, and prefer builder `->create($repository)` helpers where they exist.
+7. **Do not move logic to the wrong layer.**
+   - Permission gates belong close to the high-level operation on the `Part`.
+   - Endpoint binding, REST verbs, and cache persistence belong in the `Repository`.
+   - Gateway payload interpretation belongs in `WebSockets/Events`.
+   - Fluent payload validation belongs in `Builders`.
+
+## Skill map
+
+| If task touches... | Load these skills first |
+| --- | --- |
+| `Discord.php`, startup, intents, cache, loop, gateway connection | `runtime-bootstrap-keeper` |
+| `Parts/*`, domain modeling, mutators, typed nested data | `part-model-maintainer` |
+| `Repository/*`, endpoint vars, cache, CRUD, fetch/save/delete | `repository-cache-keeper` |
+| `WebSockets/Handlers.php`, `WebSockets/Event.php`, `WebSockets/Events/*` | `gateway-cache-sync-keeper` |
+| `Builders/*`, `Builders/Components/*`, outbound payload rules | `builder-payload-smith` |
+| subtype maps like `Channel::TYPES` or `Interaction::TYPES` | `type-map-keeper` |
+| interactions, slash commands, resolved data, autocomplete, modals | `interaction-flow-keeper` |
+| `DiscordCommandClient` or prefix-command behavior | `legacy-command-client-keeper` |
+| tests, guides, docblocks, generated reference expectations | `async-test-and-doc-sync` |
+
+---
+
+## Skill: runtime-bootstrap-keeper
+
+**Use when**
+
+- touching `src/Discord/Discord.php`
+- changing startup options, loop setup, cache configuration, gateway behavior, readiness, chunking, reconnect logic, or root repositories
+- changing anything that affects process lifecycle rather than a single resource type
+
+**Read first**
+
+- `src/Discord/Discord.php`
+- `src/Discord/WebSockets/Handlers.php`
+- `src/Discord/WebSockets/Event.php`
+- `src/Discord/Factory/Factory.php`
+- `README.md`
+- `guide/basics.rst`
+
+**Mental model**
+
+`Discord` is the orchestrator. It resolves options, wires infrastructural dependencies, creates the HTTP client, handler registry, factory, and top-level client part, connects to the gateway during construction, and only starts the loop when `run()` is called.
+
+**Protect these invariants**
+
+1. Construction is eager. `Discord::__construct()` does real setup work and calls `connectWs()`.
+2. `run()` only starts the loop. It is not where dependency wiring happens.
+3. CLI-only assumption stays explicit. The library warns when run outside `cli` or `micro`.
+4. Options are normalized centrally with `OptionsResolver`.
+5. Intent and capability arrays are folded into bitmasks at option resolution time.
+6. Root repositories remain long-lived properties on the client, not ephemeral fetch helpers.
+7. Critical gateway events must stay enabled unless explicitly disabled; disabling them has semantics, not only performance impact.
+8. Large-guild member chunking is a first-class runtime concern; it must stay compatible with intent requirements.
+9. Cache configuration and collection class configuration are repo-wide runtime services, not per-call knobs.
+
+**Common patterns to preserve**
+
+- constructor injects `loop`, `logger`, `http`, `factory`, `handlers`
+- `Factory` is created once per client and reused everywhere
+- gateway event handlers are selected through `Handlers`
+- ready flow backfills guilds, then chunking, then ready emission
+- runtime methods often coordinate multiple subsystems but still defer domain details to parts/repositories/events
+
+**Do**
+
+- normalize new options in `resolveOptions()`
+- validate new intent-dependent behavior near option resolution or startup
+- keep lifecycle flags (`connected`, `closing`, `reconnecting`, `emittedInit`) coherent
+- preserve event-loop-friendly control flow
+- reuse `Factory`, `Handlers`, `Endpoint`, and existing helper methods before introducing new runtime plumbing
+
+**Do not**
+
+- move domain mutation logic from parts/events into `Discord`
+- make startup depend on request-time context or web frameworks
+- add synchronous waits or blocking loops
+- bypass handler registry by hardcoding event logic in multiple places
+
+**Done when**
+
+- new runtime behavior still fits `Discord` as orchestrator, not as domain owner
+- option normalization, logging, and lifecycle transitions stay internally consistent
+- any new event dependency is reflected in handler registration or disabled-event behavior
+
+---
+
+## Skill: part-model-maintainer
+
+**Use when**
+
+- adding or modifying any `Part`
+- changing fillable attributes, computed properties, nested typed data, `save()`, `fetch()`, permission checks, or docblocks
+- adding a new Discord object or extending an existing one
+
+**Read first**
+
+- `src/Discord/Parts/Part.php`
+- `src/Discord/Parts/PartTrait.php`
+- representative concrete parts:
+  - `src/Discord/Parts/Guild/Guild.php`
+  - `src/Discord/Parts/Channel/Channel.php`
+  - `src/Discord/Parts/Channel/Message.php`
+  - `src/Discord/Parts/User/User.php`
+  - `src/Discord/Parts/Interactions/Interaction.php`
+
+**Mental model**
+
+A `Part` is the canonical in-memory model of a Discord resource. It stores raw API-shaped attributes, lazily exposes typed nested objects and repositories through magic access, tracks whether the entity already exists in Discord with `$created`, and delegates persistence to its originating repository.
+
+**Protect these invariants**
+
+1. Parts extend `Part`, inherit `PartTrait`, and use snake_case attribute keys matching Discord payloads.
+2. `$fillable` is the source of truth for mass-assignment. If a field is missing there, `fill()` ignores it.
+3. Nested typed values should be exposed through mutators and helpers, not left as raw arrays when a corresponding `Part` exists.
+4. Lazy child repositories belong in `$repositories`; accessing them through magic properties should construct the right repository on demand.
+5. Public/computed convenience attributes use `get{Studly}Attribute()` mutators and are documented with `@property-read`.
+6. Typed nested setters use `set{Studly}Attribute()` when data must be normalized on write.
+7. `getCreatableAttributes()`, `getUpdatableAttributes()`, `getRepository()`, `save()`, `fetch()`, and `getRepositoryAttributes()` are the semantic extension points for persistable parts.
+8. `save()` is where high-level permission checks and special-case persistence routing live before repository delegation.
+9. `createOf()` preserves `$created` linkage between parent and nested parts; use it for nested typed data.
+10. PHPDoc and runtime magic surface must stay in sync.
+
+**Helpers to prefer**
+
+- `attributeCarbonHelper()` for timestamps
+- `attributePartHelper()` for single nested parts
+- `attributeCollectionHelper()` for homogeneous nested collections
+- `attributeTypedCollectionHelper()` for runtime-dispatched subtype collections
+- `makeOptionalAttributes()` for optional API fields that must only serialize when present
+- `createOf()` for nested parts that should mirror parent `created` state
+
+**Common semantic patterns**
+
+- giant class-level `@property` surfaces describe raw, computed, and repository-backed attributes
+- constants mirror Discord enum/flag values and often keep deprecated aliases for compatibility
+- parts often expose both raw identifier fields (`guild_id`) and resolved relations (`guild`)
+- channel-like, guild-like, and similar shared behaviors are moved into focused traits instead of deep inheritance
+- permission-gated mutating methods live on parts because they understand the domain action being performed
+
+**Do**
+
+- add new Discord payload fields to `$fillable`
+- add typed getters/setters when a field should become a `Part`, collection, `Carbon`, or computed convenience property
+- update `@property` docs whenever the magic surface changes
+- update `getRepositoryAttributes()` whenever child routes depend on parent IDs
+- keep `getCreatableAttributes()` and `getUpdatableAttributes()` aligned with Discord API semantics, not just current tests
+
+**Do not**
+
+- bypass `$fillable` by stashing meaningful API state in ad hoc properties
+- expose nested Discord objects as raw arrays when the repo already has a `Part` type
+- serialize optional fields indiscriminately when the API distinguishes "missing" from `null`
+- add permission checks to repositories if the semantic action belongs on the part
+- forget that magic property names are part of public API
+
+**Done when**
+
+- raw API data, computed accessors, typed nested objects, repository access, persistence rules, and docblocks all tell the same story
+
+---
+
+## Skill: repository-cache-keeper
+
+**Use when**
+
+- changing any repository
+- adding new REST endpoints, cache behavior, or nested repository bindings
+- adjusting collection behavior for Discord-owned resources
+
+**Read first**
+
+- `src/Discord/Repository/AbstractRepository.php`
+- `src/Discord/Repository/AbstractRepositoryTrait.php`
+- representative repositories:
+  - `src/Discord/Repository/GuildRepository.php`
+  - `src/Discord/Repository/Guild/ChannelRepository.php`
+  - `src/Discord/Repository/Channel/MessageRepository.php`
+
+**Mental model**
+
+A repository is both a typed collection and the persistence boundary for a family of parts. It knows endpoint templates, route variables, cache wrapper behavior, and how to hydrate or update parts. Repositories are where REST and cache coordination happens.
+
+**Protect these invariants**
+
+1. Every repository declares `$class`; most also declare `$endpoints`; some override `$discrim`.
+2. `$vars` holds route-binding context like `guild_id`, `channel_id`, `message_id`; parts feed these through `getRepositoryAttributes()`.
+3. Repository `create()` builds a local part but does not persist to Discord.
+4. Repository `save()` decides POST vs PATCH based on `$part->created`.
+5. Repository `delete()` and `fetch()` are Promise-based and keep cache state aligned.
+6. Cache wrapper integration is per-repository and must stay transparent to callers.
+7. Collection semantics still matter: repositories behave like typed collections even while wrapping async cache access.
+8. Repository methods should return parts or repositories with meaning, not loose decoded payloads.
+
+**Common semantic patterns**
+
+- `freshen()` refreshes all cached data from REST and rewrites cache entries
+- `fetch()` prefers in-memory or cached parts before REST unless forced fresh
+- repository constructors may sanitize parent vars for route correctness
+- nested repositories are bound by parent part IDs, not by ad hoc caller knowledge
+- repositories often expose convenience methods for domain-specific endpoints but still cache typed parts
+
+**Do**
+
+- bind endpoints using `Endpoint` and `$vars`
+- create or update cache entries whenever REST mutates canonical state
+- keep repository return types typed through parts or repositories
+- use repository-specific methods for domain operations that are broader than generic CRUD
+- ensure child repositories can reconstruct correct route vars from their owning part
+
+**Do not**
+
+- move permission decisions from parts into repositories unless the operation is repository-native and not tied to a single part instance
+- return raw REST payloads when a typed part exists
+- add synchronous cache assumptions to async methods
+- forget to keep cache, `items`, and route vars coherent
+
+**Done when**
+
+- repository remains the single source of truth for REST endpoint use and cache persistence for its part family
+
+---
+
+## Skill: gateway-cache-sync-keeper
+
+**Use when**
+
+- changing any gateway event behavior
+- adding a new event class
+- changing cache mutation, event return shapes, or handler registration
+
+**Read first**
+
+- `src/Discord/WebSockets/Handlers.php`
+- `src/Discord/WebSockets/Event.php`
+- relevant event class in `src/Discord/WebSockets/Events/*`
+- relevant part/repository types that the event updates
+
+**Mental model**
+
+Gateway events are not passive notifications. In this repo, event handlers are responsible for translating raw dispatch payloads into typed parts, updating cached repositories, maintaining counters or relation state, caching related users/members, and returning the value that userland event listeners receive.
+
+**Protect these invariants**
+
+1. New gateway events must usually touch both `Event.php` and `Handlers.php`.
+2. Event handlers return typed semantic payloads, not raw transport data, unless partial/raw return is intentional.
+3. Cache mutation happens inside the event handler, close to payload interpretation.
+4. When runtime subtype dispatch exists, use `TYPES` maps instead of hardcoded switch forests.
+5. User and member caches are warmed through helper methods like `cacheUser()` and `cacheMember()`.
+6. Message events preserve special behavior around stored messages, intent-gated content, old/new return pairs, and partial updates.
+7. Guild and thread events preserve repository relationships and counts, not merely object hydration.
+
+**Common semantic patterns**
+
+- update events often return `[newPartOrData, oldPart]`
+- delete events often return the removed cached part plus extra state, not only the payload id
+- message create/update handlers maintain `last_message_id`, message caches, mention/user/member caches
+- interaction handler avoids slow cache lookups that would delay interaction handling
+- guild create handler is responsible for bulk hydration of related repositories
+
+**Do**
+
+- instantiate the right typed part for gateway payloads
+- update all affected repositories, counts, and related object caches
+- preserve existing event return shapes when extending behavior
+- use async-friendly generator/yield flow where handlers already do
+- audit side effects on parent/child relationships, not just the primary object
+
+**Do not**
+
+- update only one cache when several related repositories need coherence
+- forget handler registration after adding a new event class
+- replace typed part returns with decoded arrays without a strong compatibility reason
+- add REST fetches where gateway payloads already contain enough data to update caches
+
+**Done when**
+
+- dispatch payload, typed parts, cache state, and emitted event payload all stay semantically aligned
+
+---
+
+## Skill: builder-payload-smith
+
+**Use when**
+
+- adding or changing builders
+- adjusting outbound payload validation
+- adding component or modal payload construction rules
+- deciding whether a new public API should accept raw arrays or a builder
+
+**Read first**
+
+- `src/Discord/Builders/Builder.php`
+- `src/Discord/Helpers/DynamicPropertyMutatorTrait.php`
+- representative builders:
+  - `src/Discord/Builders/MessageBuilder.php`
+  - `src/Discord/Builders/ChannelBuilder.php`
+  - `src/Discord/Builders/CommandBuilder.php`
+  - `src/Discord/Builders/ModalBuilder.php`
+- component base types under `src/Discord/Builders/Components/*`
+
+**Mental model**
+
+Builders are request-shape specialists. They validate what userland wants to send, encode it into the shape Discord expects, and deliberately stay separate from `Part` objects. Builders are the preferred home for outbound payload invariants.
+
+**Protect these invariants**
+
+1. Builders extend `Builder`, not `Part`.
+2. Builders use `DynamicPropertyMutatorTrait`, which mirrors the part mutator pattern at property level.
+3. Builders validate limits eagerly in setters or adders.
+4. Builders implement `JsonSerializable` and own outbound array shape.
+5. `fromPart()` is the canonical bridge from stored `Part` data to editable builder state.
+6. Where supported, builders provide `create($repository)` helpers so callers do not manually juggle raw arrays.
+7. Component-capable builders use `ComponentsTrait`; usage-specific validation stays in `addComponent()`.
+
+**Common semantic patterns**
+
+- fluent setters return `$this`
+- builders keep nullable properties and omit unset optionals during `jsonSerialize()`
+- payload validation mirrors Discord API rules: lengths, counts, valid enum values, valid component usage contexts
+- builders sometimes accept both parts and scalars in setters, normalizing to IDs or raw payloads
+
+**Do**
+
+- put payload rules in builders instead of sprinkling array validation through parts or repositories
+- preserve fluent setter style and `new()` factory methods
+- keep `jsonSerialize()` shape faithful to Discord docs and existing builder conventions
+- prefer typed component objects over unstructured component arrays
+
+**Do not**
+
+- make builders own cache or persistence behavior
+- reintroduce raw array construction where a mature builder already exists
+- let builder validation drift from actual API limits
+- duplicate part mutator logic inside repositories
+
+**Done when**
+
+- outbound payloads are validated, serializable, and still clearly separated from in-memory resource models
+
+---
+
+## Skill: type-map-keeper
+
+**Use when**
+
+- adding a new channel, interaction, embed, or component subtype
+- changing any `TYPES` lookup table
+- touching code that dispatches by `type`, `component_type`, or similar runtime discriminator
+
+**Read first**
+
+- `src/Discord/Parts/Channel/Channel.php`
+- `src/Discord/Parts/Interactions/Interaction.php`
+- `src/Discord/Parts/Embed/Embed.php`
+- `src/Discord/Parts/Channel/Message/Component.php`
+- `src/Discord/Builders/Components/ComponentObject.php`
+
+**Mental model**
+
+This repo prefers runtime subtype maps over repeated conditionals. Payload discriminators select the concrete class once, then the rest of the system works with the right type.
+
+**Protect these invariants**
+
+1. Type maps keep a fallback entry at index `0` or equivalent safe default.
+2. Builder and part representations for the same subtype family should stay conceptually aligned.
+3. Event handlers and attribute helpers should consume type maps rather than duplicating branching logic.
+4. New subtype classes should inherit from the same root family and preserve shared trait behavior where applicable.
+5. Public constants remain the stable vocabulary for userland code.
+
+**Do**
+
+- extend the relevant `TYPES` map when introducing a new Discord subtype
+- add any corresponding constants, docblocks, and helper methods
+- check gateway events, attribute helpers, and builders that materialize the type family
+
+**Do not**
+
+- add a subtype class without wiring the dispatch map
+- hardcode a one-off conditional in an event while leaving the central map stale
+- forget the builder-side component or interaction mirror when the type family exists in both inbound and outbound flows
+
+**Done when**
+
+- runtime subtype dispatch works from every entry point that materializes the family
+
+---
+
+## Skill: interaction-flow-keeper
+
+**Use when**
+
+- changing interactions, slash commands, autocomplete, modal submit handling, resolved data, or command registration
+- changing how builders and interaction parts cooperate
+
+**Read first**
+
+- `src/Discord/Parts/Interactions/Interaction.php`
+- `src/Discord/WebSockets/Events/InteractionCreate.php`
+- `src/Discord/Builders/CommandBuilder.php`
+- `src/Discord/Builders/ModalBuilder.php`
+- `src/Discord/Parts/Interactions/*`
+- `guide/interactions.rst`
+
+**Mental model**
+
+Interactions are a typed inbound protocol layered on top of the gateway. The event handler must turn raw payloads into the right interaction part, cache resolved users/members/entitlements, and invoke registered command callbacks quickly enough for interaction timing constraints.
+
+**Protect these invariants**
+
+1. `Interaction::TYPES` chooses the concrete inbound subtype.
+2. Resolved users/members/channels/roles should become typed objects or collections, not loose arrays.
+3. Interaction handlers avoid unnecessary slow cache lookups that can delay responses.
+4. Autocomplete and command execution routing stay tied to registered command abstractions, not duplicated in userland-facing code.
+5. Builders for commands and modals remain the preferred outbound construction path.
+
+**Do**
+
+- preserve typed accessors on `Interaction`
+- keep resolved-data caching aligned with guild/user caches
+- keep modal and component usage constraints encoded in builders and component classes
+- treat interaction response shapes as API contracts
+
+**Do not**
+
+- collapse typed interaction subclasses back into one generic untyped object
+- block interaction flow on optional cache hydration
+- leak message-command assumptions into slash-command code paths
+
+**Done when**
+
+- inbound interaction data, registered command routing, and outbound builder-based responses still form one coherent system
+
+---
+
+## Skill: legacy-command-client-keeper
+
+**Use when**
+
+- touching `DiscordCommandClient`
+- modifying prefix-based command parsing, aliases, cooldowns, or help output
+- maintaining compatibility for message-command bots built on the optional command layer
+
+**Read first**
+
+- `src/Discord/DiscordCommandClient.php`
+- `src/Discord/CommandClient/Command.php`
+- any related guide/example files under `examples/` or `guide/`
+
+**Mental model**
+
+The command client is intentionally a higher-level convenience layer built on top of the core async client. It should not redefine the core architecture. It listens to message events, parses prefixes, routes to command objects, and offers a help/cooldown/subcommand abstraction for message-based bots.
+
+**Protect these invariants**
+
+1. `DiscordCommandClient` extends `Discord`; it is an add-on, not a separate runtime stack.
+2. Prefix parsing and alias resolution happen in the command layer, not in core message parts.
+3. Command objects own help text, cooldown state, subcommand trees, and execution callables.
+4. The help command is feature behavior of the command layer, not general library behavior.
+
+**Do**
+
+- keep command parsing localized to the command client and command objects
+- preserve option resolution and case-insensitive behavior contracts
+- keep help output and cooldown behavior tied to command metadata
+
+**Do not**
+
+- push prefix-command concerns into `Message`, `Channel`, `Discord`, or interaction code
+- make command client changes that alter core runtime semantics
+
+**Done when**
+
+- prefix-command behavior still feels like a clean optional layer on top of the core client
+
+---
+
+## Skill: async-test-and-doc-sync
+
+**Use when**
+
+- adding or changing public behavior
+- updating builder validation, part semantics, repository behavior, or docs
+- touching anything user-facing enough that tests or docs should move with it
+
+**Read first**
+
+- `tests/functions.php`
+- `tests/DiscordTestCase.php`
+- representative unit tests under `tests/Builders` and `tests/Parts`
+- `guide/`
+- `README.md`
+- `CONTRIBUTING.md`
+
+**Mental model**
+
+The repo mixes isolated PHPUnit unit tests with integration-style tests against a real Discord bot and channel. Docs are split between long-form guide content and API-reference-oriented docblocks. Keeping behavior, tests, and docs aligned is part of the maintenance job.
+
+**Protect these invariants**
+
+1. Integration tests use the real async runtime and the `wait()` helper; plain `TestCase` tests are better for isolated logic.
+2. Public magic properties and repository methods should be reflected in docblocks.
+3. Long-form guides and examples should only change when public behavior or recommended usage changes.
+4. Builders and parts should have tests that assert semantic behavior, not just trivial setters.
+
+**Do**
+
+- add or update unit tests for isolated builder/part/repository logic when behavior changes
+- use integration tests when behavior truly depends on Discord runtime interactions
+- update docblocks whenever public magic attributes, repositories, or methods change
+- update guide/docs/examples only when public guidance needs to change
+
+**Do not**
+
+- introduce blocking helpers into production code to satisfy tests
+- rely on integration tests when a unit test can cover the logic safely
+- leave docs advertising old usage when new patterns are preferred
+
+**Done when**
+
+- code, tests, and docs all describe the same behavior at the same abstraction level
+
+---
+
+## Final reminder
+
+When a change feels awkward, check whether logic has drifted into the wrong layer. In this repo, most design bugs come from violating one of these seams:
+
+- runtime vs domain model
+- part vs repository
+- repository vs gateway event
+- part vs builder
+- core client vs optional command layer
+- raw array payloads vs typed parts/builders
+
+If the seam stays clean, the change is usually on the right track.

--- a/SKILLS.md
+++ b/SKILLS.md
@@ -38,6 +38,17 @@ Before loading any specific skill, anchor on these rules:
 | `DiscordCommandClient` or prefix-command behavior | `legacy-command-client-keeper` |
 | tests, guides, docblocks, generated reference expectations | `async-test-and-doc-sync` |
 
+## Standalone hot-spot files
+
+Use root file as quick index. Use standalone files when change is concentrated in one risky layer and you need fuller playbooks, tripwires, and companion-file guidance.
+
+- `skills/part-model-maintainer.md`
+- `skills/repository-cache-keeper.md`
+- `skills/gateway-cache-sync-keeper.md`
+- `skills/builder-payload-smith.md`
+- `skills/interaction-flow-keeper.md`
+- `skills/legacy-command-client-keeper.md`
+
 ---
 
 ## Skill: runtime-bootstrap-keeper

--- a/skills/builder-payload-smith.md
+++ b/skills/builder-payload-smith.md
@@ -1,0 +1,227 @@
+# Skill: builder-payload-smith
+
+Use this skill when work touches:
+
+- `src/Discord/Builders/*`
+- `src/Discord/Builders/Components/*`
+- outbound payload construction paths in parts or interaction responses
+
+This is outbound-shape skill. Load it when a change affects how callers build data to send to Discord.
+
+## Goal
+
+Keep builders as the repo's safe way to author complex outbound payloads:
+
+- fluent and ergonomic for callers
+- validated before hitting REST
+- cleanly separated from in-memory parts
+- serializable into Discord API payloads
+
+## Read in this order
+
+1. `src/Discord/Builders/Builder.php`
+2. `src/Discord/Helpers/DynamicPropertyMutatorTrait.php`
+3. `src/Discord/Builders/ComponentsTrait.php`
+4. Representative builders:
+   - `src/Discord/Builders/MessageBuilder.php`
+   - `src/Discord/Builders/ChannelBuilder.php`
+   - `src/Discord/Builders/CommandBuilder.php`
+   - `src/Discord/Builders/ModalBuilder.php`
+5. Component base types:
+   - `src/Discord/Builders/Components/Component.php`
+   - `src/Discord/Builders/Components/ComponentObject.php`
+6. Matching part or repository family that consumes builder output
+
+## Core contract
+
+Builders are not parts. Builders:
+
+- extend `Builder`
+- often implement `JsonSerializable`
+- keep mutable fluent state for outbound payloads
+- validate limits and allowed values in setters or adders
+- serialize to request-ready arrays
+- sometimes provide `create($repository)` helpers for smoother public API
+
+If a builder starts acting like cached domain object or repository, wrong layer.
+
+## Base patterns to preserve
+
+### `Builder::fromPart(Part $part)`
+
+This is bridge from stored part data into editable payload state. Preserve it when adding new builder properties or part fields. Edit flows depend on this symmetry.
+
+### `DynamicPropertyMutatorTrait`
+
+Builder property access uses property-level mutators like:
+
+- `setContent()`
+- `getContent()`
+
+Not part-style `getContentAttribute()`. Keep that distinction.
+
+### `new()` factory
+
+Most builders expose `new()` for userland ergonomics. Preserve pattern when adding new top-level builders.
+
+### `create($repository)` helper
+
+Newer builders often let callers hand the builder to a repository directly. Prefer keeping that path because it nudges users away from raw arrays.
+
+## Validation rules
+
+Validation should live as close as possible to setter/add method that introduces invalid state.
+
+Good examples already in repo:
+
+- message content length limits
+- modal title and custom id length limits
+- max embeds/components counts
+- valid channel type enums
+- valid video quality modes
+
+Do not rely on far-away repository methods to catch simple builder invariants.
+
+## Serialization rules
+
+### `jsonSerialize()` is canonical outbound shape
+
+This is where builder translates fluent internal state into Discord payload array. Keep it:
+
+- explicit
+- ordered enough to read
+- faithful to API docs
+- selective about optionals
+
+### Omit unset optionals when possible
+
+Many Discord APIs treat missing field differently from explicit null. Builders should usually omit properties that were never set unless API specifically wants null.
+
+### Normalize nested builder or part inputs
+
+If builder accepts nested objects:
+
+- serialize nested builders
+- convert parts to raw attributes or IDs where appropriate
+- keep final payload JSON-friendly
+
+## Boundaries with parts and repositories
+
+### Builder vs part
+
+- part = canonical resource model received from Discord or stored in memory
+- builder = request payload authoring tool
+
+Do not move outbound validation rules into parts if there is already a builder abstraction.
+
+### Builder vs repository
+
+- builder prepares payload
+- repository performs REST call
+
+Repositories should not become payload authoring zones full of hand-built nested arrays if builder exists.
+
+## Component-specific rules
+
+Component system exists in both builder and part worlds:
+
+- builder components under `src/Discord/Builders/Components/*`
+- inbound message component parts under `src/Discord/Parts/Channel/Message/*`
+
+Keep these worlds aligned conceptually, but do not collapse them into one class family. Outbound builders and inbound parts solve different problems.
+
+### `ComponentObject::TYPES`
+
+If new outbound component subtype appears:
+
+1. add constant
+2. add map entry
+3. add class
+4. check matching inbound component family if relevant
+5. update builders using components
+
+### Usage contexts
+
+Component usage constraints matter:
+
+- message
+- modal
+- interaction contexts
+
+Where repo already encodes allowed contexts, keep validation there instead of free-form component insertion.
+
+## Builder selection guide
+
+Add or extend a builder when:
+
+- payload has multiple related fields
+- Discord API has length/count/value limits
+- nested structures are easy to get wrong by hand
+- same shape is authored from several call sites
+
+Raw array may be enough when:
+
+- payload is tiny
+- shape is stable and local
+- repo does not already have builder convention for that family
+
+But if users will author it directly or repeatedly, bias toward builder.
+
+## Existing patterns worth copying
+
+### Message builder
+
+Best example for:
+
+- content validation
+- embeds/files/stickers/components combination
+- fluent helpers
+- repository `create()` bridge
+
+### Channel builder
+
+Best example for:
+
+- type-specific optional fields
+- enum validation
+- payload fields that differ by channel subtype
+
+### Command builder
+
+Best example for:
+
+- optional field omission
+- payload shape depending on command type
+
+### Modal builder
+
+Best example for:
+
+- strict component usage constraints
+- response payload shape nested under `type` + `data`
+
+## Smells
+
+Stop if you see:
+
+- raw arrays duplicated across many callers when builder exists
+- validation postponed until after HTTP call
+- builder storing cache/domain state
+- repository assembling complicated payload shape that should live in builder
+- mismatch between builder and part edit flow because `fromPart()` path no longer reflects real fields
+- new component type added only on one side of builder/part system
+
+## Builder change checklist
+
+- new property has setter/getter if public
+- validation lives near write path
+- `jsonSerialize()` includes it only when appropriate
+- `fromPart()` behavior still makes sense
+- any `create($repository)` helper remains correct
+- component/type maps updated if subtype introduced
+- tests cover invalid and valid boundary cases
+- docs/examples updated if preferred public usage changed
+
+## Bottom line
+
+Builders in this repo exist to keep outbound payload rules from leaking everywhere. If a caller has to memorize Discord payload trivia instead of relying on builder methods, builder design is unfinished.

--- a/skills/gateway-cache-sync-keeper.md
+++ b/skills/gateway-cache-sync-keeper.md
@@ -1,0 +1,217 @@
+# Skill: gateway-cache-sync-keeper
+
+Use this skill when work touches:
+
+- `src/Discord/WebSockets/Handlers.php`
+- `src/Discord/WebSockets/Event.php`
+- `src/Discord/WebSockets/Events/*`
+
+This is event-to-cache coherence skill. Load it when changing gateway dispatch behavior, event return shapes, or cache mutation.
+
+## Goal
+
+Keep gateway handling as real-time state sync layer:
+
+- dispatch payloads become typed parts
+- related repositories get updated immediately
+- emitted event payloads stay semantically useful
+- caches for users, members, channels, messages, threads, guilds stay coherent
+
+## Read in this order
+
+1. `src/Discord/WebSockets/Event.php`
+2. `src/Discord/WebSockets/Handlers.php`
+3. Matching part/repository families
+4. Representative events:
+   - `src/Discord/WebSockets/Events/MessageCreate.php`
+   - `src/Discord/WebSockets/Events/MessageUpdate.php`
+   - `src/Discord/WebSockets/Events/GuildCreate.php`
+   - `src/Discord/WebSockets/Events/GuildDelete.php`
+   - `src/Discord/WebSockets/Events/InteractionCreate.php`
+   - `src/Discord/WebSockets/Events/ThreadListSync.php`
+   - `src/Discord/WebSockets/Events/GuildMemberAdd.php`
+
+## Core contract
+
+Event classes in this repo are not dumb payload forwarders. They:
+
+- interpret transport payloads
+- instantiate correct typed parts, often via runtime `TYPES` maps
+- update owning repositories and related caches
+- warm user/member caches from nested payloads
+- preserve secondary invariants like counters or `last_message_id`
+- return semantic values used by userland listeners
+
+If handler only hydrates one object and ignores related caches, change is probably incomplete.
+
+## Three files usually move together
+
+When adding or changing event family, inspect all three:
+
+1. `src/Discord/WebSockets/Event.php` — constant
+2. `src/Discord/WebSockets/Handlers.php` — registration
+3. `src/Discord/WebSockets/Events/<Name>.php` — implementation
+
+If one changes and the others do not, make sure that is intentional.
+
+## Event base helpers to use
+
+### `cacheUser(object $userdata)`
+
+Use when payload contains user data. Keeps top-level user cache current.
+
+### `cacheMember(MemberRepository $members, array $memberdata)`
+
+Use when payload contains guild member data. Keeps guild member cache current. Some event families override details for performance reasons, like `InteractionCreate`.
+
+Do not manually duplicate user/member cache update logic unless event family has special latency or shape constraints.
+
+## Hydration rules
+
+### Prefer typed parts immediately
+
+Use factory plus subtype maps when payload family is polymorphic:
+
+- channels from `Channel::TYPES`
+- interactions from `Interaction::TYPES`
+- components from component `TYPES`
+
+Do not push raw `stdClass` payloads deep into caches when repo already has typed part model.
+
+### Create vs update vs delete semantics matter
+
+- create events usually instantiate new parts and set them into owning repo
+- update events often clone old cached part, mutate current part, and return both new and old values
+- delete events often pull from cache and return removed typed part plus extra status
+
+Preserve those shapes unless you have strong compatibility reason to change them.
+
+## Coherence rules by family
+
+### Message events
+
+These are easy to break because they carry many side effects:
+
+- store or update message in channel/thread repo when configured
+- keep `last_message_id` current
+- handle message-content intent limits correctly
+- update author/mention/interacting user caches
+- preserve old/new payload behavior on update
+
+If you change `MessageCreate` or `MessageUpdate`, inspect:
+
+- message cache behavior
+- intent-gated content handling
+- DM vs guild channel routing
+- thread message counting or parent lookup logic
+
+### Guild create/delete/update families
+
+Guild events often do bulk cache work:
+
+- guild create populates guild repo plus member, user, voice state, thread, stage instance, scheduled event, sound caches
+- guild delete must preserve unavailable-vs-removed semantics
+
+Do not treat guild create as "just one guild part". It is bootstrap event for several nested repositories.
+
+### Thread events
+
+Threads are child collections hanging off parent channels. Thread handlers usually must:
+
+- locate parent channel
+- update parent `threads` repo
+- possibly update thread member state
+- preserve thread counters or metadata
+
+### Interaction events
+
+Interaction handlers are latency-sensitive. They still must:
+
+- hydrate correct interaction subtype
+- cache resolved users/members
+- avoid unnecessarily slow cache paths
+- invoke registered command handlers/autocomplete flow
+
+## Event return-shape rules
+
+Userland listens to emitted values. Keep return shapes stable and meaningful.
+
+Common patterns already used:
+
+- `MessageCreate` returns new `Message`
+- `MessageUpdate` returns `[newOrData, oldMessage]`
+- `GuildDelete` returns `[$guildPartOrData, $unavailableFlag]`
+
+Before changing a return shape, inspect:
+
+- existing event listeners in examples/tests/docs
+- parity with sibling events in same family
+- whether old state is required for consumers
+
+## Cache path playbook
+
+When changing event behavior, walk this checklist:
+
+1. What is primary part produced by payload?
+2. Which repository should own it?
+3. Which parent or child repositories also need update?
+4. Which related users or members appear in payload?
+5. Do counters, last IDs, or status fields need sync?
+6. What should event listener receive back?
+
+If you cannot answer each, handler is not fully understood yet.
+
+## Registration playbook
+
+When adding new dispatch type:
+
+1. add constant to `Event.php`
+2. add handler registration to `Handlers.php`
+3. create event class
+4. choose emitted event aliases if handler needs alternatives
+5. ensure any runtime option that disables events still behaves sensibly
+
+## Partial payload and intent rules
+
+Gateway payloads are not always full objects.
+
+Examples:
+
+- message update may be partial
+- message content may be missing without `MESSAGE_CONTENT` intent
+- interaction-related payloads may favor speed over full cache warmup
+- guild create member lists vary with guild size and enabled intents
+
+Do not blindly overwrite cached richer state with partial payload unless code already accounts for missing fields.
+
+## Performance rules
+
+- prefer payload data over avoidable REST fetches
+- reuse cache lookups instead of broad scans when possible
+- but preserve correctness for parent-child lookup when repo shape demands it
+- interaction path should avoid slow cache resolution that delays response handling
+
+## Smells
+
+Stop if you see:
+
+- event class added without handler registration
+- cache update for primary part but not related repositories
+- raw payload stuffed in cache when typed part exists
+- user/member data in payload ignored even though later code depends on cache
+- update event overwriting rich cached fields with partial sparse payload
+- return shape change with no thought for existing listener contract
+
+## Checklist before commit
+
+- event constant and handler registration aligned
+- correct subtype hydration path used
+- primary and related repositories updated
+- user/member caches updated where payload carries them
+- partial/intents behavior preserved
+- event return shape still intentional and compatible
+- tests/docs/examples checked if public listener contract changed
+
+## Bottom line
+
+Gateway events are cache-synchronization code. Treat them like consistency-critical logic, not like thin adapters. One missed repository update can make the whole object graph lie.

--- a/skills/interaction-flow-keeper.md
+++ b/skills/interaction-flow-keeper.md
@@ -1,0 +1,198 @@
+# Skill: interaction-flow-keeper
+
+Use this skill when work touches:
+
+- `src/Discord/Parts/Interactions/*`
+- `src/Discord/WebSockets/Events/InteractionCreate.php`
+- application command registration or autocomplete routing
+- modal or component interaction response behavior
+
+This is typed-interaction flow skill. Load it when work affects how interactions are received, interpreted, routed, or answered.
+
+## Goal
+
+Keep interactions as a coherent pipeline:
+
+- gateway payload enters through `InteractionCreate`
+- payload is typed into correct interaction subclass
+- resolved data warms caches
+- registered command callbacks route correctly
+- response builders and helpers stay aligned with interaction protocol
+
+## Read in this order
+
+1. `src/Discord/Parts/Interactions/Interaction.php`
+2. `src/Discord/WebSockets/Events/InteractionCreate.php`
+3. `src/Discord/Helpers/RegisteredCommand.php`
+4. Related request data parts under `src/Discord/Parts/Interactions/Request/*`
+5. Outbound builders:
+   - `src/Discord/Builders/CommandBuilder.php`
+   - `src/Discord/Builders/ModalBuilder.php`
+   - component builders when component responses matter
+6. Command repositories:
+   - `src/Discord/Repository/Interaction/GlobalCommandRepository.php`
+   - `src/Discord/Repository/Guild/GuildCommandRepository.php`
+
+## Core contract
+
+Interaction flow in this repo has two distinct sides:
+
+### Inbound
+
+- gateway dispatch handled by `InteractionCreate`
+- `Interaction::TYPES` chooses concrete subtype
+- nested data is exposed as typed interaction request parts
+- resolved users/members/entitlements are cached
+
+### Outbound
+
+- interaction response helpers or builders produce protocol-correct payloads
+- commands are declared with command builders/repositories
+- autocomplete and modal flows use interaction response types and component/modals builders
+
+Do not mix inbound part modeling with outbound builder modeling.
+
+## Typing rules
+
+### `Interaction::TYPES` is central
+
+If Discord adds or repo adds support for new interaction type:
+
+1. update `Interaction::TYPES`
+2. add subtype class if needed
+3. inspect `InteractionCreate`
+4. inspect builder/response paths if outbound behavior changes too
+
+### Resolved data should not stay loose if typed part exists
+
+`Interaction` and its request data parts should expose:
+
+- users
+- members
+- channels
+- roles
+- options
+
+through typed parts or typed collections where repo already has models.
+
+## `InteractionCreate` rules
+
+This handler is latency-sensitive and still responsible for cache correctness.
+
+Preserve these patterns:
+
+- type interaction early
+- cache resolved users
+- cache resolved members when guild/member context exists
+- avoid unnecessarily slow cache lookups that delay interaction handling
+- cache entitlements
+- route registered command execution/autocomplete callbacks
+
+The handler already overrides some cache behavior to stay fast. Do not "clean it up" into slower generic behavior without understanding timing tradeoffs.
+
+## Registered command routing rules
+
+There is an interaction-specific registered command tree in `RegisteredCommand`.
+
+Keep these facts straight:
+
+- this is separate from prefix-command `CommandClient\Command`
+- `Discord::listenCommand()` populates `application_commands`
+- `InteractionCreate` routes slash/autocomplete events into that tree
+- `RegisteredCommand` supports nested subcommand trees
+- autocomplete uses `suggest()`
+- execution uses `execute()`
+
+If change touches application command routing, inspect both:
+
+- `Discord::listenCommand()` path
+- `InteractionCreate` callback routing path
+
+## Resolved data and cache rules
+
+When payload provides users or members:
+
+- warm global user cache
+- warm guild member cache when guild is present
+- preserve interaction speed by preferring cheap access patterns
+
+When payload provides entitlements:
+
+- sync them into application entitlements repo
+
+Do not assume interaction payload is only for immediate response. It also updates local state for later code.
+
+## Performance rules
+
+Interaction code has less patience for extra work than many other gateway paths.
+
+Prefer:
+
+- type from payload
+- cache from payload
+- direct route to callback
+
+Avoid:
+
+- broad cache scans
+- avoidable REST fetches
+- generic helper usage if it adds measurable delay in hot path
+
+## Outbound response rules
+
+### Use builders where they exist
+
+- command definitions: `CommandBuilder`
+- modals: `ModalBuilder`
+- message/component payloads: message/component builders
+
+### Keep response type constants as public vocabulary
+
+`Interaction` defines response type constants. Use them to keep protocol semantics readable.
+
+### Modal and component usage constraints matter
+
+If interaction response uses components or modals:
+
+- validate allowed component contexts
+- preserve nested `type` + `data` response shape
+
+## Boundaries to preserve
+
+### Interaction system vs prefix command system
+
+They are different layers:
+
+- application commands / autocomplete / modals route through `RegisteredCommand` and interaction parts
+- message-prefix commands route through `DiscordCommandClient` and `CommandClient\Command`
+
+Do not unify them by shoving shared semantics into wrong layer. Shared ideas may exist, but execution paths are different.
+
+### Interaction part vs message part
+
+An interaction may reference a message, but it is not a message event. Keep response and request semantics on interaction types.
+
+## Smells
+
+Stop if you see:
+
+- new interaction type added without `Interaction::TYPES` update
+- resolved data left raw even though typed parts already exist
+- application command routing pushed into prefix-command code
+- autocomplete logic mixed with normal execute flow in confusing ways
+- interaction handler slowed down by broad cache or REST work
+- builders bypassed in favor of new raw response arrays for complex payloads
+
+## Checklist before commit
+
+- `Interaction::TYPES` still complete for supported types
+- `InteractionCreate` still types, caches, and routes correctly
+- resolved users/members/entitlements handled intentionally
+- registered command execution and autocomplete still work through existing tree
+- modal/component response behavior stays builder-friendly and protocol-correct
+- boundaries with prefix command layer preserved
+- docs/tests updated if public interaction behavior changed
+
+## Bottom line
+
+Interaction code in this repo is both protocol parsing and fast command routing. Keep it typed, cache-aware, and quick.

--- a/skills/legacy-command-client-keeper.md
+++ b/skills/legacy-command-client-keeper.md
@@ -1,0 +1,173 @@
+# Skill: legacy-command-client-keeper
+
+Use this skill when work touches:
+
+- `src/Discord/DiscordCommandClient.php`
+- `src/Discord/CommandClient/Command.php`
+
+This is optional-prefix-command skill. Load it when maintaining the message-command layer built on top of core `Discord`.
+
+## Goal
+
+Keep prefix-command behavior as a clean optional layer:
+
+- built on top of `Discord`
+- driven by message events
+- owning its own parsing, aliases, subcommands, cooldowns, and help behavior
+- separate from application-command interaction flow
+
+## Read in this order
+
+1. `src/Discord/DiscordCommandClient.php`
+2. `src/Discord/CommandClient/Command.php`
+3. Example or guide material using command client, if public behavior changes
+4. Interaction command path only if change risks cross-layer leakage:
+   - `src/Discord/Helpers/RegisteredCommand.php`
+   - `src/Discord/WebSockets/Events/InteractionCreate.php`
+
+## Core contract
+
+`DiscordCommandClient` extends `Discord`, but it does not replace core client architecture. It layers:
+
+- command-specific options
+- prefix detection
+- alias maps
+- command registry
+- default help command
+- message event routing into command callbacks
+
+The command layer should stay optional and message-driven.
+
+## Main responsibilities by class
+
+### `DiscordCommandClient`
+
+Owns:
+
+- command-client option resolution
+- wiring message event listeners during init
+- prefix and mention-prefix expansion
+- top-level command and alias registry
+- default help command behavior
+
+### `CommandClient\Command`
+
+Owns:
+
+- one command's callback
+- subcommand tree
+- alias mapping for subcommands
+- help metadata
+- cooldown tracking and cooldown messaging
+
+If code does not clearly belong to one of those two, re-check whether it belongs in core `Discord` instead.
+
+## Option rules
+
+`DiscordCommandClient` uses `OptionsResolver` for its own layer. Preserve existing semantics around:
+
+- `prefix`
+- `prefixes`
+- `name`
+- `description`
+- `defaultHelpCommand`
+- `discordOptions`
+- `caseInsensitiveCommands`
+- `internalRejectedPromiseHandler`
+
+Command-client options are not core runtime options. Keep them isolated unless a true cross-layer dependency exists.
+
+## Parsing rules
+
+Message-command flow today:
+
+1. command client listens on init
+2. prefix strings get mention placeholders expanded
+3. on message event, ignore self messages
+4. `checkForPrefix()` strips prefix
+5. args parsed via `str_getcsv(..., ' ', '\"', '\\\\')`
+6. command name resolved through commands then aliases
+7. command callback invoked
+8. string return values become reply messages
+
+If changing parsing, preserve expectations around:
+
+- mention prefixes
+- quoted arguments
+- alias lookup
+- case-insensitive mode
+
+## Help-system rules
+
+The default help command is not incidental. It is part of command-client feature set.
+
+Preserve:
+
+- per-command descriptions and long descriptions
+- usage text
+- alias display
+- subcommand display
+- embed-based help formatting
+
+If help behavior changes, inspect both top-level help and per-command help.
+
+## Cooldown and subcommand rules
+
+`CommandClient\Command` carries its own operational semantics:
+
+- cooldowns keyed by author id
+- subcommands recurse
+- alias lookup for subcommands
+- help visibility controlled by option metadata
+
+Do not move cooldown logic into unrelated core message or user models.
+
+## Boundaries with interaction commands
+
+This layer is not the same as application commands.
+
+Keep these separate:
+
+- prefix commands use `DiscordCommandClient` + `CommandClient\Command`
+- application commands use `Discord::listenCommand()` + `RegisteredCommand` + interaction events
+
+Do not try to force one abstraction to power both unless you intend a broad architectural redesign.
+
+Shared naming concepts are fine. Shared execution path is not current repo design.
+
+## Error-handling rules
+
+Internal rejected promises use `internalRejectedPromiseHandler`. Preserve that pattern rather than sprinkling silent catches or inconsistent logger behavior through callbacks.
+
+If user-facing callback returns string, reply behavior should remain simple and unsurprising.
+
+## Existing patterns worth copying
+
+- top-level command registration through `registerCommand()`
+- alias registration separated from command registration
+- subcommand tree managed inside `Command`
+- command options resolved once, then carried as help/cooldown metadata
+
+## Smells
+
+Stop if you see:
+
+- prefix-command concerns moving into `Message`, `Channel`, `Discord`, or interaction code
+- alias or cooldown state stored outside command layer
+- parsing changes that break quoted args or mention prefixes without explicit intent
+- help system logic duplicated in multiple places
+- interaction-command abstractions merged into prefix-command path
+
+## Checklist before commit
+
+- command-client options still resolve cleanly
+- prefix expansion and parsing still intentional
+- command and alias registry behavior still coherent
+- subcommand recursion still works
+- cooldown behavior still belongs to command objects
+- default help command still reflects command metadata
+- no leakage into interaction command layer unless explicitly intended
+
+## Bottom line
+
+Legacy command client is convenience layer, not core runtime. Keep it self-contained, predictable, and clearly separate from slash-command interactions.

--- a/skills/part-model-maintainer.md
+++ b/skills/part-model-maintainer.md
@@ -1,0 +1,283 @@
+# Skill: part-model-maintainer
+
+Use this skill when work touches `src/Discord/Parts/**/*`.
+
+This is not syntax guard. This is domain-model guard. Load it when changing what a Discord resource **is**, how it is hydrated, how it exposes related objects, or how it saves itself.
+
+## Goal
+
+Keep `Part` classes as the canonical in-memory representation of Discord resources:
+
+- raw API-shaped data lives in attributes
+- typed access lives through mutators and helpers
+- persistence delegates to repositories
+- permission and high-level domain rules stay close to the part
+- public magic surface stays documented
+
+## Read in this order
+
+1. `src/Discord/Parts/Part.php`
+2. `src/Discord/Parts/PartTrait.php`
+3. Representative concrete parts for the family you are touching:
+   - `src/Discord/Parts/Guild/Guild.php`
+   - `src/Discord/Parts/Channel/Channel.php`
+   - `src/Discord/Parts/Channel/Message.php`
+   - `src/Discord/Parts/User/User.php`
+   - `src/Discord/Parts/User/Member.php`
+   - `src/Discord/Parts/Thread/Thread.php`
+   - `src/Discord/Parts/Interactions/Interaction.php`
+4. The owning repository for the part
+5. Gateway events that hydrate or update the part
+
+Do not start from a random leaf class alone. `PartTrait` defines most real behavior.
+
+## Core contract
+
+Every real part sits on same base contract:
+
+- extends `Discord\Parts\Part`
+- inherits `PartTrait`
+- constructed with `(Discord $discord, array $attributes = [], bool $created = false)`
+- stores raw Discord payload fields in `$attributes`
+- only mass-assigns keys in `$fillable`
+- exposes related repositories from `$repositories`
+- resolves computed or typed values through `get{Studly}Attribute()`
+- normalizes writes through `set{Studly}Attribute()`
+- persists through `getRepository()` + `save()`
+
+If change breaks one of those assumptions, stop and re-check layer ownership.
+
+## Meaning of common properties
+
+### `$fillable`
+
+Whitelist for `fill()` and dynamic writes. If field is missing here:
+
+- gateway hydration ignores it
+- REST fetch hydration ignores it
+- direct `$part->field = ...` writes do not persist to `$attributes`
+- magic property docblocks become misleading
+
+When adding new API field, first ask: should this be part of canonical stored state? If yes, add it to `$fillable`.
+
+### `$attributes`
+
+Raw storage. Usually snake_case and Discord-shaped. Avoid putting derived state here unless the API itself uses that field.
+
+### `$repositories`
+
+Map of magic property name to repository class. This is how parts expose child collections like:
+
+- `$guild->channels`
+- `$channel->messages`
+- `$message->reactions`
+
+If child data should behave like a repository, wire it here. Do not fake repo behavior with arrays.
+
+### `$created`
+
+Tracks whether part already exists on Discord side.
+
+- `false` means local draft or partial unsaved object
+- `true` means known remote object
+
+Repository `save()` uses this to choose POST vs PATCH. Nested `createOf()` links child `created` state back to parent. Preserve that when materializing nested parts.
+
+## Core methods and what they mean
+
+### `fill(array $attributes)`
+
+Hydrates only fillable keys. It is not "dump every payload field in object". If new data is not appearing after fetch/event handling, check `$fillable` first.
+
+### `getAttribute()` / `__get()`
+
+Resolution order matters:
+
+1. repository from `$repositories`
+2. getter mutator
+3. raw attribute
+4. `null`
+
+This is why magic properties can expose both repositories and computed values. Preserve this behavior when adding convenience fields.
+
+### `setAttribute()` / `__set()`
+
+Setter mutator first, then raw write only if key is fillable. This protects parts from accidental shape drift. Do not bypass it by writing stray protected properties for true resource state.
+
+### `getCreatableAttributes()` / `getUpdatableAttributes()`
+
+These define what the repository sends to Discord. They are not debug dumps. They should express API intent:
+
+- required vs optional
+- create vs update differences
+- omit optional values that were never set when API cares about missing vs null
+
+Prefer `makeOptionalAttributes()` to avoid serializing absent optional fields.
+
+### `getRepository()`
+
+Returns the owning repository for this part instance. This is frequently context-sensitive:
+
+- `Guild` returns top-level `$discord->guilds`
+- `Channel` chooses guild channels vs private channels
+- `Message` chooses channel messages vs webhook messages
+- `Member` depends on `guild_id`
+- `Thread` depends on parent channel
+
+When repository ownership depends on parent IDs, also inspect `getRepositoryAttributes()`.
+
+### `save(?string $reason = null)`
+
+Part-level `save()` is where high-level semantic guards live:
+
+- permission checks
+- ownership routing
+- special-case endpoints for current user/current member/group DM/webhook cases
+
+Rule: if logic needs knowledge of what operation **means**, it likely belongs here. If logic only knows how to execute REST+cache, it belongs in repository.
+
+### `fetch()`
+
+Only override when part can be refreshed independently from Discord and that contract is meaningful. If part is not fetchable, default runtime exception is fine.
+
+## Helper methods to prefer
+
+### `attributeCarbonHelper($key)`
+
+Use for timestamp-ish fields. Keeps repeated `Carbon::parse` logic out of concrete parts.
+
+### `attributePartHelper($key, $class, $extraData = [])`
+
+Use when field is a nested Discord object and you want lazy typed hydration with caching in `$attributes`.
+
+Good for:
+
+- nested `User`
+- nested `Guild`
+- nested `Message`
+- nested message metadata objects
+
+### `attributeCollectionHelper($key, $class, ?string $discrim = 'id', ?array $extraData = [])`
+
+Use for homogeneous nested collections of one concrete part type.
+
+### `attributeTypedCollectionHelper($class, $key)`
+
+Use when payload element type decides subclass at runtime. This is important for:
+
+- message components
+- other subtype families with `TYPES` maps
+
+### `createOf(string $class, array|object $data)`
+
+Prefer this over raw factory calls for nested child parts because it preserves `created` linkage.
+
+## Part design patterns already used in repo
+
+### Raw ID plus resolved relation
+
+Common pair:
+
+- raw: `guild_id`, `channel_id`, `owner_id`
+- resolved: `guild`, `channel`, `owner`
+
+Keep both if the API provides IDs and the library benefits from relation convenience.
+
+### Constants as public vocabulary
+
+Large resource parts publish Discord enum values and flags as class constants. Keep aliases when the project already supports deprecated constant names for compatibility.
+
+### Traits for shared semantics
+
+If behavior applies horizontally across siblings, prefer trait:
+
+- `ChannelTrait`
+- `GuildTrait`
+
+Do not introduce a new intermediate abstract class unless there is truly no cleaner trait shape.
+
+### PHPDoc as magic surface contract
+
+Update class docblock whenever you add:
+
+- fillable raw field
+- computed read-only property
+- repository property
+- new typed collection
+
+If code and docblock drift, IDE help and generated reference docs drift too.
+
+## Save and routing playbook
+
+When making a part persistable or changing save behavior:
+
+1. Define or update `getCreatableAttributes()`
+2. Define or update `getUpdatableAttributes()`
+3. Define or update `getRepository()`
+4. Define or update `save()`
+5. Define or update `getRepositoryAttributes()`
+6. Inspect owning repository endpoint vars
+7. Inspect gateway events that hydrate/update the part
+
+### Examples worth copying
+
+- `Channel::save()` handles guild permission checks and group-DM special case before repository delegation
+- `Message::save()` handles send/manage permissions and webhook message routing
+- `Member::save()` handles current-member special route instead of generic repository save
+- `Thread::save()` blocks unsupported creation path and redirects callers to `Channel::startThread()`
+
+## Nested data playbook
+
+When new Discord payload includes nested object:
+
+1. Ask if repo already has a `Part` type for it
+2. If yes, add field to `$fillable`
+3. Add getter mutator using helper
+4. Add docblock type
+5. If nested collection, choose homogeneous vs typed collection helper
+6. If nested item needs parent IDs, pass `extraData`
+
+Do not leave meaningful nested objects as raw arrays if equivalent typed part exists.
+
+## Repository-binding playbook
+
+When child repository routes depend on parent context:
+
+1. expose repository in `$repositories`
+2. make sure parent part has required IDs in `$attributes`
+3. override `getRepositoryAttributes()` when raw `$attributes` is not enough or not in right shape
+4. inspect repository constructor for `$vars` assumptions
+
+Examples:
+
+- channels need `guild_id` and `channel_id`
+- messages need `channel_id`, maybe `guild_id`, maybe webhook context
+- members need `guild_id`
+
+## Smells
+
+Stop if you see:
+
+- raw arrays where typed nested parts already exist
+- new field added to docblock but not to `$fillable`
+- `save()` building raw endpoints even though repository exists
+- permission check added only in repository while part clearly knows semantic action
+- part state stored in new ad hoc property instead of `$attributes`
+- child repository added without `getRepositoryAttributes()` support
+- subtype family added without updating a `TYPES` map or typed collection helper path
+
+## Checklist before commit
+
+- `$fillable` matches intended canonical fields
+- getter/setter mutators added where typing or normalization needed
+- `$repositories` updated if new child collection exposed
+- `getCreatableAttributes()` / `getUpdatableAttributes()` express API semantics
+- `getRepository()` and `getRepositoryAttributes()` route correctly
+- `save()` enforces semantic permission or special-case behavior when needed
+- class docblock reflects public magic surface
+- related repository and gateway event code still coherent
+- tests/docs updated if public behavior changed
+
+## Bottom line
+
+Part classes in this repo are not dumb DTOs and not service objects. They are typed, lazily-resolved domain resources with controlled hydration and repository-backed persistence. Keep them centered on that job.

--- a/skills/repository-cache-keeper.md
+++ b/skills/repository-cache-keeper.md
@@ -1,0 +1,246 @@
+# Skill: repository-cache-keeper
+
+Use this skill when work touches `src/Discord/Repository/**/*`.
+
+This is cache-and-REST boundary skill. Load it when a change affects how parts are collected, fetched, persisted, cached, or routed to endpoints.
+
+## Goal
+
+Keep repositories as:
+
+- typed collections
+- route-aware REST wrappers
+- cache coordinators
+- owning persistence boundary for a part family
+
+Not as service dumping ground.
+
+## Read in this order
+
+1. `src/Discord/Repository/AbstractRepository.php`
+2. `src/Discord/Repository/AbstractRepositoryTrait.php`
+3. `src/Discord/Parts/PartTrait.php` sections for `getRepositoryAttributes()`, `getCreatableAttributes()`, `getUpdatableAttributes()`
+4. `src/Discord/Helpers/CacheWrapper.php` and cache config code if cache behavior matters
+5. Representative repos:
+   - `src/Discord/Repository/GuildRepository.php`
+   - `src/Discord/Repository/Guild/ChannelRepository.php`
+   - `src/Discord/Repository/Channel/MessageRepository.php`
+   - `src/Discord/Repository/Interaction/GlobalCommandRepository.php`
+   - `src/Discord/Repository/Guild/GuildCommandRepository.php`
+6. The owning part for the repository you are touching
+
+## Core contract
+
+Every repository centers on same shape:
+
+- extends `AbstractRepository`
+- sets `$class` to the concrete part family
+- usually sets `$endpoints`
+- may override `$discrim`
+- receives `$vars` route context from parent part or caller
+- stores typed items in collection semantics
+- persists through HTTP
+- mirrors authoritative state into cache
+
+If a method no longer feels like typed collection + route-aware persistence, it probably belongs elsewhere.
+
+## Meaning of common properties
+
+### `$class`
+
+Concrete part family allowed in this repository. If wrong, hydration, type checks, and cache writes all become unsafe.
+
+### `$endpoints`
+
+Route templates keyed by operation name. Typical keys:
+
+- `all`
+- `get`
+- `create`
+- `update`
+- `delete`
+
+Not every repository supports every operation. Missing endpoint is an intentional capability statement.
+
+### `$vars`
+
+Route-binding context. This is how nested repos know where they live:
+
+- guild repositories get `guild_id`
+- channel repositories get `channel_id`
+- some repos also need `application_id`, `message_id`, or other parent route pieces
+
+When repo behavior looks wrong, inspect parent part `getRepositoryAttributes()` first.
+
+### `$discrim`
+
+Collection key field, usually `id`. Only change when payload family genuinely keys on a different field.
+
+### `$cache`
+
+Per-repository cache wrapper. It is not optional frosting. Repo methods should keep it coherent with in-memory `items`.
+
+## Core methods and what they mean
+
+### `create(array|object $attributes = [], bool $created = false)`
+
+Builds local typed part using repository context plus attributes. No REST call. No remote persistence. Use it for drafts or hydration helpers.
+
+### `save(Part $part, ?string $reason = null)`
+
+Generic persistence path:
+
+- POST when `$part->created` is false
+- PATCH when `$part->created` is true
+- uses part-provided repository attributes and creatable/updatable attributes
+- updates cache with returned part
+
+Part-level `save()` may wrap or redirect this when semantics demand it.
+
+### `delete($part, ?string $reason = null)`
+
+Remote delete plus cache removal. Accepts part or identifier. Keep typed return contract.
+
+### `fetch(string $id, bool $fresh = false)`
+
+Resolve from memory, then cache, then REST unless forced fresh. This is one of main async entry points. Keep it Promise-based.
+
+### `fresh(Part $part, array $queryparams = [])`
+
+Refresh a known created part from REST and update cache.
+
+### `freshen(array $queryparams = [])`
+
+Bulk refresh repository contents from REST. This is repo-wide sync tool, not a one-item fetch.
+
+## How cache and collection semantics fit together
+
+Repositories are hybrid objects:
+
+- collection-like for iteration, filtering, `get()`, `find()`, `first()`, `last()`
+- async cache-aware for `cacheGet()`, `cachePull()`, `fetch()`, `freshen()`
+
+That dual nature is intentional. Do not flatten repository into only async map or only plain collection.
+
+### Important behavior to preserve
+
+- in-memory `items` can hold real parts, `WeakReference`, or null placeholders
+- cache wrapper may outlive in-memory strong references
+- repo methods often try memory first, then cache, then REST
+- successful REST mutations should refresh cache state immediately
+
+## Endpoint routing rules
+
+### Use `Endpoint` and bound vars
+
+Repository methods should bind route vars through `Endpoint`/`Endpoint::bind()`, not manual string interpolation spread across code.
+
+### Parent context comes from parts
+
+If child repository starts losing route info, fix parent part `getRepositoryAttributes()` or repo constructor normalization, not random callers.
+
+### Constructor normalization is acceptable
+
+If a repo needs to clean or enrich vars for route correctness, constructor override is fine. Example patterns already exist:
+
+- `MessageRepository` unsets `thread_id` for thread message routing
+- `GuildCommandRepository` injects bot application id
+
+## When to add domain-specific repository methods
+
+Add repo-specific methods when operation is broader than generic CRUD and naturally belongs to collection/route boundary.
+
+Good examples:
+
+- leaving a guild from `GuildRepository`
+- previewing a guild from `GuildRepository`
+- creating guild channels from `ChannelRepository`
+
+Bad examples:
+
+- permission-heavy semantic operation better expressed as `$part->save()` or `$part->someAction()`
+- userland convenience that only repackages one line and adds no domain meaning
+
+## Ownership boundary: part vs repository
+
+### Part owns
+
+- semantic meaning of operation
+- permission checks
+- special-case routing based on object meaning
+- public high-level API surface
+
+### Repository owns
+
+- endpoint selection
+- request method and payload dispatch
+- cache persistence
+- typed hydration from HTTP response
+
+If code needs to know "is this current member or generic member", "is this webhook message or normal message", or "does bot need manage_messages here", that usually belongs on part side first.
+
+## New repository playbook
+
+1. Choose concrete part family and set `$class`
+2. Set `$endpoints`
+3. Decide `$discrim`
+4. Verify parent route vars required
+5. Verify parent part `getRepositoryAttributes()`
+6. Add domain-specific methods only if generic CRUD not enough
+7. Inspect gateway events that should populate this repo
+8. Add docblock `@method` helpers if family uses them
+
+## Existing patterns worth copying
+
+### Thin specialization
+
+Some repos are intentionally small:
+
+- `GlobalCommandRepository`
+- `MessageRepository`
+
+That is okay. Not every repo needs custom methods.
+
+### Constructor route correction
+
+If nested route shape is tricky, normalize vars in constructor instead of forcing every caller to know internals.
+
+### Cache-first reads
+
+Methods like `fetch()` and `get()` preserve performance by preferring in-memory/cache before REST. Keep that bias unless correctness requires bypass.
+
+## Gateway interaction rules
+
+Repositories are often updated from gateway events, not only from their own REST methods. When changing repository keying or cache semantics, inspect matching event handlers. If repository expectations change but event cache writes do not, the repo will look "randomly stale".
+
+Common families to cross-check:
+
+- guild/channel/message/thread create/update/delete events
+- interaction entitlements or command-related caches
+- member/user/presence caches
+
+## Smells
+
+Stop if you see:
+
+- raw REST payloads returned where typed part should be returned
+- new route vars threaded manually through many call sites
+- repo mutating part semantics that belong in part `save()`
+- cache not updated after successful REST mutation
+- in-memory `items` updated but cache wrapper ignored, or reverse
+- parent part and repo disagree on route context
+- generic service/helper class added to do what repository already does
+
+## Checklist before commit
+
+- `$class`, `$endpoints`, `$discrim`, `$vars` still describe repo correctly
+- parent `getRepositoryAttributes()` still supplies needed route vars
+- create/save/delete/fetch semantics remain typed and Promise-based
+- cache and in-memory items stay aligned
+- any special methods belong here semantically
+- related gateway event handlers still populate repo coherently
+- docs/tests updated if public behavior changed
+
+## Bottom line
+
+Repository code in this repo should feel boring in right way: typed, route-aware, cache-coherent, and predictable. If a repository starts making domain decisions or returning untyped transport data, pull it back to its real job.


### PR DESCRIPTION
Just some handy dandy files that add "skills" for AI agents to read to (hopefully) make AI workflows more consistent across the repo.

At the top level:
 
- `SKILLS.md` is the quick map. It lays out the big-picture rules for the repo and points agents at the right skill depending on what they’re touching.
- `AGENTS.md` is more of a working guide. It explains how the repo is structured, which files tend to move together, and the kinds of boundaries agents should try to preserve.
 
Then there are a few deeper skills for the main hotspots:
 
- `skills/part-model-maintainer.md` covers how Parts are supposed to work: `$fillable`, mutators, nested typed data, repository bindings, save/fetch hooks, and docblocks.
- `skills/repository-cache-keeper.md` covers repositories: endpoint vars, CRUD flow, cache behavior, and where repository logic should stop and part logic should take over.
- `skills/gateway-cache-sync-keeper.md` covers gateway event handlers: how payloads become typed parts, how caches should be updated, and what related repos or side effects need to stay in sync.
- `skills/builder-payload-smith.md` covers builders: payload validation, `jsonSerialize()` rules, component usage, and keeping builders separate from Parts.
- `skills/interaction-flow-keeper.md` covers interactions: typed interaction handling, resolved data hydration, command/autocomplete routing, and response flow.
- `skills/legacy-command-client-keeper.md` covers the older prefix-command layer so agents keep that model separate from slash-command and interaction code.
 
So basically: broad repo rules up top, then more detailed guidance for the areas that are easiest to get subtly wrong.