### PR TITLE
Update Factory class implementation to use a switch

### DIFF
--- a/src/Discord/Factory/Factory.php
+++ b/src/Discord/Factory/Factory.php
@@ -60,16 +60,19 @@ class Factory
             $data = (array) $data;
         }
 
-        if (is_subclass_of($class, Part::class)) {
-            $object = $this->part($class, $data, $created);
-        } elseif (is_subclass_of($class, AbstractRepository::class)) {
-            $object = $this->repository($class, $data);
-        } elseif (strpos($class, 'Discord\\Parts') !== false) {
-            $object = $this->part($class, $data, $created);
-        } elseif (strpos($class, 'Discord\\Repository') !== false) {
-            $object = $this->repository($class, $data);
-        } else {
-            throw new \Exception('The class '.$class.' is not a Part or a Repository.');
+        switch (true) {
+            case is_subclass_of($class, Part::class):
+            case strpos($class, 'Discord\\Parts') !== false:
+                $object = $this->part($class, $data, $created);
+                break;
+
+            case is_subclass_of($class, AbstractRepository::class):
+            case strpos($class, 'Discord\\Repository') !== false:
+                $object = $this->repository($class, $data);
+                break;
+
+            default:
+                throw new \Exception('The class '.$class.' is not a Part or a Repository.');
         }
 
         return $object;


### PR DESCRIPTION
This pull request refactors the logic for instantiating objects in the `Factory::create` method to make it more maintainable and less error-prone. The main improvement is the use of a `switch (true)` statement to consolidate condition checks for class types, reducing duplicated code and improving readability.

Refactoring and logic simplification:

* Refactored the conditional logic in `Factory.php`'s `create` method to use a `switch (true)` construct, consolidating checks for `Part` and `Repository` subclasses and their namespace strings, which eliminates duplicated code paths and makes future maintenance easier.