### PR TITLE
MessageCommandClient

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -328,6 +328,8 @@ When you need an example worth imitating, start here:
 - Use `wait()` from `tests/functions.php` to bridge promises into test assertions.
 - Keep semantic tests focused on behavior, not on incidental implementation details.
 
+- When a test requires a live `Discord` or `MessageCommandClient` instance (for example, to exercise registration, event handling, or runtime integration), obtain the client via the `wait(function (Discord $discord, $resolve) { ... })` pattern (and extend `DiscordTestCase`) rather than attempting to mock `Discord`/`MessageCommandClient`. Use mocks or `PHPUnit\Framework\TestCase` only for isolated logic that does not need a runtime client.
+
 ### Docs
 
 - Public magic properties, repositories, and helpers should be reflected in PHPDoc.

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,27 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.5/phpunit.xsd"
-         bootstrap="tests/bootstrap.php"
-         cacheResultFile=".phpunit.cache/test-results"
-         executionOrder="depends,defects"
-         forceCoversAnnotation="false"
-         beStrictAboutCoversAnnotation="false"
-         beStrictAboutOutputDuringTests="true"
-         beStrictAboutTodoAnnotatedTests="true"
-         failOnRisky="true"
-         failOnWarning="true"
-         verbose="true">
-    <testsuites>
-        <testsuite name="default">
-            <directory suffix="Test.php">tests</directory>
-            <!--<file>tests/DiscordTest.php</file>-->
-        </testsuite>
-    </testsuites>
-
-    <coverage cacheDirectory=".phpunit.cache/code-coverage"
-              processUncoveredFiles="true">
-        <include>
-            <directory suffix=".php">src</directory>
-        </include>
-    </coverage>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/12.5/phpunit.xsd" bootstrap="tests/bootstrap.php" executionOrder="depends,defects" beStrictAboutOutputDuringTests="true" failOnRisky="true" failOnWarning="true" cacheDirectory=".phpunit.cache" requireCoverageMetadata="false" beStrictAboutCoverageMetadata="false">
+  <testsuites>
+    <testsuite name="default">
+      <directory suffix="Test.php">tests</directory>
+      <!--<file>tests/DiscordTest.php</file>-->
+    </testsuite>
+  </testsuites>
+  <source>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+  </source>
 </phpunit>

--- a/phpunit.xml.bak
+++ b/phpunit.xml.bak
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.5/phpunit.xsd"
+         bootstrap="tests/bootstrap.php"
+         cacheResultFile=".phpunit.cache/test-results"
+         executionOrder="depends,defects"
+         forceCoversAnnotation="false"
+         beStrictAboutCoversAnnotation="false"
+         beStrictAboutOutputDuringTests="true"
+         beStrictAboutTodoAnnotatedTests="true"
+         failOnRisky="true"
+         failOnWarning="true"
+         verbose="true">
+    <testsuites>
+        <testsuite name="default">
+            <directory suffix="Test.php">tests</directory>
+            <!--<file>tests/DiscordTest.php</file>-->
+        </testsuite>
+    </testsuites>
+
+    <coverage cacheDirectory=".phpunit.cache/code-coverage"
+              processUncoveredFiles="true">
+        <include>
+            <directory suffix=".php">src</directory>
+        </include>
+    </coverage>
+</phpunit>

--- a/src/Discord/Discord.php
+++ b/src/Discord/Discord.php
@@ -116,7 +116,7 @@ class Discord
      *
      * @var string Version.
      */
-    public const VERSION = 'v10.48.0';
+    public const VERSION = 'v10.49.0';
 
     public const REFERRER = 'https://github.com/discord-php/DiscordPHP';
 

--- a/src/Discord/Discord.php
+++ b/src/Discord/Discord.php
@@ -142,6 +142,36 @@ class Discord
     protected $options = [];
 
     /**
+     * An array of defined options for validation and resolution.
+     * 
+     * @var string[] Defined options.
+     */
+    protected $definedOptions = [
+        'token',
+        'loop',
+        'logger',
+        'loadAllMembers',
+        'disabledEvents',
+        'storeMessages',
+        'retrieveBans',
+        'large_threshold',
+        'shard',
+        'shard_id',
+        'num_shards',
+        'shardId',
+        'shardCount',
+        'presence',
+        'intents',
+        'capabilities',
+        'socket_options',
+        'dnsConfig',
+        'cache',
+        'collection',
+        'useTransportCompression',
+        'usePayloadCompression',
+    ];
+
+    /**
      * The authentication token.
      *
      * @var string Token.
@@ -1888,30 +1918,7 @@ class Discord
 
         $resolver
             ->setRequired('token')
-            ->setDefined([
-                'token',
-                'loop',
-                'logger',
-                'loadAllMembers',
-                'disabledEvents',
-                'storeMessages',
-                'retrieveBans',
-                'large_threshold',
-                'shard',
-                'shard_id',
-                'num_shards',
-                'shardId',
-                'shardCount',
-                'presence',
-                'intents',
-                'capabilities',
-                'socket_options',
-                'dnsConfig',
-                'cache',
-                'collection',
-                'useTransportCompression',
-                'usePayloadCompression',
-            ])
+            ->setDefined($this->definedOptions)
             ->setDefaults([
                 'logger' => null,
                 'loadAllMembers' => false,

--- a/src/Discord/Discord.php
+++ b/src/Discord/Discord.php
@@ -143,7 +143,7 @@ class Discord
 
     /**
      * An array of defined options for validation and resolution.
-     * 
+     *
      * @var string[] Defined options.
      */
     protected $definedOptions = [

--- a/src/Discord/DiscordCommandClient.php
+++ b/src/Discord/DiscordCommandClient.php
@@ -120,7 +120,7 @@ class DiscordCommandClient extends Discord
                         $commandString = array_shift($args);
                         $newCommand = $command->getCommand($commandString);
 
-                        if (null === $newCommand) {
+                        if ($newCommand === null) {
                             return "The command {$commandString} does not exist.";
                         }
 

--- a/src/Discord/DiscordCommandClient.php
+++ b/src/Discord/DiscordCommandClient.php
@@ -364,12 +364,7 @@ class DiscordCommandClient extends Discord
             $this,
             $command,
             $callable,
-            $options['description'],
-            $options['longDescription'],
-            $options['usage'],
-            $options['cooldown'],
-            $options['cooldownMessage'],
-            $options['showHelp']
+            $options
         );
 
         return [$commandInstance, $options];

--- a/src/Discord/DiscordCommandClient.php
+++ b/src/Discord/DiscordCommandClient.php
@@ -364,7 +364,12 @@ class DiscordCommandClient extends Discord
             $this,
             $command,
             $callable,
-            $options
+            $options['description'],
+            $options['longDescription'],
+            $options['usage'],
+            $options['cooldown'],
+            $options['cooldownMessage'],
+            $options['showHelp']
         );
 
         return [$commandInstance, $options];

--- a/src/Discord/DiscordCommandClient.php
+++ b/src/Discord/DiscordCommandClient.php
@@ -22,7 +22,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  * Provides an easy way to have triggerable message based commands.
  *
  * @since 4.0.0
- * 
+ *
  * @deprecated 10.49.0 Use 'MessageCommandClient'
  */
 class DiscordCommandClient extends Discord

--- a/src/Discord/DiscordCommandClient.php
+++ b/src/Discord/DiscordCommandClient.php
@@ -22,6 +22,8 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  * Provides an easy way to have triggerable message based commands.
  *
  * @since 4.0.0
+ * 
+ * @deprecated 10.49.0 Use 'MessageCommandClient'
  */
 class DiscordCommandClient extends Discord
 {

--- a/src/Discord/MessageCommandClient.php
+++ b/src/Discord/MessageCommandClient.php
@@ -345,7 +345,7 @@ class MessageCommandClient extends Discord
         }
 
         if (method_exists($this, 'emit')) {
-            $this->emit('messagecommandclient.command.registered', [$name, $commandInstance, $resolvedOptions]);
+            $this->emit('command-registered', [$name, $commandInstance, $resolvedOptions]);
         }
 
         return $commandInstance;

--- a/src/Discord/MessageCommandClient.php
+++ b/src/Discord/MessageCommandClient.php
@@ -395,7 +395,6 @@ class MessageCommandClient extends Discord
 
         if (count($args) > 0) {
             $command = null;
-            $commandParts = [];
             $fullCommandString = implode(' ', $args);
 
             while (count($args) > 0) {
@@ -418,7 +417,6 @@ class MessageCommandClient extends Discord
                 }
 
                 $command = $newCommand;
-                $commandParts[] = $commandString;
             }
 
             $help = $command->getHelp($prefix);

--- a/src/Discord/MessageCommandClient.php
+++ b/src/Discord/MessageCommandClient.php
@@ -20,7 +20,6 @@ use Discord\MessageCommandClient\CommandRegistry;
 use Discord\MessageCommandClient\Command;
 use Discord\Parts\Channel\Message;
 use Discord\Parts\Embed\Embed;
-use Monolog\Level;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\OptionsResolver\Options;
 

--- a/src/Discord/MessageCommandClient.php
+++ b/src/Discord/MessageCommandClient.php
@@ -206,7 +206,7 @@ class MessageCommandClient extends Discord
 
         // Ensure no collision with existing command or alias names.
         if ($this->registry->has($name)) {
-            throw new \RuntimeException("A command with the name {$name} already exists.");
+            throw new \RuntimeException("A command with the same name already exists.");
         }
 
         $this->registry->add($name, $commandInstance);
@@ -218,7 +218,7 @@ class MessageCommandClient extends Discord
 
             $aliasNormalized = $this->normalizeCommandName($alias);
             if ($this->registry->has($aliasNormalized)) {
-                throw new \RuntimeException("An alias with the name {$aliasNormalized} already exists.");
+                throw new \RuntimeException("An alias with the same name already exists.");
             }
 
             $this->registry->addAlias((string) $aliasNormalized, $name);
@@ -241,7 +241,7 @@ class MessageCommandClient extends Discord
     public function unregisterCommand(string $name): void
     {
         if (! $this->registry->hasCommand($name)) {
-            throw new \RuntimeException("A command with the name {$name} does not exist.");
+            throw new \RuntimeException("A command with the same name does not exist.");
         }
 
         $this->registry->remove($name);
@@ -261,11 +261,11 @@ class MessageCommandClient extends Discord
         $commandNormalized = $this->normalizeCommandName($command);
 
         if ($this->registry->has($aliasNormalized)) {
-            throw new \RuntimeException("An alias with the name {$aliasNormalized} already exists.");
+            throw new \RuntimeException("An alias with the same name already exists.");
         }
 
         if (! $this->registry->hasCommand($commandNormalized)) {
-            throw new \RuntimeException("A command with the name {$commandNormalized} does not exist.");
+            throw new \RuntimeException("A command with the same name does not exist.");
         }
 
         $this->registry->addAlias($aliasNormalized, $commandNormalized);

--- a/src/Discord/MessageCommandClient.php
+++ b/src/Discord/MessageCommandClient.php
@@ -401,16 +401,31 @@ class MessageCommandClient extends Discord
         $prefix = str_replace((string) $this->user, '@'.$this->username, $this->options['prefix']);
 
         if (count($args) > 0) {
-            $command = $this;
+            $command = null;
+            $commandParts = [];
+            $fullCommandString = implode(' ', $args);
+
             while (count($args) > 0) {
                 $commandString = array_shift($args);
-                $newCommand = $this->getCommand($commandString);
 
-                if (null === $newCommand) {
+                if ($this->options['caseInsensitiveCommands']) {
+                    $commandString = function_exists('mb_strtolower')
+                        ? mb_strtolower($commandString)
+                        : strtolower($commandString);
+                }
+
+                if ($command === null) {
+                    $newCommand = $this->getCommand($commandString);
+                } else {
+                    $newCommand = $command->getCommand($commandString);
+                }
+
+                if ($newCommand === null) {
                     return "The command {$commandString} does not exist.";
                 }
 
                 $command = $newCommand;
+                $commandParts[] = $commandString;
             }
 
             $help = $command->getHelp($prefix);
@@ -420,7 +435,7 @@ class MessageCommandClient extends Discord
 
             $embed = new Embed($this);
             $embed->setAuthor($this->options['name'], $this->client->user->avatar)
-                ->setTitle($prefix.implode(' ', $args).'\'s Help')
+                ->setTitle($prefix.$fullCommandString.'\'s Help')
                 ->setDescription(! empty($help['longDescription']) ? $help['longDescription'] : $help['description'])
                 ->setFooter($this->options['name']);
 
@@ -436,7 +451,6 @@ class MessageCommandClient extends Discord
         $embed = new Embed($this);
         $embed->setAuthor($this->options['name'], $this->client->avatar)
             ->setTitle($this->options['name'])
-            ->setType(Embed::TYPE_RICH)
             ->setFooter($this->options['name']);
 
         $commandsDescription = '';

--- a/src/Discord/MessageCommandClient.php
+++ b/src/Discord/MessageCommandClient.php
@@ -28,13 +28,6 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 class MessageCommandClient extends Discord
 {
     /**
-     * Options passed to the command client.
-     *
-     * @var array<string,mixed>
-     */
-    protected array $options;
-
-    /**
      * Command registry storing commands and aliases.
      *
      * @var CommandRegistry

--- a/src/Discord/MessageCommandClient.php
+++ b/src/Discord/MessageCommandClient.php
@@ -115,7 +115,9 @@ class MessageCommandClient extends Discord
         }
 
         if ($this->options['caseInsensitiveCommands']) {
-            $commandName = mb_strtolower($commandName);
+            $commandName = function_exists('mb_strtolower')
+                ? mb_strtolower($commandName)
+                : strtolower($commandName);
         }
 
         $command = $this->registry->get($commandName);
@@ -140,10 +142,39 @@ class MessageCommandClient extends Discord
     protected function checkForPrefix(string $content): ?string
     {
         foreach ($this->options['prefixes'] as $prefix) {
+            $matchedContent = $this->removePrefixFromContent($content, (string) $prefix);
+            if ($matchedContent !== null) {
+                return $matchedContent;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Remove a prefix from content when it matches.
+     *
+     * @param string $content Message content.
+     * @param string $prefix  Prefix to match.
+     *
+     * @return string|null Content without prefix, or null when no match.
+     */
+    protected function removePrefixFromContent(string $content, string $prefix): ?string
+    {
+        static $hasMbString = function_exists('mb_strlen') && function_exists('mb_substr');
+
+        if ($hasMbString) {
             $len = mb_strlen($prefix);
             if (mb_substr($content, 0, $len) === $prefix) {
                 return mb_substr($content, $len);
             }
+
+            return null;
+        }
+
+        $len = strlen($prefix);
+        if (substr($content, 0, $len) === $prefix) {
+            return substr($content, $len);
         }
 
         return null;
@@ -266,7 +297,7 @@ class MessageCommandClient extends Discord
 
         return [
             'command' => $commandInstance,
-            'options' => $options
+            'options' => $options,
         ];
     }
 

--- a/src/Discord/MessageCommandClient.php
+++ b/src/Discord/MessageCommandClient.php
@@ -1,0 +1,464 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is a part of the DiscordPHP project.
+ *
+ * Copyright (c) 2015-2022 David Cole <david.cole1340@gmail.com>
+ * Copyright (c) 2020-present Valithor Obsidion <valithor@discordphp.org>
+ *
+ * This file is subject to the MIT license that is bundled
+ * with this source code in the LICENSE.md file.
+ */
+
+namespace Discord;
+
+use Discord\MessageCommandClient\CommandRegistry;
+use Discord\MessageCommandClient\Command;
+use Discord\Parts\Channel\Message;
+use Discord\Parts\Embed\Embed;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+/**
+ * Modern, modular replacement for the legacy DiscordCommandClient.
+ *
+ * @since 10.49.0
+ */
+class MessageCommandClient extends Discord
+{
+    /**
+     * Options passed to the command client.
+     *
+     * @var array<string,mixed>
+     */
+    protected array $options;
+
+    /**
+     * Command registry storing commands and aliases.
+     *
+     * @var CommandRegistry
+     */
+    protected CommandRegistry $registry;
+
+    /**
+     * Construct the message command client.
+     *
+     * @param array $options Client options (see resolveOptions()).
+     */
+    public function __construct(array $options = [])
+    {
+        $this->options = $this->resolveOptions($options);
+
+        $discordOptions = array_merge($this->options['discordOptions'] ?? [], ['token' => $this->options['token']]);
+
+        parent::__construct($discordOptions);
+
+        $this->registry = new CommandRegistry((bool) ($this->options['caseInsensitiveCommands'] ?? false));
+
+        $this->on('init', function () {
+            $this->preparePrefixes();
+
+            $this->on('message', function ($message) {
+                $this->handleMessage($message);
+            });
+        });
+
+        if ($this->options['defaultHelpCommand']) {
+            $this->registerCommand('help', function ($message, $args) {
+                return $this->defaultHelpHandler($message, $args);
+            }, [
+                'description' => 'Provides a list of commands available.',
+                'usage' => '[command]',
+            ]);
+        }
+    }
+
+    /**
+     * Prepare and normalize prefixes, expanding @mention placeholders.
+     */
+    protected function preparePrefixes(): void
+    {
+        $this->options['prefix'] = str_replace('@mention', (string) $this->user, $this->options['prefix']);
+        $this->options['name'] = str_replace('<UsernamePlaceholder>', $this->username, $this->options['name']);
+
+        foreach ($this->options['prefixes'] as $key => $prefix) {
+            if (strpos($prefix, '@mention') !== false) {
+                $this->options['prefixes'][] = str_replace('@mention', "<@{$this->user->id}>", $prefix);
+                $this->options['prefixes'][] = str_replace('@mention', "<@!{$this->user->id}>", $prefix);
+                unset($this->options['prefixes'][$key]);
+            }
+        }
+    }
+
+    /**
+     * Handle an incoming message event and dispatch commands.
+     *
+     * @param Message $message The received message.
+     */
+    protected function handleMessage(Message $message): void
+    {
+        if ($message->author->id === $this->id) {
+            return;
+        }
+
+        $withoutPrefix = $this->checkForPrefix((string) $message->content);
+        if ($withoutPrefix === null) {
+            return;
+        }
+
+        $args = str_getcsv($withoutPrefix, ' ', '"', '\\');
+        $commandName = array_shift($args);
+
+        if ($commandName === null) {
+            return;
+        }
+
+        if ($this->options['caseInsensitiveCommands']) {
+            $commandName = mb_strtolower($commandName);
+        }
+
+        $command = $this->registry->get($commandName);
+        if ($command === null) {
+            return;
+        }
+
+        $result = $command($message, $args);
+
+        if (is_string($result)) {
+            $message->reply($result)->then(null, $this->options['internalRejectedPromiseHandler']);
+        }
+    }
+
+    /**
+     * Check whether the given content starts with a configured prefix.
+     *
+     * @param string $content Message content.
+     *
+     * @return string|null The content without the prefix, or null when no prefix matched.
+     */
+    protected function checkForPrefix(string $content): ?string
+    {
+        foreach ($this->options['prefixes'] as $prefix) {
+            $len = mb_strlen($prefix);
+            if (mb_substr($content, 0, $len) === $prefix) {
+                return mb_substr($content, $len);
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Register a new command.
+     *
+     * @param string                $name     Command trigger name.
+     * @param callable|string|array $callable Callable, string or array to execute.
+     * @param array                 $options  Command options.
+     *
+     * @return Command The registered command instance.
+     */
+    public function registerCommand(string $name, $callable, array $options = []): Command
+    {
+        if ($this->options['caseInsensitiveCommands']) {
+            $name = mb_strtolower($name);
+        }
+
+        list($commandInstance, $resolved) = $this->buildCommand($name, $callable, $options);
+
+        $this->registry->add($name, $commandInstance);
+
+        foreach ($resolved['aliases'] as $alias) {
+            if ($this->options['caseInsensitiveCommands'] && $alias !== null) {
+                $alias = mb_strtolower($alias);
+            }
+            $this->registry->addAlias((string) $alias, $name);
+        }
+
+        return $commandInstance;
+    }
+
+    /**
+     * Unregister an existing command.
+     *
+     * @param string $name Command name to remove.
+     *
+     * @throws \RuntimeException If the command does not exist.
+     */
+    public function unregisterCommand(string $name): void
+    {
+        if (! $this->registry->has($name)) {
+            throw new \RuntimeException("A command with the name {$name} does not exist.");
+        }
+
+        $this->registry->remove($name);
+    }
+
+    /**
+     * Register an alias for a command.
+     *
+     * @param string $alias   Alias to register.
+     * @param string $command Target command name.
+     */
+    public function registerAlias(string $alias, string $command): void
+    {
+        $this->registry->addAlias($alias, $command);
+    }
+
+    /**
+     * Unregister a command alias.
+     *
+     * @param string $alias Alias to remove.
+     */
+    public function unregisterCommandAlias(string $alias): void
+    {
+        $this->registry->removeAlias($alias);
+    }
+
+    /**
+     * Get a command by name or alias.
+     *
+     * @param string $name Command name or alias.
+     *
+     * @return Command|null
+     */
+    public function getCommand(string $name): ?Command
+    {
+        return $this->registry->get($name);
+    }
+
+    /**
+     * Build a Command instance from provided parameters.
+     *
+     * @param string                $name     Command name.
+     * @param callable|string|array $callable Callable, string or array.
+     * @param array                 $options  Command options.
+     *
+     * @return array{0:Command,1:array} Tuple of Command instance and resolved options.
+     *
+     * @throws \InvalidArgumentException When callable is not valid.
+     */
+    public function buildCommand(string $name, $callable, array $options = []): array
+    {
+        if (is_string($callable)) {
+            $callable = function ($message) use ($callable) {
+                return $callable;
+            };
+        } elseif (is_array($callable) && ! is_callable($callable)) {
+            $callable = function ($message) use ($callable) {
+                return $callable[array_rand($callable)];
+            };
+        }
+
+        if (! is_callable($callable)) {
+            throw new \InvalidArgumentException('The callable parameter must be a string, array or callable.');
+        }
+
+        $options = $this->resolveCommandOptions($options);
+
+        $commandInstance = new Command(
+            $this,
+            $name,
+            $callable,
+            $options['description'],
+            $options['longDescription'],
+            $options['usage'],
+            $options['cooldown'],
+            $options['cooldownMessage'],
+            $options['showHelp']
+        );
+
+        return [$commandInstance, $options];
+    }
+
+    /**
+     * Resolve options for a single command.
+     *
+     * @param array $options Input options.
+     *
+     * @return array Resolved options.
+     */
+    protected function resolveCommandOptions(array $options): array
+    {
+        $resolver = new OptionsResolver();
+
+        $resolver
+            ->setDefined([
+                'description',
+                'longDescription',
+                'usage',
+                'aliases',
+                'cooldown',
+                'cooldownMessage',
+                'showHelp',
+            ])
+            ->setDefaults([
+                'description' => 'No description provided.',
+                'longDescription' => '',
+                'usage' => '',
+                'aliases' => [],
+                'cooldown' => 0,
+                'cooldownMessage' => 'please wait %d second(s) to use this command again.',
+                'showHelp' => true,
+            ]);
+
+        return $resolver->resolve($options);
+    }
+
+    /**
+     * Resolve client-level options.
+     *
+     * @param array $options Input options.
+     *
+     * @return array Resolved options used by the client.
+     */
+    protected function resolveOptions(array $options = []): array
+    {
+        $resolver = new OptionsResolver();
+
+        $resolver
+            ->setRequired('token')
+            ->setAllowedTypes('token', 'string')
+            ->setDefined([
+                'token',
+                'prefix',
+                'prefixes',
+                'name',
+                'description',
+                'defaultHelpCommand',
+                'discordOptions',
+                'caseInsensitiveCommands',
+                'internalRejectedPromiseHandler',
+            ])
+            ->setAllowedTypes('internalRejectedPromiseHandler', ['null', 'callable'])
+            ->setDefaults([
+                'prefix' => '@mention ',
+                'prefixes' => [],
+                'name' => '<UsernamePlaceholder>',
+                'description' => 'A bot made with DiscordPHP '.self::VERSION.'.',
+                'defaultHelpCommand' => true,
+                'discordOptions' => [],
+                'caseInsensitiveCommands' => false,
+                'internalRejectedPromiseHandler' => function ($reason): void {
+                    if (is_string($reason) || $reason instanceof \Stringable) {
+                        $this->getLogger()->error($reason);
+                    } else {
+                        $this->getLogger()->warning('Unhandled internal rejected promise, $reason is not a Throwable, '.gettype($reason).' given.');
+                    }
+                },
+            ]);
+
+        $resolved = $resolver->resolve($options);
+        $resolved['prefixes'][] = $resolved['prefix'];
+
+        return $resolved;
+    }
+
+    /**
+     * Default help command handler.
+     *
+     * @param Message $message Message instance.
+     * @param array   $args    Command path parts.
+     *
+     * @return mixed|null
+     */
+    protected function defaultHelpHandler($message, array $args)
+    {
+        $prefix = str_replace((string) $this->user, '@'.$this->username, $this->options['prefix']);
+
+        if (count($args) > 0) {
+            $command = $this;
+            while (count($args) > 0) {
+                $commandString = array_shift($args);
+                $newCommand = $this->getCommand($commandString);
+
+                if (null === $newCommand) {
+                    return "The command {$commandString} does not exist.";
+                }
+
+                $command = $newCommand;
+            }
+
+            $help = $command->getHelp($prefix);
+            if (empty($help)) {
+                return;
+            }
+
+            $embed = new Embed($this);
+            $embed->setAuthor($this->options['name'], $this->client->user->avatar)
+                ->setTitle($prefix.implode(' ', $args).'\'s Help')
+                ->setDescription(! empty($help['longDescription']) ? $help['longDescription'] : $help['description'])
+                ->setFooter($this->options['name']);
+
+            if (! empty($help['usage'])) {
+                $embed->addFieldValues('Usage', '``'.$help['usage'].'``', true);
+            }
+
+            $message->channel->sendEmbed($embed)->then(null, $this->options['internalRejectedPromiseHandler']);
+
+            return;
+        }
+
+        $embed = new Embed($this);
+        $embed->setAuthor($this->options['name'], $this->client->avatar)
+            ->setTitle($this->options['name'])
+            ->setType(Embed::TYPE_RICH)
+            ->setFooter($this->options['name']);
+
+        $commandsDescription = '';
+        $embedfields = [];
+        foreach ($this->registry->all() as $command) {
+            $help = $command->getHelp($prefix);
+            if (empty($help)) {
+                continue;
+            }
+
+            $embedfields[] = [
+                'name' => $help['command'],
+                'value' => $help['description'],
+                'inline' => true,
+            ];
+            $commandsDescription .= "\n\n`".$help['command'].'`\n'.$help['description'];
+
+            foreach ($help['subCommandsHelp'] as $subCommandHelp) {
+                $embedfields[] = [
+                    'name' => $subCommandHelp['command'],
+                    'value' => $subCommandHelp['description'],
+                    'inline' => true,
+                ];
+                $commandsDescription .= "\n\n`".$subCommandHelp['command'].'`\n'.$subCommandHelp['description'];
+            }
+        }
+
+        if (count($embedfields) <= 25) {
+            foreach ($embedfields as $field) {
+                $embed->addField($field);
+            }
+            $commandsDescription = '';
+        }
+
+        $embed->setDescription(mb_substr($this->options['description'].$commandsDescription, 0, 2048));
+
+        $message->channel->sendEmbed($embed)->then(null, $this->options['internalRejectedPromiseHandler']);
+    }
+
+    /**
+     * Return the resolved client options.
+     *
+     * @return array<string,mixed>
+     */
+    public function getCommandClientOptions(): array
+    {
+        return $this->options;
+    }
+
+    /**
+     * Return the command registry instance.
+     *
+     * @return CommandRegistry
+     */
+    public function getCommandRegistry(): CommandRegistry
+    {
+        return $this->registry;
+    }
+}

--- a/src/Discord/MessageCommandClient.php
+++ b/src/Discord/MessageCommandClient.php
@@ -20,6 +20,7 @@ use Discord\MessageCommandClient\Command;
 use Discord\Parts\Channel\Message;
 use Discord\Parts\Embed\Embed;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\OptionsResolver\Options;
 
 /**
  * Modern, modular replacement for the legacy DiscordCommandClient.
@@ -361,7 +362,29 @@ class MessageCommandClient extends Discord
                 'cooldown' => 0,
                 'cooldownMessage' => 'please wait %d second(s) to use this command again.',
                 'showHelp' => true,
-            ]);
+            ])
+            ->setAllowedTypes('aliases', ['array', 'string', 'null'])
+            ->setNormalizer('aliases', function (Options $options, $value) {
+                if ($value === null) {
+                    return [];
+                }
+
+                if (! is_array($value)) {
+                    $value = [$value];
+                }
+
+                $sanitized = [];
+                foreach ($value as $alias) {
+                    if (is_scalar($alias) || (is_object($alias) && method_exists($alias, '__toString'))) {
+                        $aliasStr = trim((string) $alias);
+                        if ($aliasStr !== '') {
+                            $sanitized[] = $aliasStr;
+                        }
+                    }
+                }
+
+                return array_values(array_unique($sanitized));
+            });
 
         return $resolver->resolve($options);
     }

--- a/src/Discord/MessageCommandClient.php
+++ b/src/Discord/MessageCommandClient.php
@@ -251,10 +251,23 @@ class MessageCommandClient extends Discord
      *
      * @param string $alias   Alias to register.
      * @param string $command Target command name.
+     *
+     * @throws \RuntimeException If the target command does not exist or alias is already taken.
      */
     public function registerAlias(string $alias, string $command): void
     {
-        $this->registry->addAlias($alias, $command);
+        $aliasNormalized = $this->normalizeCommandName($alias);
+        $commandNormalized = $this->normalizeCommandName($command);
+
+        if ($this->registry->has($aliasNormalized)) {
+            throw new \RuntimeException("An alias with the name {$aliasNormalized} already exists.");
+        }
+
+        if (! $this->registry->hasCommand($commandNormalized)) {
+            throw new \RuntimeException("A command with the name {$commandNormalized} does not exist.");
+        }
+
+        $this->registry->addAlias($aliasNormalized, $commandNormalized);
     }
 
     /**

--- a/src/Discord/MessageCommandClient.php
+++ b/src/Discord/MessageCommandClient.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 
 namespace Discord;
 
+use Discord\MessageCommandClient\BuiltCommand;
 use Discord\MessageCommandClient\CommandRegistry;
 use Discord\MessageCommandClient\Command;
 use Discord\Parts\Channel\Message;
@@ -39,7 +40,7 @@ class MessageCommandClient extends Discord
      *
      * @param array $options Client options (see resolveOptions()).
      */
-    public function __construct(array $options = [])
+    public function __construct(array $options = [], ?CommandRegistry $registry = null)
     {
         $this->options = $this->resolveOptions($options);
 
@@ -47,7 +48,7 @@ class MessageCommandClient extends Discord
 
         parent::__construct($discordOptions);
 
-        $this->registry = new CommandRegistry((bool) ($this->options['caseInsensitiveCommands'] ?? false));
+        $this->registry = $registry ?? new CommandRegistry((bool) ($this->options['caseInsensitiveCommands'] ?? false));
 
         $this->on('init', function () {
             $this->preparePrefixes();
@@ -65,6 +66,18 @@ class MessageCommandClient extends Discord
                 'usage' => '[command]',
             ]);
         }
+    }
+
+    /**
+     * Normalize a command or alias according to client options.
+     */
+    public function normalizeCommandName(string $name): string
+    {
+        if ($this->options['caseInsensitiveCommands']) {
+            return function_exists('mb_strtolower') ? mb_strtolower($name) : strtolower($name);
+        }
+
+        return $name;
     }
 
     /**
@@ -107,11 +120,7 @@ class MessageCommandClient extends Discord
             return;
         }
 
-        if ($this->options['caseInsensitiveCommands']) {
-            $commandName = function_exists('mb_strtolower')
-                ? mb_strtolower($commandName)
-                : strtolower($commandName);
-        }
+        $commandName = $this->normalizeCommandName($commandName);
 
         $command = $this->registry->get($commandName);
         if ($command === null) {
@@ -184,23 +193,38 @@ class MessageCommandClient extends Discord
      */
     public function registerCommand(string $name, $callable, array $options = []): Command
     {
-        if ($this->options['caseInsensitiveCommands']) {
-            $name = function_exists('mb_strtolower')
-                ? mb_strtolower($name)
-                : strtolower($name);
+        $name = $this->normalizeCommandName($name);
+
+        $built = $this->buildCommand($name, $callable, $options);
+        if ($built instanceof BuiltCommand) {
+            $commandInstance = $built->command;
+            $resolvedOptions = $built->options;
+        } else {
+            ['command' => $commandInstance, 'options' => $resolvedOptions] = $built;
         }
 
-        ['command' => $commandInstance, 'options' => $resolvedOptions] = $this->buildCommand($name, $callable, $options);
+        // Ensure no collision with existing command or alias names.
+        if ($this->registry->has($name)) {
+            throw new \RuntimeException("A command with the name {$name} already exists.");
+        }
 
         $this->registry->add($name, $commandInstance);
 
         foreach ($resolvedOptions['aliases'] as $alias) {
-            if ($this->options['caseInsensitiveCommands'] && $alias !== null) {
-                $alias = function_exists('mb_strtolower')
-                    ? mb_strtolower($alias)
-                    : strtolower($alias);
+            if ($alias === null) {
+                continue;
             }
-            $this->registry->addAlias((string) $alias, $name);
+
+            $aliasNormalized = $this->normalizeCommandName($alias);
+            if ($this->registry->has($aliasNormalized)) {
+                throw new \RuntimeException("An alias with the name {$aliasNormalized} already exists.");
+            }
+
+            $this->registry->addAlias((string) $aliasNormalized, $name);
+        }
+
+        if (method_exists($this, 'emit')) {
+            $this->emit('messagecommandclient.command.registered', [$name, $commandInstance, $resolvedOptions]);
         }
 
         return $commandInstance;
@@ -262,11 +286,11 @@ class MessageCommandClient extends Discord
      * @param callable|string|array $callable Callable, string or array.
      * @param array                 $options  Command options.
      *
-     * @return array{command: Command, options: array} Tuple of Command instance and resolved options.
+     * @return BuiltCommand DTO of Command instance and resolved options.
      *
      * @throws \InvalidArgumentException When callable is not valid.
      */
-    public function buildCommand(string $name, $callable, array $options = []): array
+    public function buildCommand(string $name, $callable, array $options = []): BuiltCommand
     {
         if (is_string($callable)) {
             $callable = fn ($message, array $args = []) => $callable;
@@ -292,10 +316,7 @@ class MessageCommandClient extends Discord
             $options['showHelp']
         );
 
-        return [
-            'command' => $commandInstance,
-            'options' => $options,
-        ];
+        return new BuiltCommand($commandInstance, $options);
     }
 
     /**

--- a/src/Discord/MessageCommandClient.php
+++ b/src/Discord/MessageCommandClient.php
@@ -316,6 +316,12 @@ class MessageCommandClient extends Discord
             throw new \InvalidArgumentException('The callable parameter must be a string, array or callable.');
         }
 
+        // Wrap user-provided callable so it can be safely invoked with
+        // 0/1/2 parameters depending on its declared arity. This prevents
+        // ArgumentCountError when users register callables that accept
+        // fewer parameters than the invocation site provides.
+        $callable = $this->wrapRegisteredCallable($callable);
+
         $options = $this->resolveCommandOptions($options);
 
         $commandInstance = new Command(
@@ -331,6 +337,59 @@ class MessageCommandClient extends Discord
         );
 
         return new BuiltCommand($commandInstance, $options);
+    }
+
+    /**
+     * Wrap a registered callable to adapt invocation based on its declared arity.
+     *
+     * The wrapper will call the original callable with 0, 1 or 2 arguments
+     * depending on how many required parameters the callable declares. This
+     * avoids runtime ArgumentCountError when users register callables that
+     * accept fewer parameters than the command invocation provides.
+     *
+     * @param callable $callable
+     *
+     * @return callable
+     */
+    protected function wrapRegisteredCallable(callable $callable): callable
+    {
+        try {
+            if (is_array($callable)) {
+                $ref = new \ReflectionMethod($callable[0], $callable[1]);
+            } elseif (is_string($callable) && strpos($callable, '::') !== false) {
+                [$class, $method] = explode('::', $callable, 2);
+                $ref = new \ReflectionMethod($class, $method);
+            } else {
+                $ref = new \ReflectionFunction($callable);
+            }
+
+            $required = $ref->getNumberOfRequiredParameters();
+            $isVariadic = $ref->isVariadic();
+        } catch (\ReflectionException $e) {
+            // If reflection fails for any reason, fall back to a safe default
+            // that calls the callable with message and args to preserve
+            // previous behavior.
+            $required = 2;
+            $isVariadic = false;
+        }
+
+        return function ($message, array $args = []) use ($callable, $required, $isVariadic) {
+            if ($isVariadic) {
+                // If callable is variadic, prefer to expand $args after the
+                // message so the handler can accept multiple individual args.
+                return call_user_func_array($callable, array_merge([$message], $args));
+            }
+
+            if ($required === 0) {
+                return call_user_func($callable);
+            }
+
+            if ($required === 1) {
+                return call_user_func($callable, $message);
+            }
+
+            return call_user_func($callable, $message, $args);
+        };
     }
 
     /**

--- a/src/Discord/MessageCommandClient.php
+++ b/src/Discord/MessageCommandClient.php
@@ -20,6 +20,7 @@ use Discord\MessageCommandClient\CommandRegistry;
 use Discord\MessageCommandClient\Command;
 use Discord\Parts\Channel\Message;
 use Discord\Parts\Embed\Embed;
+use Monolog\Level;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\OptionsResolver\Options;
 
@@ -79,13 +80,14 @@ class MessageCommandClient extends Discord
      */
     protected function resolveOptions(array $options = []): array
     {
+        $options = parent::resolveOptions($options);
+
         $resolver = new OptionsResolver();
 
         $resolver
             ->setRequired('token')
             ->setAllowedTypes('token', 'string')
-            ->setDefined([
-                'token',
+            ->setDefined(array_merge($this->definedOptions, [
                 'prefix',
                 'prefixes',
                 'name',
@@ -94,7 +96,7 @@ class MessageCommandClient extends Discord
                 'discordOptions',
                 'caseInsensitiveCommands',
                 'internalRejectedPromiseHandler',
-            ])
+            ]))
             ->setAllowedTypes('internalRejectedPromiseHandler', ['null', 'callable'])
             ->setDefaults([
                 'prefix' => '@mention ',
@@ -113,10 +115,11 @@ class MessageCommandClient extends Discord
                 },
             ]);
 
-        $resolved = $resolver->resolve($options);
-        $resolved['prefixes'][] = $resolved['prefix'];
+        $options = $resolver->resolve($options);
 
-        return $resolved;
+        $options['prefixes'][] = $options['prefix'];
+
+        return $options;
     }
 
     /**

--- a/src/Discord/MessageCommandClient.php
+++ b/src/Discord/MessageCommandClient.php
@@ -354,21 +354,17 @@ class MessageCommandClient extends Discord
     protected function wrapRegisteredCallable(callable $callable): callable
     {
         try {
-            if (is_array($callable)) {
-                $ref = new \ReflectionMethod($callable[0], $callable[1]);
-            } elseif (is_string($callable) && strpos($callable, '::') !== false) {
-                [$class, $method] = explode('::', $callable, 2);
-                $ref = new \ReflectionMethod($class, $method);
-            } else {
-                $ref = new \ReflectionFunction($callable);
-            }
+            // Normalize any callable to a Closure first so invokable objects,
+            // callable strings and arrays are all handled uniformly.
+            $closure = \Closure::fromCallable($callable);
+            $ref = new \ReflectionFunction($closure);
 
             $required = $ref->getNumberOfRequiredParameters();
             $isVariadic = $ref->isVariadic();
-        } catch (\ReflectionException $e) {
-            // If reflection fails for any reason, fall back to a safe default
-            // that calls the callable with message and args to preserve
-            // previous behavior.
+        } catch (\Throwable $e) {
+            // If reflection fails for any reason (including TypeError for
+            // invokable objects on older reflection paths), fall back to a
+            // safe default that preserves previous behavior.
             $required = 2;
             $isVariadic = false;
         }

--- a/src/Discord/MessageCommandClient.php
+++ b/src/Discord/MessageCommandClient.php
@@ -328,12 +328,7 @@ class MessageCommandClient extends Discord
             $this,
             $name,
             $callable,
-            $options['description'],
-            $options['longDescription'],
-            $options['usage'],
-            $options['cooldown'],
-            $options['cooldownMessage'],
-            $options['showHelp']
+            $options
         );
 
         return new BuiltCommand($commandInstance, $options);

--- a/src/Discord/MessageCommandClient.php
+++ b/src/Discord/MessageCommandClient.php
@@ -192,7 +192,9 @@ class MessageCommandClient extends Discord
     public function registerCommand(string $name, $callable, array $options = []): Command
     {
         if ($this->options['caseInsensitiveCommands']) {
-            $name = mb_strtolower($name);
+            $name = function_exists('mb_strtolower')
+                ? mb_strtolower($name)
+                : strtolower($name);
         }
 
         ['command' => $commandInstance, 'options' => $resolvedOptions] = $this->buildCommand($name, $callable, $options);
@@ -201,7 +203,9 @@ class MessageCommandClient extends Discord
 
         foreach ($resolvedOptions['aliases'] as $alias) {
             if ($this->options['caseInsensitiveCommands'] && $alias !== null) {
-                $alias = mb_strtolower($alias);
+                $alias = function_exists('mb_strtolower')
+                    ? mb_strtolower($alias)
+                    : strtolower($alias);
             }
             $this->registry->addAlias((string) $alias, $name);
         }
@@ -218,7 +222,7 @@ class MessageCommandClient extends Discord
      */
     public function unregisterCommand(string $name): void
     {
-        if (! $this->registry->has($name)) {
+        if (! $this->registry->hasCommand($name)) {
             throw new \RuntimeException("A command with the name {$name} does not exist.");
         }
 
@@ -467,7 +471,11 @@ class MessageCommandClient extends Discord
             $commandsDescription = '';
         }
 
-        $embed->setDescription(mb_substr($this->options['description'].$commandsDescription, 0, 2048));
+        $embed->setDescription(
+            function_exists('mb_substr')
+                ? mb_substr($this->options['description'].$commandsDescription, 0, 2048)
+                : substr($this->options['description'].$commandsDescription, 0, 2048)
+        );
 
         $message->channel->sendEmbed($embed)->then(null, $this->options['internalRejectedPromiseHandler']);
     }

--- a/src/Discord/MessageCommandClient.php
+++ b/src/Discord/MessageCommandClient.php
@@ -344,9 +344,7 @@ class MessageCommandClient extends Discord
             $this->registry->addAlias((string) $aliasNormalized, $name);
         }
 
-        if (method_exists($this, 'emit')) {
-            $this->emit('command-registered', [$name, $commandInstance, $resolvedOptions]);
-        }
+        $this->emit('command-registered', [$name, $commandInstance, $resolvedOptions]);
 
         return $commandInstance;
     }

--- a/src/Discord/MessageCommandClient.php
+++ b/src/Discord/MessageCommandClient.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 
 namespace Discord;
 
+use Discord\Builders\MessageBuilder;
 use Discord\MessageCommandClient\BuiltCommand;
 use Discord\MessageCommandClient\CommandRegistry;
 use Discord\MessageCommandClient\Command;
@@ -67,6 +68,123 @@ class MessageCommandClient extends Discord
                 'usage' => '[command]',
             ]);
         }
+    }
+
+    /**
+     * Resolve client-level options.
+     *
+     * @param array $options Input options.
+     *
+     * @return array Resolved options used by the client.
+     */
+    protected function resolveOptions(array $options = []): array
+    {
+        $resolver = new OptionsResolver();
+
+        $resolver
+            ->setRequired('token')
+            ->setAllowedTypes('token', 'string')
+            ->setDefined([
+                'token',
+                'prefix',
+                'prefixes',
+                'name',
+                'description',
+                'defaultHelpCommand',
+                'discordOptions',
+                'caseInsensitiveCommands',
+                'internalRejectedPromiseHandler',
+            ])
+            ->setAllowedTypes('internalRejectedPromiseHandler', ['null', 'callable'])
+            ->setDefaults([
+                'prefix' => '@mention ',
+                'prefixes' => [],
+                'name' => '<UsernamePlaceholder>',
+                'description' => 'A bot made with DiscordPHP '.self::VERSION.'.',
+                'defaultHelpCommand' => true,
+                'discordOptions' => [],
+                'caseInsensitiveCommands' => false,
+                'internalRejectedPromiseHandler' => function ($reason): void {
+                    if (is_string($reason) || $reason instanceof \Stringable) {
+                        $this->getLogger()->error($reason);
+                    } else {
+                        $this->getLogger()->warning('Unhandled internal rejected promise, $reason is not a Throwable, '.gettype($reason).' given.');
+                    }
+                },
+            ]);
+
+        $resolved = $resolver->resolve($options);
+        $resolved['prefixes'][] = $resolved['prefix'];
+
+        return $resolved;
+    }
+
+    /**
+     * Resolve options for a single command.
+     *
+     * @param array $options Input options.
+     *
+     * @return array Resolved options.
+     */
+    protected function resolveCommandOptions(array $options): array
+    {
+        $resolver = new OptionsResolver();
+
+        $resolver
+            ->setDefined([
+                'description',
+                'longDescription',
+                'usage',
+                'aliases',
+                'cooldown',
+                'cooldownMessage',
+                'showHelp',
+            ])
+            ->setDefaults([
+                'description' => 'No description provided.',
+                'longDescription' => '',
+                'usage' => '',
+                'aliases' => [],
+                'cooldown' => 0,
+                'cooldownMessage' => 'please wait %d second(s) to use this command again.',
+                'showHelp' => true,
+            ])
+            ->setAllowedTypes('aliases', ['array', 'string', 'null'])
+            ->setNormalizer('aliases', function (Options $options, $value) {
+                if ($value === null) {
+                    return [];
+                }
+
+                if (! is_array($value)) {
+                    $value = [$value];
+                }
+
+                $sanitized = [];
+                foreach ($value as $alias) {
+                    if (is_scalar($alias) || (is_object($alias) && method_exists($alias, '__toString'))) {
+                        $aliasStr = trim((string) $alias);
+                        if ($aliasStr !== '') {
+                            $sanitized[] = $aliasStr;
+                        }
+                    }
+                }
+
+                return array_values(array_unique($sanitized));
+            });
+
+        return $resolver->resolve($options);
+    }
+
+    /**
+     * Creates a message builder instance.
+     *
+     * Override this method during construction to provide a custom message builder.
+     *
+     * @return MessageBuilder
+     */
+    public function createMessageBuilder(): MessageBuilder
+    {
+        return MessageBuilder::new();
     }
 
     /**
@@ -206,7 +324,7 @@ class MessageCommandClient extends Discord
 
         // Ensure no collision with existing command or alias names.
         if ($this->registry->has($name)) {
-            throw new \RuntimeException("A command with the same name already exists.");
+            throw new \RuntimeException('A command with the same name already exists.');
         }
 
         $this->registry->add($name, $commandInstance);
@@ -218,7 +336,7 @@ class MessageCommandClient extends Discord
 
             $aliasNormalized = $this->normalizeCommandName($alias);
             if ($this->registry->has($aliasNormalized)) {
-                throw new \RuntimeException("An alias with the same name already exists.");
+                throw new \RuntimeException('An alias with the same name already exists.');
             }
 
             $this->registry->addAlias((string) $aliasNormalized, $name);
@@ -241,7 +359,7 @@ class MessageCommandClient extends Discord
     public function unregisterCommand(string $name): void
     {
         if (! $this->registry->hasCommand($name)) {
-            throw new \RuntimeException("A command with the same name does not exist.");
+            throw new \RuntimeException('A command with the same name does not exist.');
         }
 
         $this->registry->remove($name);
@@ -261,11 +379,11 @@ class MessageCommandClient extends Discord
         $commandNormalized = $this->normalizeCommandName($command);
 
         if ($this->registry->has($aliasNormalized)) {
-            throw new \RuntimeException("An alias with the same name already exists.");
+            throw new \RuntimeException('An alias with the same name already exists.');
         }
 
         if (! $this->registry->hasCommand($commandNormalized)) {
-            throw new \RuntimeException("A command with the same name does not exist.");
+            throw new \RuntimeException('A command with the same name does not exist.');
         }
 
         $this->registry->addAlias($aliasNormalized, $commandNormalized);
@@ -384,111 +502,6 @@ class MessageCommandClient extends Discord
     }
 
     /**
-     * Resolve options for a single command.
-     *
-     * @param array $options Input options.
-     *
-     * @return array Resolved options.
-     */
-    protected function resolveCommandOptions(array $options): array
-    {
-        $resolver = new OptionsResolver();
-
-        $resolver
-            ->setDefined([
-                'description',
-                'longDescription',
-                'usage',
-                'aliases',
-                'cooldown',
-                'cooldownMessage',
-                'showHelp',
-            ])
-            ->setDefaults([
-                'description' => 'No description provided.',
-                'longDescription' => '',
-                'usage' => '',
-                'aliases' => [],
-                'cooldown' => 0,
-                'cooldownMessage' => 'please wait %d second(s) to use this command again.',
-                'showHelp' => true,
-            ])
-            ->setAllowedTypes('aliases', ['array', 'string', 'null'])
-            ->setNormalizer('aliases', function (Options $options, $value) {
-                if ($value === null) {
-                    return [];
-                }
-
-                if (! is_array($value)) {
-                    $value = [$value];
-                }
-
-                $sanitized = [];
-                foreach ($value as $alias) {
-                    if (is_scalar($alias) || (is_object($alias) && method_exists($alias, '__toString'))) {
-                        $aliasStr = trim((string) $alias);
-                        if ($aliasStr !== '') {
-                            $sanitized[] = $aliasStr;
-                        }
-                    }
-                }
-
-                return array_values(array_unique($sanitized));
-            });
-
-        return $resolver->resolve($options);
-    }
-
-    /**
-     * Resolve client-level options.
-     *
-     * @param array $options Input options.
-     *
-     * @return array Resolved options used by the client.
-     */
-    protected function resolveOptions(array $options = []): array
-    {
-        $resolver = new OptionsResolver();
-
-        $resolver
-            ->setRequired('token')
-            ->setAllowedTypes('token', 'string')
-            ->setDefined([
-                'token',
-                'prefix',
-                'prefixes',
-                'name',
-                'description',
-                'defaultHelpCommand',
-                'discordOptions',
-                'caseInsensitiveCommands',
-                'internalRejectedPromiseHandler',
-            ])
-            ->setAllowedTypes('internalRejectedPromiseHandler', ['null', 'callable'])
-            ->setDefaults([
-                'prefix' => '@mention ',
-                'prefixes' => [],
-                'name' => '<UsernamePlaceholder>',
-                'description' => 'A bot made with DiscordPHP '.self::VERSION.'.',
-                'defaultHelpCommand' => true,
-                'discordOptions' => [],
-                'caseInsensitiveCommands' => false,
-                'internalRejectedPromiseHandler' => function ($reason): void {
-                    if (is_string($reason) || $reason instanceof \Stringable) {
-                        $this->getLogger()->error($reason);
-                    } else {
-                        $this->getLogger()->warning('Unhandled internal rejected promise, $reason is not a Throwable, '.gettype($reason).' given.');
-                    }
-                },
-            ]);
-
-        $resolved = $resolver->resolve($options);
-        $resolved['prefixes'][] = $resolved['prefix'];
-
-        return $resolved;
-    }
-
-    /**
      * Default help command handler.
      *
      * @param Message $message Message instance.
@@ -501,51 +514,87 @@ class MessageCommandClient extends Discord
         $prefix = str_replace((string) $this->user, '@'.$this->username, $this->options['prefix']);
 
         if (count($args) > 0) {
-            $command = null;
-            $fullCommandString = implode(' ', $args);
-
-            while (count($args) > 0) {
-                $commandString = array_shift($args);
-
-                if ($this->options['caseInsensitiveCommands']) {
-                    $commandString = function_exists('mb_strtolower')
-                        ? mb_strtolower($commandString)
-                        : strtolower($commandString);
-                }
-
-                if ($command === null) {
-                    $newCommand = $this->getCommand($commandString);
-                } else {
-                    $newCommand = $command->getCommand($commandString);
-                }
-
-                if ($newCommand === null) {
-                    return "The command {$commandString} does not exist.";
-                }
-
-                $command = $newCommand;
+            $result = $this->findCommandForHelp($args);
+            if (isset($result['missing'])) {
+                return "The command {$result['missing']} does not exist.";
             }
+
+            $command = $result['command'];
+            $fullCommandString = $result['full'];
 
             $help = $command->getHelp($prefix);
             if (empty($help)) {
                 return;
             }
 
-            $embed = new Embed($this);
-            $embed->setAuthor($this->options['name'], $this->client->user->avatar)
-                ->setTitle($prefix.$fullCommandString.'\'s Help')
-                ->setDescription(! empty($help['longDescription']) ? $help['longDescription'] : $help['description'])
-                ->setFooter($this->options['name']);
-
-            if (! empty($help['usage'])) {
-                $embed->addFieldValues('Usage', '``'.$help['usage'].'``', true);
-            }
-
-            $message->channel->sendEmbed($embed)->then(null, $this->options['internalRejectedPromiseHandler']);
+            $embed = $this->buildHelpEmbedForCommand($command, $prefix, $fullCommandString, $help);
+            $message->channel->sendMessage($this->createMessageBuilder()->addEmbed($embed))->then(null, $this->options['internalRejectedPromiseHandler']);
 
             return;
         }
 
+        $embed = $this->buildCommandsListEmbed($prefix);
+        $message->channel->sendMessage($this->createMessageBuilder()->addEmbed($embed))->then(null, $this->options['internalRejectedPromiseHandler']);
+    }
+
+    /**
+     * Find a command instance based on a path of command parts for help lookup.
+     *
+     * @param array $parts
+     *
+     * @return array{command?: \Discord\MessageCommandClient\Command, full?: string, missing?: string}
+     */
+    protected function findCommandForHelp(array $parts): array
+    {
+        $command = null;
+        $fullCommandString = implode(' ', $parts);
+
+        while (count($parts) > 0) {
+            $commandString = array_shift($parts);
+
+            if ($this->options['caseInsensitiveCommands']) {
+                $commandString = function_exists('mb_strtolower') ? mb_strtolower($commandString) : strtolower($commandString);
+            }
+
+            if ($command === null) {
+                $newCommand = $this->getCommand($commandString);
+            } else {
+                $newCommand = $command->getCommand($commandString);
+            }
+
+            if ($newCommand === null) {
+                return ['missing' => $commandString];
+            }
+
+            $command = $newCommand;
+        }
+
+        return ['command' => $command, 'full' => $fullCommandString];
+    }
+
+    /**
+     * Build an embed for a specific command help view.
+     */
+    protected function buildHelpEmbedForCommand($command, string $prefix, string $fullCommandString, array $help): Embed
+    {
+        $embed = new Embed($this);
+        $embed->setAuthor($this->options['name'], $this->client->user->avatar)
+            ->setTitle($prefix.$fullCommandString.'\'s Help')
+            ->setDescription(! empty($help['longDescription']) ? $help['longDescription'] : $help['description'])
+            ->setFooter($this->options['name']);
+
+        if (! empty($help['usage'])) {
+            $embed->addFieldValues('Usage', '``'.$help['usage'].'``', true);
+        }
+
+        return $embed;
+    }
+
+    /**
+     * Build an embed listing all commands for the help command root.
+     */
+    protected function buildCommandsListEmbed(string $prefix): Embed
+    {
         $embed = new Embed($this);
         $embed->setAuthor($this->options['name'], $this->client->avatar)
             ->setTitle($this->options['name'])
@@ -589,7 +638,7 @@ class MessageCommandClient extends Discord
                 : substr($this->options['description'].$commandsDescription, 0, 2048)
         );
 
-        $message->channel->sendEmbed($embed)->then(null, $this->options['internalRejectedPromiseHandler']);
+        return $embed;
     }
 
     /**

--- a/src/Discord/MessageCommandClient.php
+++ b/src/Discord/MessageCommandClient.php
@@ -164,11 +164,11 @@ class MessageCommandClient extends Discord
             $name = mb_strtolower($name);
         }
 
-        list($commandInstance, $resolved) = $this->buildCommand($name, $callable, $options);
+        ['command' => $commandInstance, 'options' => $resolvedOptions] = $this->buildCommand($name, $callable, $options);
 
         $this->registry->add($name, $commandInstance);
 
-        foreach ($resolved['aliases'] as $alias) {
+        foreach ($resolvedOptions['aliases'] as $alias) {
             if ($this->options['caseInsensitiveCommands'] && $alias !== null) {
                 $alias = mb_strtolower($alias);
             }
@@ -234,20 +234,16 @@ class MessageCommandClient extends Discord
      * @param callable|string|array $callable Callable, string or array.
      * @param array                 $options  Command options.
      *
-     * @return array{0:Command,1:array} Tuple of Command instance and resolved options.
+     * @return array{command: Command, options: array} Tuple of Command instance and resolved options.
      *
      * @throws \InvalidArgumentException When callable is not valid.
      */
     public function buildCommand(string $name, $callable, array $options = []): array
     {
         if (is_string($callable)) {
-            $callable = function ($message) use ($callable) {
-                return $callable;
-            };
+            $callable = fn ($message, array $args = []) => $callable;
         } elseif (is_array($callable) && ! is_callable($callable)) {
-            $callable = function ($message) use ($callable) {
-                return $callable[array_rand($callable)];
-            };
+            $callable = fn ($message, array $args = []) => $callable[array_rand($callable)];
         }
 
         if (! is_callable($callable)) {
@@ -268,7 +264,10 @@ class MessageCommandClient extends Discord
             $options['showHelp']
         );
 
-        return [$commandInstance, $options];
+        return [
+            'command' => $commandInstance,
+            'options' => $options
+        ];
     }
 
     /**

--- a/src/Discord/MessageCommandClient/BuiltCommand.php
+++ b/src/Discord/MessageCommandClient/BuiltCommand.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is a part of the DiscordPHP project.
+ *
+ * Copyright (c) 2015-2022 David Cole <david.cole1340@gmail.com>
+ * Copyright (c) 2020-present Valithor Obsidion <valithor@discordphp.org>
+ *
+ * This file is subject to the MIT license that is bundled
+ * with this source code in the LICENSE.md file.
+ */
+
+namespace Discord\MessageCommandClient;
+
+/**
+ * Small DTO returned by MessageCommandClient::buildCommand().
+ */
+final class BuiltCommand
+{
+    /**
+     * The Command instance built by the client.
+     *
+     * @var Command
+     */
+    public Command $command;
+
+    /**
+     * Resolved options for the command.
+     *
+     * @var array<string,mixed>
+     */
+    public array $options;
+
+    public function __construct(Command $command, array $options)
+    {
+        $this->command = $command;
+        $this->options = $options;
+    }
+}

--- a/src/Discord/MessageCommandClient/Command.php
+++ b/src/Discord/MessageCommandClient/Command.php
@@ -280,10 +280,10 @@ class Command
 
         $key = $this->normalizeName($commandInstance->command);
         if (array_key_exists($key, $this->subCommandAliases)) {
-            throw new \RuntimeException("A sub-command with the same name already exists as an alias for another sub-command.");
+            throw new \RuntimeException('A sub-command with the same name already exists as an alias for another sub-command.');
         }
         if (array_key_exists($key, $this->subCommands)) {
-            throw new \RuntimeException("A sub-command with the same name already exists.");
+            throw new \RuntimeException('A sub-command with the same name already exists.');
         }
 
         $this->subCommands[$key] = $commandInstance;
@@ -310,7 +310,7 @@ class Command
         $command = $this->normalizeName($command);
 
         if (! array_key_exists($command, $this->subCommands)) {
-            throw new \RuntimeException("The sub-command does not exist.");
+            throw new \RuntimeException('The sub-command does not exist.');
         }
 
         unset($this->subCommands[$command]);
@@ -329,12 +329,12 @@ class Command
 
         // Ensure the target sub-command exists.
         if (! array_key_exists($command, $this->subCommands)) {
-            throw new \RuntimeException("The target sub-command does not exist.");
+            throw new \RuntimeException('The target sub-command does not exist.');
         }
 
         // Alias must not collide with an existing sub-command name.
         if (array_key_exists($alias, $this->subCommands)) {
-            throw new \RuntimeException("Cannot create alias because a sub-command with that name already exists.");
+            throw new \RuntimeException('Cannot create alias because a sub-command with that name already exists.');
         }
 
         // If alias already exists, ensure it's not being remapped to a different target.
@@ -345,7 +345,7 @@ class Command
                 return;
             }
 
-            throw new \RuntimeException("Cannot remap alias because it is already mapped to a different sub-command.");
+            throw new \RuntimeException('Cannot remap alias because it is already mapped to a different sub-command.');
         }
 
         $this->subCommandAliases[$alias] = $command;
@@ -362,7 +362,7 @@ class Command
         $alias = $this->normalizeName($alias);
 
         if (! array_key_exists($alias, $this->subCommandAliases)) {
-            throw new \RuntimeException("The sub-command alias does not exist.");
+            throw new \RuntimeException('The sub-command alias does not exist.');
         }
 
         unset($this->subCommandAliases[$alias]);

--- a/src/Discord/MessageCommandClient/Command.php
+++ b/src/Discord/MessageCommandClient/Command.php
@@ -148,6 +148,11 @@ class Command
      */
     protected function normalizeName(string $name): string
     {
+        if (method_exists($this->client, 'normalizeCommandName')) {
+            return $this->client->normalizeCommandName($name);
+        }
+
+        // Fallback: mirror previous behavior if client does not provide helper.
         if ($this->client->getCommandClientOptions()['caseInsensitiveCommands']) {
             return function_exists('mb_strtolower') ? mb_strtolower($name) : strtolower($name);
         }
@@ -199,7 +204,14 @@ class Command
     {
         $command = $this->normalizeName($command);
 
-        ['command' => $commandInstance, 'options' => $resolvedOptions] = $this->client->buildCommand($command, $callable, $options);
+        $built = $this->client->buildCommand($command, $callable, $options);
+        if ($built instanceof \Discord\MessageCommandClient\BuiltCommand) {
+            $commandInstance = $built->command;
+            $resolvedOptions = $built->options;
+        } else {
+            // Backwards compatibility: accept old array shape
+            ['command' => $commandInstance, 'options' => $resolvedOptions] = $built;
+        }
 
         $key = $this->normalizeName($commandInstance->command);
         if (array_key_exists($key, $this->subCommandAliases)) {
@@ -213,6 +225,11 @@ class Command
 
         foreach ($resolvedOptions['aliases'] as $alias) {
             $this->registerSubCommandAlias($alias, $key);
+        }
+
+        // Emit a lifecycle event so extensions/plugins can react.
+        if (method_exists($this->client, 'emit')) {
+            $this->client->emit('messagecommandclient.subcommand.registered', [$this->command, $key, $commandInstance, $resolvedOptions]);
         }
 
         return $commandInstance;

--- a/src/Discord/MessageCommandClient/Command.php
+++ b/src/Discord/MessageCommandClient/Command.php
@@ -105,7 +105,7 @@ class Command
      *
      * @var callable
      */
-    protected $callable;
+    protected callable $callable;
 
     /**
      * An array of options passed to the command.

--- a/src/Discord/MessageCommandClient/Command.php
+++ b/src/Discord/MessageCommandClient/Command.php
@@ -270,6 +270,7 @@ class Command
      * Unregister a sub-command.
      *
      * @param string $command Sub-command name.
+     * 
      * @throws \RuntimeException If the sub-command does not exist.
      */
     public function unregisterSubCommand(string $command): void
@@ -282,6 +283,8 @@ class Command
      *
      * @param string $alias   Alias name.
      * @param string $command Target sub-command name.
+     * 
+     * @throws \RuntimeException If the alias or target command name conflicts with existing sub-commands or aliases.
      */
     public function registerSubCommandAlias(string $alias, string $command): void
     {

--- a/src/Discord/MessageCommandClient/Command.php
+++ b/src/Discord/MessageCommandClient/Command.php
@@ -180,7 +180,9 @@ class Command
         }
 
         if ($command !== null && $this->client->getCommandClientOptions()['caseInsensitiveCommands']) {
-            $command = mb_strtolower($command);
+            $command = function_exists('mb_strtolower')
+                ? mb_strtolower($command)
+                : strtolower($command);
         }
 
         ['command' => $commandInstance, 'options' => $resolvedOptions] = $this->client->buildCommand($command, $callable, $options);
@@ -216,7 +218,9 @@ class Command
     public function registerSubCommandAlias(string $alias, string $command): void
     {
         if ($alias !== null && $this->client->getCommandClientOptions()['caseInsensitiveCommands']) {
-            $alias = mb_strtolower($alias);
+            $alias = function_exists('mb_strtolower')
+                ? mb_strtolower($alias)
+                : strtolower($alias);
         }
 
         $this->subCommandAliases[$alias] = $command;
@@ -249,7 +253,9 @@ class Command
         $subCommand = $originalSubCommand = array_shift($args);
 
         if ($subCommand !== null && $this->client->getCommandClientOptions()['caseInsensitiveCommands']) {
-            $subCommand = mb_strtolower($subCommand);
+            $subCommand = function_exists('mb_strtolower')
+                ? mb_strtolower($subCommand)
+                : strtolower($subCommand);
         }
 
         if (array_key_exists($subCommand, $this->subCommands)) {

--- a/src/Discord/MessageCommandClient/Command.php
+++ b/src/Discord/MessageCommandClient/Command.php
@@ -259,9 +259,7 @@ class Command
 
         $key = $this->subCommandRegistry->register($commandInstance, $resolvedOptions['aliases']);
 
-        if (method_exists($this->client, 'emit')) {
-            $this->client->emit('subcommand-registered', [$this->command, $key, $commandInstance, $resolvedOptions]);
-        }
+        $this->client->emit('subcommand-registered', [$this->command, $key, $commandInstance, $resolvedOptions]);
 
         return $commandInstance;
     }

--- a/src/Discord/MessageCommandClient/Command.php
+++ b/src/Discord/MessageCommandClient/Command.php
@@ -109,38 +109,42 @@ class Command
     protected $callable;
 
     /**
+     * An array of options passed to the command.
+     *
+     * @var array
+     */
+    protected $options;
+
+    /**
      * Creates a command instance.
      *
-     * @param MessageCommandClient $client          The message command client.
-     * @param string               $command         Command trigger.
-     * @param callable             $callable        Callable to execute.
-     * @param string               $description     Short description.
-     * @param string               $longDescription Long description.
-     * @param string               $usage           Usage string.
-     * @param int                  $cooldown        Cooldown in milliseconds.
-     * @param string               $cooldownMessage Cooldown message.
-     * @param bool                 $showHelp        Whether to show in help.
+     * @param MessageCommandClient $client                     The message command client.
+     * @param string               $command                    Command trigger.
+     * @param callable             $callable                   Callable to execute.
+     * @param array                $options                    Command options:
+     * @param string               $options['description']     Short description.
+     * @param string               $options['longDescription'] Long description.
+     * @param string               $options['usage']           Usage string.
+     * @param int                  $options['cooldown']        Cooldown in milliseconds.
+     * @param string               $options['cooldownMessage'] Cooldown message.
+     * @param bool                 $options['showHelp']        Whether to show in help.
      */
     public function __construct(
         MessageCommandClient $client,
         string $command,
         callable $callable,
-        string $description,
-        string $longDescription,
-        string $usage,
-        int $cooldown,
-        string $cooldownMessage,
-        bool $showHelp = true
+        array $options = []
     ) {
         $this->client = $client;
         $this->command = $command;
         $this->callable = $callable;
-        $this->description = $description;
-        $this->longDescription = $longDescription;
-        $this->usage = $usage;
-        $this->cooldown = $cooldown;
-        $this->cooldownMessage = $cooldownMessage;
-        $this->showHelp = $showHelp;
+        $this->options = $options;
+        $this->description = $options['description'] ?? '';
+        $this->longDescription = $options['longDescription'] ?? '';
+        $this->usage = $options['usage'] ?? '';
+        $this->cooldown = $options['cooldown'] ?? 0;
+        $this->cooldownMessage = $options['cooldownMessage'] ?? '';
+        $this->showHelp = $options['showHelp'] ?? true;
     }
 
     /**

--- a/src/Discord/MessageCommandClient/Command.php
+++ b/src/Discord/MessageCommandClient/Command.php
@@ -144,12 +144,12 @@ class Command
         $options = $this->resolveOptions($options);
 
         $this->options = $options;
-        $this->description = $this->options['description'];
-        $this->longDescription = $this->options['longDescription'];
-        $this->usage = $this->options['usage'];
-        $this->cooldown = $this->options['cooldown'];
-        $this->cooldownMessage = $this->options['cooldownMessage'];
-        $this->showHelp = $this->options['showHelp'];
+        $this->description = $options['description'];
+        $this->longDescription = $options['longDescription'];
+        $this->usage = $options['usage'];
+        $this->cooldown = $options['cooldown'];
+        $this->cooldownMessage = $options['cooldownMessage'];
+        $this->showHelp = $options['showHelp'];
     }
 
     /**

--- a/src/Discord/MessageCommandClient/Command.php
+++ b/src/Discord/MessageCommandClient/Command.php
@@ -260,7 +260,7 @@ class Command
         $key = $this->subCommandRegistry->register($commandInstance, $resolvedOptions['aliases']);
 
         if (method_exists($this->client, 'emit')) {
-            $this->client->emit('messagecommandclient.subcommand.registered', [$this->command, $key, $commandInstance, $resolvedOptions]);
+            $this->client->emit('subcommand-registered', [$this->command, $key, $commandInstance, $resolvedOptions]);
         }
 
         return $commandInstance;

--- a/src/Discord/MessageCommandClient/Command.php
+++ b/src/Discord/MessageCommandClient/Command.php
@@ -1,0 +1,339 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is a part of the DiscordPHP project.
+ *
+ * Copyright (c) 2015-2022 David Cole <david.cole1340@gmail.com>
+ * Copyright (c) 2020-present Valithor Obsidion <valithor@discordphp.org>
+ *
+ * This file is subject to the MIT license that is bundled
+ * with this source code in the LICENSE.md file.
+ */
+
+namespace Discord\MessageCommandClient;
+
+use Discord\MessageCommandClient;
+use Discord\Parts\Channel\Message;
+
+/**
+ * A message-based command that the MessageCommandClient will listen for.
+ *
+ * @since 10.49.0
+ */
+class Command
+{
+    /**
+     * The trigger for the command.
+     *
+     * @var string
+     */
+    public string $command;
+
+    /**
+     * Short description shown in help listings.
+     *
+     * @var string
+     */
+    public string $description;
+
+    /**
+     * Long description for detailed help.
+     *
+     * @var string
+     */
+    public string $longDescription;
+
+    /**
+     * Usage string.
+     *
+     * @var string
+     */
+    public string $usage;
+
+    /**
+     * Cooldown duration in milliseconds.
+     *
+     * @var int
+     */
+    public int $cooldown;
+
+    /**
+     * Message displayed when the cooldown is active.
+     *
+     * @var string
+     */
+    public string $cooldownMessage;
+
+    /**
+     * Whether this command should be shown in help listings.
+     *
+     * @var bool
+     */
+    public bool $showHelp;
+
+    /**
+     * Cooldowns map: user ID => timestamp when cooldown expires.
+     *
+     * @var array<string,int>
+     */
+    protected array $cooldowns = [];
+
+    /**
+     * Sub-commands map: name => Command.
+     *
+     * @var array<string, Command>
+     */
+    protected array $subCommands = [];
+
+    /**
+     * Sub-command aliases: alias => sub-command name.
+     *
+     * @var array<string, string>
+     */
+    protected array $subCommandAliases = [];
+
+    /**
+     * Owning MessageCommandClient instance.
+     *
+     * @var MessageCommandClient
+     */
+    protected MessageCommandClient $client;
+
+    /**
+     * The callable executed when the command is invoked.
+     *
+     * @var callable
+     */
+    protected $callable;
+
+    /**
+     * Creates a command instance.
+     *
+     * @param MessageCommandClient $client          The message command client.
+     * @param string               $command         Command trigger.
+     * @param callable             $callable        Callable to execute.
+     * @param string               $description     Short description.
+     * @param string               $longDescription Long description.
+     * @param string               $usage           Usage string.
+     * @param int                  $cooldown        Cooldown in milliseconds.
+     * @param string               $cooldownMessage Cooldown message.
+     * @param bool                 $showHelp        Whether to show in help.
+     */
+    public function __construct(
+        MessageCommandClient $client,
+        string $command,
+        callable $callable,
+        string $description,
+        string $longDescription,
+        string $usage,
+        int $cooldown,
+        string $cooldownMessage,
+        bool $showHelp = true
+    ) {
+        $this->client = $client;
+        $this->command = $command;
+        $this->callable = $callable;
+        $this->description = $description;
+        $this->longDescription = $longDescription;
+        $this->usage = $usage;
+        $this->cooldown = $cooldown;
+        $this->cooldownMessage = $cooldownMessage;
+        $this->showHelp = $showHelp;
+    }
+
+    /**
+     * Attempts to get a sub command.
+     *
+     * @param string $command The sub-command to get.
+     * @param bool   $aliases Whether to search aliases as well.
+     *
+     * @return Command|null
+     */
+    public function getCommand(string $command, bool $aliases = true): ?Command
+    {
+        if (array_key_exists($command, $this->subCommands)) {
+            return $this->subCommands[$command];
+        }
+
+        if ($aliases && array_key_exists($command, $this->subCommandAliases)) {
+            return $this->subCommands[$this->subCommandAliases[$command]];
+        }
+
+        return null;
+    }
+
+    /**
+     * Registers a new sub-command.
+     *
+     * @param string          $command  The command name.
+     * @param callable|string $callable The function called when the sub-command is executed.
+     * @param array           $options  Options for the sub-command.
+     *
+     * @return Command The created sub-command instance.
+     */
+    public function registerSubCommand(string $command, $callable, array $options = []): Command
+    {
+        if (array_key_exists($command, $this->subCommands)) {
+            throw new \RuntimeException("A sub-command with the name {$command} already exists.");
+        }
+
+        if ($command !== null && $this->client->getCommandClientOptions()['caseInsensitiveCommands']) {
+            $command = mb_strtolower($command);
+        }
+
+        list($commandInstance, $options) = $this->client->buildCommand($command, $callable, $options);
+        $this->subCommands[$command] = $commandInstance;
+
+        foreach ($options['aliases'] as $alias) {
+            $this->registerSubCommandAlias($alias, $command);
+        }
+
+        return $commandInstance;
+    }
+
+    /**
+     * Unregister a sub-command.
+     *
+     * @param string $command Sub-command name.
+     */
+    public function unregisterSubCommand(string $command): void
+    {
+        if (! array_key_exists($command, $this->subCommands)) {
+            throw new \RuntimeException("A sub-command with the name {$command} does not exist.");
+        }
+
+        unset($this->subCommands[$command]);
+    }
+
+    /**
+     * Register an alias for a sub-command.
+     *
+     * @param string $alias   Alias name.
+     * @param string $command Target sub-command name.
+     */
+    public function registerSubCommandAlias(string $alias, string $command): void
+    {
+        if ($alias !== null && $this->client->getCommandClientOptions()['caseInsensitiveCommands']) {
+            $alias = mb_strtolower($alias);
+        }
+
+        $this->subCommandAliases[$alias] = $command;
+    }
+
+    /**
+     * Unregister a sub-command alias.
+     *
+     * @param string $alias Alias name.
+     */
+    public function unregisterSubCommandAlias(string $alias): void
+    {
+        if (! array_key_exists($alias, $this->subCommandAliases)) {
+            throw new \RuntimeException("A sub-command alias with the name {$alias} does not exist.");
+        }
+
+        unset($this->subCommandAliases[$alias]);
+    }
+
+    /**
+     * Executes the command.
+     *
+     * @param Message $message The message that triggered the command.
+     * @param array   $args    Parsed arguments.
+     *
+     * @return mixed The response from the callable or sub-command.
+     */
+    public function handle(Message $message, array $args)
+    {
+        $subCommand = $originalSubCommand = array_shift($args);
+
+        if ($subCommand !== null && $this->client->getCommandClientOptions()['caseInsensitiveCommands']) {
+            $subCommand = mb_strtolower($subCommand);
+        }
+
+        if (array_key_exists($subCommand, $this->subCommands)) {
+            return $this->subCommands[$subCommand]->handle($message, $args);
+        } elseif (array_key_exists($subCommand, $this->subCommandAliases)) {
+            return $this->subCommands[$this->subCommandAliases[$subCommand]]->handle($message, $args);
+        }
+
+        if (null !== $subCommand) {
+            array_unshift($args, $originalSubCommand);
+        }
+
+        $currentTime = (int) round(microtime(true) * 1000);
+        if (isset($this->cooldowns[$message->author->id])) {
+            if ($this->cooldowns[$message->author->id] < $currentTime) {
+                $this->cooldowns[$message->author->id] = $currentTime + $this->cooldown;
+            } else {
+                return sprintf($this->cooldownMessage, (($this->cooldowns[$message->author->id] - $currentTime) / 1000));
+            }
+        } else {
+            $this->cooldowns[$message->author->id] = $currentTime + $this->cooldown;
+        }
+
+        return call_user_func_array($this->callable, [$message, $args]);
+    }
+
+    /**
+     * Gets help information for this command.
+     *
+     * @param string $prefix The prefix to display before the command.
+     *
+     * @return array Help information.
+     */
+    public function getHelp(string $prefix): array
+    {
+        if (! $this->showHelp) {
+            return [];
+        }
+
+        $subCommandsHelp = [];
+
+        foreach ($this->subCommands as $command) {
+            if ($command->showHelp) {
+                $subCommandsHelp[] = $command->getHelp($prefix.$this->command.' ');
+            }
+        }
+
+        return [
+            'command' => $prefix.$this->command,
+            'description' => $this->description,
+            'longDescription' => $this->longDescription,
+            'usage' => $this->usage,
+            'subCommandsHelp' => $subCommandsHelp,
+        ];
+    }
+
+    /**
+     * Handles dynamic getters for some public properties.
+     *
+     * @param string $variable Property name.
+     *
+     * @return mixed|null
+     */
+    public function __get(string $variable)
+    {
+        static $allowed = ['command', 'description', 'longDescription', 'usage', 'cooldown', 'cooldownMessage', 'showHelp'];
+
+        if (in_array($variable, $allowed, true)) {
+            return $this->{$variable};
+        }
+
+        return null;
+    }
+
+    /**
+     * Magic invoke to allow the command to be called like a callable.
+     *
+     * @param Message $message The message that triggered the command.
+     * @param array   $args    Parsed arguments.
+     *
+     * @return mixed The result of {@see handle()}.
+     */
+    public function __invoke(Message $message, array $args)
+    {
+        return $this->handle($message, $args);
+    }
+}

--- a/src/Discord/MessageCommandClient/Command.php
+++ b/src/Discord/MessageCommandClient/Command.php
@@ -144,6 +144,18 @@ class Command
     }
 
     /**
+     * Normalize a command or alias according to the client's case sensitivity setting.
+     */
+    protected function normalizeName(string $name): string
+    {
+        if ($this->client->getCommandClientOptions()['caseInsensitiveCommands']) {
+            return function_exists('mb_strtolower') ? mb_strtolower($name) : strtolower($name);
+        }
+
+        return $name;
+    }
+
+    /**
      * Attempts to get a sub command.
      *
      * @param string $command The sub-command to get.
@@ -153,10 +165,8 @@ class Command
      */
     public function getCommand(string $command, bool $aliases = true): ?Command
     {
-        if ($command !== null && $this->client->getCommandClientOptions()['caseInsensitiveCommands']) {
-            $command = function_exists('mb_strtolower')
-                ? mb_strtolower($command)
-                : strtolower($command);
+        if ($command !== null) {
+            $command = $this->normalizeName($command);
         }
 
         if (array_key_exists($command, $this->subCommands)) {
@@ -187,14 +197,10 @@ class Command
      */
     public function registerSubCommand(string $command, $callable, array $options = []): Command
     {
+        $command = $this->normalizeName($command);
+
         if (array_key_exists($command, $this->subCommands)) {
             throw new \RuntimeException("A sub-command with the name {$command} already exists.");
-        }
-
-        if ($command !== null && $this->client->getCommandClientOptions()['caseInsensitiveCommands']) {
-            $command = function_exists('mb_strtolower')
-                ? mb_strtolower($command)
-                : strtolower($command);
         }
 
         ['command' => $commandInstance, 'options' => $resolvedOptions] = $this->client->buildCommand($command, $callable, $options);
@@ -214,14 +220,12 @@ class Command
      */
     public function unregisterSubCommand(string $command): void
     {
+        $command = $this->normalizeName($command);
+
         if (! array_key_exists($command, $this->subCommands)) {
             throw new \RuntimeException("A sub-command with the name {$command} does not exist.");
         }
-        if ($command !== null && $this->client->getCommandClientOptions()['caseInsensitiveCommands']) {
-            $command = function_exists('mb_strtolower')
-                ? mb_strtolower($command)
-                : strtolower($command);
-        }
+
         unset($this->subCommands[$command]);
     }
 
@@ -233,17 +237,8 @@ class Command
      */
     public function registerSubCommandAlias(string $alias, string $command): void
     {
-        if ($alias !== null && $this->client->getCommandClientOptions()['caseInsensitiveCommands']) {
-            $alias = function_exists('mb_strtolower')
-                ? mb_strtolower($alias)
-                : strtolower($alias);
-        }
-
-        if ($command !== null && $this->client->getCommandClientOptions()['caseInsensitiveCommands']) {
-            $command = function_exists('mb_strtolower')
-                ? mb_strtolower($command)
-                : strtolower($command);
-        }
+        $alias = $this->normalizeName($alias);
+        $command = $this->normalizeName($command);
 
         $this->subCommandAliases[$alias] = $command;
     }
@@ -255,14 +250,11 @@ class Command
      */
     public function unregisterSubCommandAlias(string $alias): void
     {
-        if ($alias !== null && $this->client->getCommandClientOptions()['caseInsensitiveCommands']) {
-            $alias = function_exists('mb_strtolower')
-                ? mb_strtolower($alias)
-                : strtolower($alias);
-        }
+        $originalAlias = $alias;
+        $alias = $this->normalizeName($alias);
 
         if (! array_key_exists($alias, $this->subCommandAliases)) {
-            throw new \RuntimeException("A sub-command alias with the name {$alias} does not exist.");
+            throw new \RuntimeException("A sub-command alias with the name {$originalAlias} does not exist.");
         }
 
         unset($this->subCommandAliases[$alias]);
@@ -280,10 +272,8 @@ class Command
     {
         $subCommand = $originalSubCommand = array_shift($args);
 
-        if ($subCommand !== null && $this->client->getCommandClientOptions()['caseInsensitiveCommands']) {
-            $subCommand = function_exists('mb_strtolower')
-                ? mb_strtolower($subCommand)
-                : strtolower($subCommand);
+        if ($subCommand !== null) {
+            $subCommand = $this->normalizeName($subCommand);
         }
 
         if (array_key_exists($subCommand, $this->subCommands)) {

--- a/src/Discord/MessageCommandClient/Command.php
+++ b/src/Discord/MessageCommandClient/Command.php
@@ -262,6 +262,27 @@ class Command
         $alias = $this->normalizeName($alias);
         $command = $this->normalizeName($command);
 
+        // Ensure the target sub-command exists.
+        if (! array_key_exists($command, $this->subCommands)) {
+            throw new \RuntimeException("Cannot create alias {$alias} for non-existent sub-command {$command}.");
+        }
+
+        // Alias must not collide with an existing sub-command name.
+        if (array_key_exists($alias, $this->subCommands)) {
+            throw new \RuntimeException("Cannot create alias {$alias} because a sub-command with that name already exists.");
+        }
+
+        // If alias already exists, ensure it's not being remapped to a different target.
+        if (array_key_exists($alias, $this->subCommandAliases)) {
+            $existing = $this->subCommandAliases[$alias];
+            if ($existing === $command) {
+                // Already mapped to the same target — no-op.
+                return;
+            }
+
+            throw new \RuntimeException("Cannot remap alias {$alias} from {$existing} to {$command}.");
+        }
+
         $this->subCommandAliases[$alias] = $command;
     }
 

--- a/src/Discord/MessageCommandClient/Command.php
+++ b/src/Discord/MessageCommandClient/Command.php
@@ -199,15 +199,17 @@ class Command
     {
         $command = $this->normalizeName($command);
 
-        if (array_key_exists($command, $this->subCommands)) {
-            throw new \RuntimeException("A sub-command with the name {$command} already exists.");
+        ['command' => $commandInstance, 'options' => $resolvedOptions] = $this->client->buildCommand($command, $callable, $options);
+
+        $key = $this->normalizeName($commandInstance->command);
+        if (array_key_exists($key, $this->subCommands)) {
+            throw new \RuntimeException("A sub-command with the name {$key} already exists.");
         }
 
-        ['command' => $commandInstance, 'options' => $resolvedOptions] = $this->client->buildCommand($command, $callable, $options);
-        $this->subCommands[$command] = $commandInstance;
+        $this->subCommands[$key] = $commandInstance;
 
         foreach ($resolvedOptions['aliases'] as $alias) {
-            $this->registerSubCommandAlias($alias, $command);
+            $this->registerSubCommandAlias($alias, $key);
         }
 
         return $commandInstance;

--- a/src/Discord/MessageCommandClient/Command.php
+++ b/src/Discord/MessageCommandClient/Command.php
@@ -153,12 +153,24 @@ class Command
      */
     public function getCommand(string $command, bool $aliases = true): ?Command
     {
+        if ($command !== null && $this->client->getCommandClientOptions()['caseInsensitiveCommands']) {
+            $command = function_exists('mb_strtolower')
+                ? mb_strtolower($command)
+                : strtolower($command);
+        }
+
         if (array_key_exists($command, $this->subCommands)) {
             return $this->subCommands[$command];
         }
 
-        if ($aliases && array_key_exists($command, $this->subCommandAliases)) {
-            return $this->subCommands[$this->subCommandAliases[$command]];
+        if ($aliases) {
+            if (array_key_exists($command, $this->subCommandAliases)) {
+                $target = $this->subCommandAliases[$command];
+
+                if (array_key_exists($target, $this->subCommands)) {
+                    return $this->subCommands[$target];
+                }
+            }
         }
 
         return null;

--- a/src/Discord/MessageCommandClient/Command.php
+++ b/src/Discord/MessageCommandClient/Command.php
@@ -205,7 +205,11 @@ class Command
         if (! array_key_exists($command, $this->subCommands)) {
             throw new \RuntimeException("A sub-command with the name {$command} does not exist.");
         }
-
+        if ($command !== null && $this->client->getCommandClientOptions()['caseInsensitiveCommands']) {
+            $command = function_exists('mb_strtolower')
+                ? mb_strtolower($command)
+                : strtolower($command);
+        }
         unset($this->subCommands[$command]);
     }
 

--- a/src/Discord/MessageCommandClient/Command.php
+++ b/src/Discord/MessageCommandClient/Command.php
@@ -18,6 +18,7 @@ use Discord\MessageCommandClient;
 use Discord\Parts\Channel\Message;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\OptionsResolver\Options;
+use Discord\MessageCommandClient\BuiltCommand;
 
 /**
  * A message-based command that the MessageCommandClient will listen for.
@@ -105,7 +106,7 @@ class Command
      *
      * @var callable
      */
-    protected callable $callable;
+    protected $callable;
 
     /**
      * An array of options passed to the command.
@@ -249,7 +250,7 @@ class Command
     public function registerSubCommand(string $command, $callable, array $options = []): Command
     {
         $built = $this->client->buildCommand($command, $callable, $options);
-        if ($built instanceof \Discord\MessageCommandClient\BuiltCommand) {
+        if ($built instanceof BuiltCommand) {
             $commandInstance = $built->command;
             $resolvedOptions = $built->options;
         } else {
@@ -269,6 +270,7 @@ class Command
      * Unregister a sub-command.
      *
      * @param string $command Sub-command name.
+     * @throws \RuntimeException If the sub-command does not exist.
      */
     public function unregisterSubCommand(string $command): void
     {

--- a/src/Discord/MessageCommandClient/Command.php
+++ b/src/Discord/MessageCommandClient/Command.php
@@ -280,10 +280,10 @@ class Command
 
         $key = $this->normalizeName($commandInstance->command);
         if (array_key_exists($key, $this->subCommandAliases)) {
-            throw new \RuntimeException("A sub-command with the name {$key} already exists as an alias for another sub-command.");
+            throw new \RuntimeException("A sub-command with the same name already exists as an alias for another sub-command.");
         }
         if (array_key_exists($key, $this->subCommands)) {
-            throw new \RuntimeException("A sub-command with the name {$key} already exists.");
+            throw new \RuntimeException("A sub-command with the same name already exists.");
         }
 
         $this->subCommands[$key] = $commandInstance;
@@ -310,7 +310,7 @@ class Command
         $command = $this->normalizeName($command);
 
         if (! array_key_exists($command, $this->subCommands)) {
-            throw new \RuntimeException("A sub-command with the name {$command} does not exist.");
+            throw new \RuntimeException("The sub-command does not exist.");
         }
 
         unset($this->subCommands[$command]);
@@ -329,12 +329,12 @@ class Command
 
         // Ensure the target sub-command exists.
         if (! array_key_exists($command, $this->subCommands)) {
-            throw new \RuntimeException("Cannot create alias {$alias} for non-existent sub-command {$command}.");
+            throw new \RuntimeException("The target sub-command does not exist.");
         }
 
         // Alias must not collide with an existing sub-command name.
         if (array_key_exists($alias, $this->subCommands)) {
-            throw new \RuntimeException("Cannot create alias {$alias} because a sub-command with that name already exists.");
+            throw new \RuntimeException("Cannot create alias because a sub-command with that name already exists.");
         }
 
         // If alias already exists, ensure it's not being remapped to a different target.
@@ -345,7 +345,7 @@ class Command
                 return;
             }
 
-            throw new \RuntimeException("Cannot remap alias {$alias} from {$existing} to {$command}.");
+            throw new \RuntimeException("Cannot remap alias because it is already mapped to a different sub-command.");
         }
 
         $this->subCommandAliases[$alias] = $command;
@@ -362,7 +362,7 @@ class Command
         $alias = $this->normalizeName($alias);
 
         if (! array_key_exists($alias, $this->subCommandAliases)) {
-            throw new \RuntimeException("A sub-command alias with the name {$originalAlias} does not exist.");
+            throw new \RuntimeException("The sub-command alias does not exist.");
         }
 
         unset($this->subCommandAliases[$alias]);

--- a/src/Discord/MessageCommandClient/Command.php
+++ b/src/Discord/MessageCommandClient/Command.php
@@ -239,6 +239,12 @@ class Command
                 : strtolower($alias);
         }
 
+        if ($command !== null && $this->client->getCommandClientOptions()['caseInsensitiveCommands']) {
+            $command = function_exists('mb_strtolower')
+                ? mb_strtolower($command)
+                : strtolower($command);
+        }
+
         $this->subCommandAliases[$alias] = $command;
     }
 
@@ -249,6 +255,12 @@ class Command
      */
     public function unregisterSubCommandAlias(string $alias): void
     {
+        if ($alias !== null && $this->client->getCommandClientOptions()['caseInsensitiveCommands']) {
+            $alias = function_exists('mb_strtolower')
+                ? mb_strtolower($alias)
+                : strtolower($alias);
+        }
+
         if (! array_key_exists($alias, $this->subCommandAliases)) {
             throw new \RuntimeException("A sub-command alias with the name {$alias} does not exist.");
         }

--- a/src/Discord/MessageCommandClient/Command.php
+++ b/src/Discord/MessageCommandClient/Command.php
@@ -183,10 +183,10 @@ class Command
             $command = mb_strtolower($command);
         }
 
-        list($commandInstance, $options) = $this->client->buildCommand($command, $callable, $options);
+        ['command' => $commandInstance, 'options' => $resolvedOptions] = $this->client->buildCommand($command, $callable, $options);
         $this->subCommands[$command] = $commandInstance;
 
-        foreach ($options['aliases'] as $alias) {
+        foreach ($resolvedOptions['aliases'] as $alias) {
             $this->registerSubCommandAlias($alias, $command);
         }
 

--- a/src/Discord/MessageCommandClient/Command.php
+++ b/src/Discord/MessageCommandClient/Command.php
@@ -78,23 +78,20 @@ class Command
     /**
      * Cooldowns map: user ID => timestamp when cooldown expires.
      *
-     * @var array<string,int>
+     * Managed by CooldownManager.
+     *
+     * @var CooldownManager
      */
-    protected array $cooldowns = [];
+    protected CooldownManager $cooldownManager;
 
     /**
      * Sub-commands map: name => Command.
      *
-     * @var array<string, Command>
-     */
-    protected array $subCommands = [];
-
-    /**
-     * Sub-command aliases: alias => sub-command name.
+     * Managed by SubCommandRegistry.
      *
-     * @var array<string, string>
+     * @var SubCommandRegistry
      */
-    protected array $subCommandAliases = [];
+    protected SubCommandRegistry $subCommandRegistry;
 
     /**
      * Owning MessageCommandClient instance.
@@ -150,6 +147,8 @@ class Command
         $this->cooldown = $options['cooldown'];
         $this->cooldownMessage = $options['cooldownMessage'];
         $this->showHelp = $options['showHelp'];
+        $this->subCommandRegistry = new SubCommandRegistry(fn (string $name) => $this->normalizeName($name));
+        $this->cooldownManager = new CooldownManager();
     }
 
     /**
@@ -235,25 +234,7 @@ class Command
      */
     public function getCommand(string $command, bool $aliases = true): ?Command
     {
-        if ($command !== null) {
-            $command = $this->normalizeName($command);
-        }
-
-        if (array_key_exists($command, $this->subCommands)) {
-            return $this->subCommands[$command];
-        }
-
-        if ($aliases) {
-            if (array_key_exists($command, $this->subCommandAliases)) {
-                $target = $this->subCommandAliases[$command];
-
-                if (array_key_exists($target, $this->subCommands)) {
-                    return $this->subCommands[$target];
-                }
-            }
-        }
-
-        return null;
+        return $this->subCommandRegistry->get($command, $aliases);
     }
 
     /**
@@ -267,32 +248,16 @@ class Command
      */
     public function registerSubCommand(string $command, $callable, array $options = []): Command
     {
-        $command = $this->normalizeName($command);
-
         $built = $this->client->buildCommand($command, $callable, $options);
         if ($built instanceof \Discord\MessageCommandClient\BuiltCommand) {
             $commandInstance = $built->command;
             $resolvedOptions = $built->options;
         } else {
-            // Backwards compatibility: accept old array shape
             ['command' => $commandInstance, 'options' => $resolvedOptions] = $built;
         }
 
-        $key = $this->normalizeName($commandInstance->command);
-        if (array_key_exists($key, $this->subCommandAliases)) {
-            throw new \RuntimeException('A sub-command with the same name already exists as an alias for another sub-command.');
-        }
-        if (array_key_exists($key, $this->subCommands)) {
-            throw new \RuntimeException('A sub-command with the same name already exists.');
-        }
+        $key = $this->subCommandRegistry->register($commandInstance, $resolvedOptions['aliases']);
 
-        $this->subCommands[$key] = $commandInstance;
-
-        foreach ($resolvedOptions['aliases'] as $alias) {
-            $this->registerSubCommandAlias($alias, $key);
-        }
-
-        // Emit a lifecycle event so extensions/plugins can react.
         if (method_exists($this->client, 'emit')) {
             $this->client->emit('messagecommandclient.subcommand.registered', [$this->command, $key, $commandInstance, $resolvedOptions]);
         }
@@ -307,13 +272,7 @@ class Command
      */
     public function unregisterSubCommand(string $command): void
     {
-        $command = $this->normalizeName($command);
-
-        if (! array_key_exists($command, $this->subCommands)) {
-            throw new \RuntimeException('The sub-command does not exist.');
-        }
-
-        unset($this->subCommands[$command]);
+        $this->subCommandRegistry->unregister($command);
     }
 
     /**
@@ -324,31 +283,7 @@ class Command
      */
     public function registerSubCommandAlias(string $alias, string $command): void
     {
-        $alias = $this->normalizeName($alias);
-        $command = $this->normalizeName($command);
-
-        // Ensure the target sub-command exists.
-        if (! array_key_exists($command, $this->subCommands)) {
-            throw new \RuntimeException('The target sub-command does not exist.');
-        }
-
-        // Alias must not collide with an existing sub-command name.
-        if (array_key_exists($alias, $this->subCommands)) {
-            throw new \RuntimeException('Cannot create alias because a sub-command with that name already exists.');
-        }
-
-        // If alias already exists, ensure it's not being remapped to a different target.
-        if (array_key_exists($alias, $this->subCommandAliases)) {
-            $existing = $this->subCommandAliases[$alias];
-            if ($existing === $command) {
-                // Already mapped to the same target — no-op.
-                return;
-            }
-
-            throw new \RuntimeException('Cannot remap alias because it is already mapped to a different sub-command.');
-        }
-
-        $this->subCommandAliases[$alias] = $command;
+        $this->subCommandRegistry->registerAlias($alias, $command);
     }
 
     /**
@@ -358,13 +293,7 @@ class Command
      */
     public function unregisterSubCommandAlias(string $alias): void
     {
-        $alias = $this->normalizeName($alias);
-
-        if (! array_key_exists($alias, $this->subCommandAliases)) {
-            throw new \RuntimeException('The sub-command alias does not exist.');
-        }
-
-        unset($this->subCommandAliases[$alias]);
+        $this->subCommandRegistry->unregisterAlias($alias);
     }
 
     /**
@@ -383,13 +312,9 @@ class Command
             $subCommand = $this->normalizeName($subCommand);
         }
 
-        if (array_key_exists($subCommand, $this->subCommands)) {
-            return $this->subCommands[$subCommand]->handle($message, $args);
-        } elseif (array_key_exists($subCommand, $this->subCommandAliases)) {
-            $target = $this->subCommandAliases[$subCommand];
-            if (array_key_exists($target, $this->subCommands)) {
-                return $this->subCommands[$target]->handle($message, $args);
-            }
+        $found = $this->subCommandRegistry->get($subCommand, true);
+        if ($found instanceof Command) {
+            return $found->handle($message, $args);
         }
 
         if (null !== $subCommand) {
@@ -398,7 +323,7 @@ class Command
 
         $currentTime = (int) round(microtime(true) * 1000);
 
-        if (($cooldownResult = $this->enforceCooldown($message, $currentTime)) !== null) {
+        if (($cooldownResult = $this->cooldownManager->enforce($message, $currentTime, $this->cooldown, $this->cooldownMessage)) !== null) {
             return $cooldownResult;
         }
 
@@ -419,21 +344,8 @@ class Command
             return null;
         }
 
-        $userId = $message->author->id;
-
-        if (isset($this->cooldowns[$userId])) {
-            if ($this->cooldowns[$userId] < $currentTime) {
-                $this->cooldowns[$userId] = $currentTime + $this->cooldown;
-
-                return null;
-            }
-
-            return sprintf($this->cooldownMessage, (($this->cooldowns[$userId] - $currentTime) / 1000));
-        }
-
-        $this->cooldowns[$userId] = $currentTime + $this->cooldown;
-
-        return null;
+        // Deprecated: functionality moved to CooldownManager.
+        return $this->cooldownManager->enforce($message, $currentTime, $this->cooldown, $this->cooldownMessage);
     }
 
     /**
@@ -451,7 +363,7 @@ class Command
 
         $subCommandsHelp = [];
 
-        foreach ($this->subCommands as $command) {
+        foreach ($this->subCommandRegistry->all() as $command) {
             if ($command->showHelp) {
                 $subCommandsHelp[] = $command->getHelp($prefix.$this->command.' ');
             }

--- a/src/Discord/MessageCommandClient/Command.php
+++ b/src/Discord/MessageCommandClient/Command.php
@@ -301,7 +301,10 @@ class Command
         if (array_key_exists($subCommand, $this->subCommands)) {
             return $this->subCommands[$subCommand]->handle($message, $args);
         } elseif (array_key_exists($subCommand, $this->subCommandAliases)) {
-            return $this->subCommands[$this->subCommandAliases[$subCommand]]->handle($message, $args);
+            $target = $this->subCommandAliases[$subCommand];
+            if (array_key_exists($target, $this->subCommands)) {
+                return $this->subCommands[$target]->handle($message, $args);
+            }
         }
 
         if (null !== $subCommand) {

--- a/src/Discord/MessageCommandClient/Command.php
+++ b/src/Discord/MessageCommandClient/Command.php
@@ -202,6 +202,9 @@ class Command
         ['command' => $commandInstance, 'options' => $resolvedOptions] = $this->client->buildCommand($command, $callable, $options);
 
         $key = $this->normalizeName($commandInstance->command);
+        if (array_key_exists($key, $this->subCommandAliases)) {
+            throw new \RuntimeException("A sub-command with the name {$key} already exists as an alias for another sub-command.");
+        }
         if (array_key_exists($key, $this->subCommands)) {
             throw new \RuntimeException("A sub-command with the name {$key} already exists.");
         }

--- a/src/Discord/MessageCommandClient/Command.php
+++ b/src/Discord/MessageCommandClient/Command.php
@@ -213,16 +213,7 @@ class Command
      */
     protected function normalizeName(string $name): string
     {
-        if (method_exists($this->client, 'normalizeCommandName')) {
-            return $this->client->normalizeCommandName($name);
-        }
-
-        // Fallback: mirror previous behavior if client does not provide helper.
-        if ($this->client->getCommandClientOptions()['caseInsensitiveCommands']) {
-            return function_exists('mb_strtolower') ? mb_strtolower($name) : strtolower($name);
-        }
-
-        return $name;
+        return $this->client->normalizeCommandName($name);
     }
 
     /**

--- a/src/Discord/MessageCommandClient/Command.php
+++ b/src/Discord/MessageCommandClient/Command.php
@@ -16,6 +16,8 @@ namespace Discord\MessageCommandClient;
 
 use Discord\MessageCommandClient;
 use Discord\Parts\Channel\Message;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\OptionsResolver\Options;
 
 /**
  * A message-based command that the MessageCommandClient will listen for.
@@ -138,13 +140,72 @@ class Command
         $this->client = $client;
         $this->command = $command;
         $this->callable = $callable;
+        
+        $options = $this->resolveOptions($options);
+
         $this->options = $options;
-        $this->description = $options['description'] ?? '';
-        $this->longDescription = $options['longDescription'] ?? '';
-        $this->usage = $options['usage'] ?? '';
-        $this->cooldown = $options['cooldown'] ?? 0;
-        $this->cooldownMessage = $options['cooldownMessage'] ?? '';
-        $this->showHelp = $options['showHelp'] ?? true;
+        $this->description = $this->options['description'];
+        $this->longDescription = $this->options['longDescription'];
+        $this->usage = $this->options['usage'];
+        $this->cooldown = $this->options['cooldown'];
+        $this->cooldownMessage = $this->options['cooldownMessage'];
+        $this->showHelp = $this->options['showHelp'];
+    }
+
+    /**
+     * Resolve and normalize command options.
+     *
+     * @param array $options
+     *
+     * @return array
+     */
+    protected function resolveOptions(array $options = []): array
+    {
+        $resolver = new OptionsResolver();
+
+        $resolver
+            ->setDefined([
+                'description',
+                'longDescription',
+                'usage',
+                'aliases',
+                'cooldown',
+                'cooldownMessage',
+                'showHelp',
+            ])
+            ->setDefaults([
+                'description' => 'No description provided.',
+                'longDescription' => '',
+                'usage' => '',
+                'aliases' => [],
+                'cooldown' => 0,
+                'cooldownMessage' => 'please wait %d second(s) to use this command again.',
+                'showHelp' => true,
+            ])
+            ->setAllowedTypes('aliases', ['array', 'string', 'null'])
+            ->setNormalizer('aliases', function (Options $options, $value) {
+                if ($value === null) {
+                    return [];
+                }
+
+                if (! is_array($value)) {
+                    $value = [$value];
+                }
+
+                $sanitized = [];
+                foreach ($value as $alias) {
+                    if (is_scalar($alias) || (is_object($alias) && method_exists($alias, '__toString'))) {
+                        $aliasStr = trim((string) $alias);
+                        if ($aliasStr !== '') {
+                            $sanitized[] = $aliasStr;
+                        }
+                    }
+                }
+
+                return array_values(array_unique($sanitized));
+            });
+
+        return $resolver->resolve($options);
     }
 
     /**

--- a/src/Discord/MessageCommandClient/Command.php
+++ b/src/Discord/MessageCommandClient/Command.php
@@ -273,17 +273,43 @@ class Command
         }
 
         $currentTime = (int) round(microtime(true) * 1000);
-        if (isset($this->cooldowns[$message->author->id])) {
-            if ($this->cooldowns[$message->author->id] < $currentTime) {
-                $this->cooldowns[$message->author->id] = $currentTime + $this->cooldown;
-            } else {
-                return sprintf($this->cooldownMessage, (($this->cooldowns[$message->author->id] - $currentTime) / 1000));
-            }
-        } else {
-            $this->cooldowns[$message->author->id] = $currentTime + $this->cooldown;
+
+        if ($cooldownResult = $this->enforceCooldown($message, $currentTime)) {
+            return $cooldownResult;
         }
 
         return call_user_func_array($this->callable, [$message, $args]);
+    }
+
+    /**
+     * Enforce and update cooldowns for a message author.
+     *
+     * @param Message $message     The message that triggered the command.
+     * @param int     $currentTime Current time in milliseconds.
+     *
+     * @return string|null Returns a formatted cooldown message when the author is on cooldown, or null when allowed.
+     */
+    protected function enforceCooldown(Message $message, int $currentTime): ?string
+    {
+        if ($this->cooldown <= 0) {
+            return null;
+        }
+
+        $userId = $message->author->id;
+
+        if (isset($this->cooldowns[$userId])) {
+            if ($this->cooldowns[$userId] < $currentTime) {
+                $this->cooldowns[$userId] = $currentTime + $this->cooldown;
+
+                return null;
+            }
+
+            return sprintf($this->cooldownMessage, (($this->cooldowns[$userId] - $currentTime) / 1000));
+        }
+
+        $this->cooldowns[$userId] = $currentTime + $this->cooldown;
+
+        return null;
     }
 
     /**

--- a/src/Discord/MessageCommandClient/Command.php
+++ b/src/Discord/MessageCommandClient/Command.php
@@ -358,7 +358,6 @@ class Command
      */
     public function unregisterSubCommandAlias(string $alias): void
     {
-        $originalAlias = $alias;
         $alias = $this->normalizeName($alias);
 
         if (! array_key_exists($alias, $this->subCommandAliases)) {

--- a/src/Discord/MessageCommandClient/Command.php
+++ b/src/Discord/MessageCommandClient/Command.php
@@ -334,7 +334,7 @@ class Command
 
         $currentTime = (int) round(microtime(true) * 1000);
 
-        if ($cooldownResult = $this->enforceCooldown($message, $currentTime)) {
+        if (($cooldownResult = $this->enforceCooldown($message, $currentTime)) !== null) {
             return $cooldownResult;
         }
 

--- a/src/Discord/MessageCommandClient/CommandRegistry.php
+++ b/src/Discord/MessageCommandClient/CommandRegistry.php
@@ -74,7 +74,7 @@ final class CommandRegistry
     {
         $name = $this->normalize($name);
         if (isset($this->commands[$name])) {
-            throw new \RuntimeException("A command with the same name already exists.");
+            throw new \RuntimeException('A command with the same name already exists.');
         }
 
         $this->commands[$name] = $command;

--- a/src/Discord/MessageCommandClient/CommandRegistry.php
+++ b/src/Discord/MessageCommandClient/CommandRegistry.php
@@ -82,6 +82,8 @@ final class CommandRegistry
 
     /**
      * Remove a command from the registry.
+     * 
+     * This does not remove any aliases pointing to this command, so they will become invalid until removed or updated.
      *
      * @param string $name Command trigger name.
      */

--- a/src/Discord/MessageCommandClient/CommandRegistry.php
+++ b/src/Discord/MessageCommandClient/CommandRegistry.php
@@ -74,7 +74,7 @@ final class CommandRegistry
     {
         $name = $this->normalize($name);
         if (isset($this->commands[$name])) {
-            throw new \RuntimeException("A command with the name {$name} already exists.");
+            throw new \RuntimeException("A command with the same name already exists.");
         }
 
         $this->commands[$name] = $command;

--- a/src/Discord/MessageCommandClient/CommandRegistry.php
+++ b/src/Discord/MessageCommandClient/CommandRegistry.php
@@ -1,0 +1,168 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is a part of the DiscordPHP project.
+ *
+ * Copyright (c) 2015-2022 David Cole <david.cole1340@gmail.com>
+ * Copyright (c) 2020-present Valithor Obsidion <valithor@discordphp.org>
+ *
+ * This file is subject to the MIT license that is bundled
+ * with this source code in the LICENSE.md file.
+ */
+
+namespace Discord\MessageCommandClient;
+
+/**
+ * Registry for message command client commands and aliases.
+ *
+ * @since 10.49.0
+ */
+final class CommandRegistry
+{
+    /**
+     * Map of command name => Command instance.
+     *
+     * @var array<string, Command>
+     */
+    protected array $commands = [];
+
+    /**
+     * Map of alias => command name.
+     *
+     * @var array<string, string>
+     */
+    protected array $aliases = [];
+
+    /**
+     * Whether command names/aliases should be treated case-insensitively.
+     *
+     * @var bool
+     */
+    protected bool $caseInsensitive;
+
+    /**
+     * Creates a command registry instance.
+     *
+     * @param bool $caseInsensitive Whether command names/aliases should be treated case-insensitively.
+     */
+    public function __construct(bool $caseInsensitive = false)
+    {
+        $this->caseInsensitive = $caseInsensitive;
+    }
+
+    /**
+     * Normalize a command/alias name according to the case sensitivity setting.
+     */
+    protected function normalize(string $name): string
+    {
+        return $this->caseInsensitive ? mb_strtolower($name) : $name;
+    }
+
+    /**
+     * Add a command to the registry.
+     *
+     * @param string  $name    Command trigger name.
+     * @param Command $command Command instance.
+     *
+     * @throws \RuntimeException When a command with the same name already exists.
+     */
+    public function add(string $name, Command $command): void
+    {
+        $name = $this->normalize($name);
+        if (isset($this->commands[$name])) {
+            throw new \RuntimeException("A command with the name {$name} already exists.");
+        }
+
+        $this->commands[$name] = $command;
+    }
+
+    /**
+     * Remove a command from the registry.
+     *
+     * @param string $name Command trigger name.
+     */
+    public function remove(string $name): void
+    {
+        $name = $this->normalize($name);
+        unset($this->commands[$name]);
+    }
+
+    /**
+     * Check whether a command or alias exists.
+     *
+     * @param string $name Command or alias to check.
+     */
+    public function has(string $name): bool
+    {
+        $name = $this->normalize($name);
+
+        return isset($this->commands[$name]) || isset($this->aliases[$name]);
+    }
+
+    /**
+     * Retrieve a command by name or alias.
+     *
+     * @param string $name Command name or alias.
+     *
+     * @return Command|null The command instance or null if not found.
+     */
+    public function get(string $name): ?Command
+    {
+        $name = $this->normalize($name);
+        if (isset($this->commands[$name])) {
+            return $this->commands[$name];
+        }
+
+        if (isset($this->aliases[$name]) && isset($this->commands[$this->aliases[$name]])) {
+            return $this->commands[$this->aliases[$name]];
+        }
+
+        return null;
+    }
+
+    /**
+     * Add an alias for an existing command name.
+     *
+     * @param string $alias       Alias name.
+     * @param string $commandName Target command name.
+     */
+    public function addAlias(string $alias, string $commandName): void
+    {
+        $alias = $this->normalize($alias);
+        $commandName = $this->normalize($commandName);
+        $this->aliases[$alias] = $commandName;
+    }
+
+    /**
+     * Remove an alias.
+     *
+     * @param string $alias Alias to remove.
+     */
+    public function removeAlias(string $alias): void
+    {
+        $alias = $this->normalize($alias);
+        unset($this->aliases[$alias]);
+    }
+
+    /**
+     * Return all registered commands.
+     *
+     * @return array<string, Command>
+     */
+    public function all(): array
+    {
+        return $this->commands;
+    }
+
+    /**
+     * Return all registered aliases.
+     *
+     * @return array<string, string>
+     */
+    public function aliases(): array
+    {
+        return $this->aliases;
+    }
+}

--- a/src/Discord/MessageCommandClient/CommandRegistry.php
+++ b/src/Discord/MessageCommandClient/CommandRegistry.php
@@ -57,7 +57,9 @@ final class CommandRegistry
      */
     protected function normalize(string $name): string
     {
-        return $this->caseInsensitive ? mb_strtolower($name) : $name;
+        return $this->caseInsensitive
+            ? (function_exists('mb_strtolower') ? mb_strtolower($name) : strtolower($name))
+            : $name;
     }
 
     /**

--- a/src/Discord/MessageCommandClient/CommandRegistry.php
+++ b/src/Discord/MessageCommandClient/CommandRegistry.php
@@ -82,7 +82,7 @@ final class CommandRegistry
 
     /**
      * Remove a command from the registry.
-     * 
+     *
      * This does not remove any aliases pointing to this command, so they will become invalid until removed or updated.
      *
      * @param string $name Command trigger name.
@@ -103,6 +103,30 @@ final class CommandRegistry
         $name = $this->normalize($name);
 
         return isset($this->commands[$name]) || isset($this->aliases[$name]);
+    }
+
+    /**
+     * Check whether a command exists.
+     *
+     * @param string $name Command name to check.
+     */
+    public function hasCommand(string $name): bool
+    {
+        $name = $this->normalize($name);
+
+        return isset($this->commands[$name]);
+    }
+
+    /**
+     * Check whether an alias exists.
+     *
+     * @param string $alias Alias to check.
+     */
+    public function hasAlias(string $alias): bool
+    {
+        $alias = $this->normalize($alias);
+
+        return isset($this->aliases[$alias]);
     }
 
     /**

--- a/src/Discord/MessageCommandClient/CooldownManager.php
+++ b/src/Discord/MessageCommandClient/CooldownManager.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is a part of the DiscordPHP project.
+ *
+ * Copyright (c) 2015-2022 David Cole <david.cole1340@gmail.com>
+ * Copyright (c) 2020-present Valithor Obsidion <valithor@discordphp.org>
+ *
+ * This file is subject to the MIT license that is bundled
+ * with this source code in the LICENSE.md file.
+ */
+
+namespace Discord\MessageCommandClient;
+
+use Discord\Parts\Channel\Message;
+
+class CooldownManager
+{
+    /**
+     * @var array<string,int>
+     */
+    protected array $cooldowns = [];
+
+    /**
+     * Enforce and update cooldowns for a message author.
+     *
+     * @param Message $message
+     * @param int     $currentTime
+     * @param int     $cooldownMs
+     * @param string  $cooldownMessage
+     *
+     * @return string|null
+     */
+    public function enforce(Message $message, int $currentTime, int $cooldownMs, string $cooldownMessage): ?string
+    {
+        if ($cooldownMs <= 0) {
+            return null;
+        }
+
+        $userId = $message->author->id;
+
+        if (isset($this->cooldowns[$userId])) {
+            if ($this->cooldowns[$userId] < $currentTime) {
+                $this->cooldowns[$userId] = $currentTime + $cooldownMs;
+
+                return null;
+            }
+
+            return sprintf($cooldownMessage, (($this->cooldowns[$userId] - $currentTime) / 1000));
+        }
+
+        $this->cooldowns[$userId] = $currentTime + $cooldownMs;
+
+        return null;
+    }
+}

--- a/src/Discord/MessageCommandClient/SubCommandRegistry.php
+++ b/src/Discord/MessageCommandClient/SubCommandRegistry.php
@@ -1,0 +1,165 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is a part of the DiscordPHP project.
+ *
+ * Copyright (c) 2015-2022 David Cole <david.cole1340@gmail.com>
+ * Copyright (c) 2020-present Valithor Obsidion <valithor@discordphp.org>
+ *
+ * This file is subject to the MIT license that is bundled
+ * with this source code in the LICENSE.md file.
+ */
+
+namespace Discord\MessageCommandClient;
+
+/**
+ * Registry for managing sub-commands and their aliases.
+ */
+class SubCommandRegistry
+{
+    /**
+     * @var array<string, Command>
+     */
+    protected array $subCommands = [];
+
+    /**
+     * @var array<string, string>
+     */
+    protected array $subCommandAliases = [];
+
+    /**
+     * Callable normalizer for command/alias names.
+     *
+     * @var callable
+     */
+    protected $normalizer;
+
+    public function __construct(callable $normalizer)
+    {
+        $this->normalizer = $normalizer;
+    }
+
+    protected function normalize(string $name): string
+    {
+        $fn = $this->normalizer;
+
+        return $fn($name);
+    }
+
+    public function get(?string $command, bool $aliases = true): ?Command
+    {
+        if ($command !== null) {
+            $command = $this->normalize($command);
+        }
+
+        if ($command !== null && array_key_exists($command, $this->subCommands)) {
+            return $this->subCommands[$command];
+        }
+
+        if ($aliases && $command !== null) {
+            if (array_key_exists($command, $this->subCommandAliases)) {
+                $target = $this->subCommandAliases[$command];
+
+                if (array_key_exists($target, $this->subCommands)) {
+                    return $this->subCommands[$target];
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Register a Command instance and its aliases. Returns the normalized key.
+     *
+     * @param Command $commandInstance
+     * @param array   $aliases
+     *
+     * @return string
+     */
+    public function register(Command $commandInstance, array $aliases = []): string
+    {
+        $key = $this->normalize($commandInstance->command);
+
+        if (array_key_exists($key, $this->subCommandAliases)) {
+            throw new \RuntimeException('A sub-command with the same name already exists as an alias for another sub-command.');
+        }
+        if (array_key_exists($key, $this->subCommands)) {
+            throw new \RuntimeException('A sub-command with the same name already exists.');
+        }
+
+        $this->subCommands[$key] = $commandInstance;
+
+        foreach ($aliases as $alias) {
+            $this->registerAlias($alias, $key);
+        }
+
+        return $key;
+    }
+
+    public function unregister(string $command): void
+    {
+        $command = $this->normalize($command);
+
+        if (! array_key_exists($command, $this->subCommands)) {
+            throw new \RuntimeException('The sub-command does not exist.');
+        }
+
+        unset($this->subCommands[$command]);
+
+        // Remove any aliases that pointed to this command.
+        foreach ($this->subCommandAliases as $alias => $target) {
+            if ($target === $command) {
+                unset($this->subCommandAliases[$alias]);
+            }
+        }
+    }
+
+    public function registerAlias(string $alias, string $command): void
+    {
+        $alias = $this->normalize($alias);
+        $command = $this->normalize($command);
+
+        if (! array_key_exists($command, $this->subCommands)) {
+            throw new \RuntimeException('The target sub-command does not exist.');
+        }
+
+        if (array_key_exists($alias, $this->subCommands)) {
+            throw new \RuntimeException('Cannot create alias because a sub-command with that name already exists.');
+        }
+
+        if (array_key_exists($alias, $this->subCommandAliases)) {
+            $existing = $this->subCommandAliases[$alias];
+            if ($existing === $command) {
+                return;
+            }
+
+            throw new \RuntimeException('Cannot remap alias because it is already mapped to a different sub-command.');
+        }
+
+        $this->subCommandAliases[$alias] = $command;
+    }
+
+    public function unregisterAlias(string $alias): void
+    {
+        $alias = $this->normalize($alias);
+
+        if (! array_key_exists($alias, $this->subCommandAliases)) {
+            throw new \RuntimeException('The sub-command alias does not exist.');
+        }
+
+        unset($this->subCommandAliases[$alias]);
+    }
+
+    /**
+     * Returns all registered sub-commands.
+     *
+     * @return array<string, Command>
+     */
+    public function all(): array
+    {
+        return $this->subCommands;
+    }
+}

--- a/tests/MessageCommandClient/CommandRegistrationTest.php
+++ b/tests/MessageCommandClient/CommandRegistrationTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+use Discord\MessageCommandClient as MessageCommandClientClass;
+use Discord\MessageCommandClient\Command;
+use PHPUnit\Framework\TestCase;
+
+final class CommandRegistrationTest extends TestCase
+{
+    public function testCaseInsensitiveSubcommandDuplicateThrows()
+    {
+        $this->expectException(\RuntimeException::class);
+
+        $client = $this->getMockBuilder(MessageCommandClientClass::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $client->method('getCommandClientOptions')->willReturn(['caseInsensitiveCommands' => true]);
+        $client->method('buildCommand')->willReturnCallback(function ($name, $callable, $options) use ($client) {
+            $cmd = new Command($client, $name, $callable, '', '', '', 0, '', true);
+            $resolved = array_merge(['aliases' => []], is_array($options) ? $options : []);
+            return ['command' => $cmd, 'options' => $resolved];
+        });
+
+        $parent = new Command($client, 'parent', fn () => null, '', '', '', 0, '', true);
+
+        $parent->registerSubCommand('foo', fn () => null, []);
+
+        // Should throw because 'FOO' normalizes to 'foo'
+        $parent->registerSubCommand('FOO', fn () => null, []);
+    }
+
+    public function testSubcommandNameCollidesWithAliasThrows()
+    {
+        $this->expectException(\RuntimeException::class);
+
+        $client = $this->getMockBuilder(MessageCommandClientClass::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $client->method('getCommandClientOptions')->willReturn(['caseInsensitiveCommands' => true]);
+        $client->method('buildCommand')->willReturnCallback(function ($name, $callable, $options) use ($client) {
+            $cmd = new Command($client, $name, $callable, '', '', '', 0, '', true);
+            $resolved = array_merge(['aliases' => []], is_array($options) ? $options : []);
+            return ['command' => $cmd, 'options' => $resolved];
+        });
+
+        $parent = new Command($client, 'parent', fn () => null, '', '', '', 0, '', true);
+
+        // Register a subcommand with an alias 'bar'
+        $parent->registerSubCommand('foo', fn () => null, ['aliases' => ['bar']]);
+
+        // Registering a subcommand named 'BAR' should collide with alias 'bar' after normalization
+        $parent->registerSubCommand('BAR', fn () => null, []);
+    }
+
+    public function testCaseSensitiveAllowsCaseVariants()
+    {
+        $client = $this->getMockBuilder(MessageCommandClientClass::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $client->method('getCommandClientOptions')->willReturn(['caseInsensitiveCommands' => false]);
+        $client->method('buildCommand')->willReturnCallback(function ($name, $callable, $options) use ($client) {
+            $cmd = new Command($client, $name, $callable, '', '', '', 0, '', true);
+            $resolved = array_merge(['aliases' => []], is_array($options) ? $options : []);
+            return ['command' => $cmd, 'options' => $resolved];
+        });
+
+        $parent = new Command($client, 'parent', fn () => null, '', '', '', 0, '', true);
+
+        $parent->registerSubCommand('foo', fn () => null, []);
+        $parent->registerSubCommand('FOO', fn () => null, []);
+
+        $this->assertInstanceOf(Command::class, $parent->getCommand('foo'));
+        $this->assertInstanceOf(Command::class, $parent->getCommand('FOO'));
+    }
+}
+
+
+

--- a/tests/MessageCommandClient/CommandRegistrationTest.php
+++ b/tests/MessageCommandClient/CommandRegistrationTest.php
@@ -34,12 +34,26 @@ final class CommandRegistrationTest extends TestCase
             return $ci ? (function_exists('mb_strtolower') ? mb_strtolower($name) : strtolower($name)) : $name;
         });
         $client->method('buildCommand')->willReturnCallback(function ($name, $callable, $options) use ($client) {
-            $cmd = new Command($client, $name, $callable, '', '', '', 0, '', true);
+            $cmd = new Command($client, $name, $callable, [
+                'description' => '',
+                'longDescription' => '',
+                'usage' => '',
+                'cooldown' => 0,
+                'cooldownMessage' => '',
+                'showHelp' => true,
+            ]);
 
             return new BuiltCommand($cmd, is_array($options) ? array_merge(['aliases' => []], $options) : ['aliases' => []]);
         });
 
-        $parent = new Command($client, 'parent', fn () => null, '', '', '', 0, '', true);
+        $parent = new Command($client, 'parent', fn () => null, [
+            'description' => '',
+            'longDescription' => '',
+            'usage' => '',
+            'cooldown' => 0,
+            'cooldownMessage' => '',
+            'showHelp' => true,
+        ]);
 
         $parent->registerSubCommand('foo', fn () => null, []);
 
@@ -61,12 +75,26 @@ final class CommandRegistrationTest extends TestCase
             return $ci ? (function_exists('mb_strtolower') ? mb_strtolower($name) : strtolower($name)) : $name;
         });
         $client->method('buildCommand')->willReturnCallback(function ($name, $callable, $options) use ($client) {
-            $cmd = new Command($client, $name, $callable, '', '', '', 0, '', true);
+            $cmd = new Command($client, $name, $callable, [
+                'description' => '',
+                'longDescription' => '',
+                'usage' => '',
+                'cooldown' => 0,
+                'cooldownMessage' => '',
+                'showHelp' => true,
+            ]);
 
             return new BuiltCommand($cmd, is_array($options) ? array_merge(['aliases' => []], $options) : ['aliases' => []]);
         });
 
-        $parent = new Command($client, 'parent', fn () => null, '', '', '', 0, '', true);
+        $parent = new Command($client, 'parent', fn () => null, [
+            'description' => '',
+            'longDescription' => '',
+            'usage' => '',
+            'cooldown' => 0,
+            'cooldownMessage' => '',
+            'showHelp' => true,
+        ]);
 
         // Register a subcommand with an alias 'bar'
         $parent->registerSubCommand('foo', fn () => null, ['aliases' => ['bar']]);
@@ -87,12 +115,26 @@ final class CommandRegistrationTest extends TestCase
             return $ci ? (function_exists('mb_strtolower') ? mb_strtolower($name) : strtolower($name)) : $name;
         });
         $client->method('buildCommand')->willReturnCallback(function ($name, $callable, $options) use ($client) {
-            $cmd = new Command($client, $name, $callable, '', '', '', 0, '', true);
+            $cmd = new Command($client, $name, $callable, [
+                'description' => '',
+                'longDescription' => '',
+                'usage' => '',
+                'cooldown' => 0,
+                'cooldownMessage' => '',
+                'showHelp' => true,
+            ]);
 
             return new BuiltCommand($cmd, is_array($options) ? array_merge(['aliases' => []], $options) : ['aliases' => []]);
         });
 
-        $parent = new Command($client, 'parent', fn () => null, '', '', '', 0, '', true);
+        $parent = new Command($client, 'parent', fn () => null, [
+            'description' => '',
+            'longDescription' => '',
+            'usage' => '',
+            'cooldown' => 0,
+            'cooldownMessage' => '',
+            'showHelp' => true,
+        ]);
 
         $parent->registerSubCommand('foo', fn () => null, []);
         $parent->registerSubCommand('FOO', fn () => null, []);

--- a/tests/MessageCommandClient/CommandRegistrationTest.php
+++ b/tests/MessageCommandClient/CommandRegistrationTest.php
@@ -2,9 +2,21 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is a part of the DiscordPHP project.
+ *
+ * Copyright (c) 2015-2022 David Cole <david.cole1340@gmail.com>
+ * Copyright (c) 2020-present Valithor Obsidion <valithor@discordphp.org>
+ *
+ * This file is subject to the MIT license that is bundled
+ * with this source code in the LICENSE.md file.
+ */
+
 use Discord\MessageCommandClient as MessageCommandClientClass;
 use Discord\MessageCommandClient\Command;
 use PHPUnit\Framework\TestCase;
+
+use Discord\MessageCommandClient\BuiltCommand;
 
 final class CommandRegistrationTest extends TestCase
 {
@@ -15,12 +27,16 @@ final class CommandRegistrationTest extends TestCase
         $client = $this->getMockBuilder(MessageCommandClientClass::class)
             ->disableOriginalConstructor()
             ->getMock();
-
         $client->method('getCommandClientOptions')->willReturn(['caseInsensitiveCommands' => true]);
+        $client->method('normalizeCommandName')->willReturnCallback(function ($name) use ($client) {
+            $ci = $client->getCommandClientOptions()['caseInsensitiveCommands'];
+
+            return $ci ? (function_exists('mb_strtolower') ? mb_strtolower($name) : strtolower($name)) : $name;
+        });
         $client->method('buildCommand')->willReturnCallback(function ($name, $callable, $options) use ($client) {
             $cmd = new Command($client, $name, $callable, '', '', '', 0, '', true);
-            $resolved = array_merge(['aliases' => []], is_array($options) ? $options : []);
-            return ['command' => $cmd, 'options' => $resolved];
+
+            return new BuiltCommand($cmd, is_array($options) ? array_merge(['aliases' => []], $options) : ['aliases' => []]);
         });
 
         $parent = new Command($client, 'parent', fn () => null, '', '', '', 0, '', true);
@@ -38,12 +54,16 @@ final class CommandRegistrationTest extends TestCase
         $client = $this->getMockBuilder(MessageCommandClientClass::class)
             ->disableOriginalConstructor()
             ->getMock();
-
         $client->method('getCommandClientOptions')->willReturn(['caseInsensitiveCommands' => true]);
+        $client->method('normalizeCommandName')->willReturnCallback(function ($name) use ($client) {
+            $ci = $client->getCommandClientOptions()['caseInsensitiveCommands'];
+
+            return $ci ? (function_exists('mb_strtolower') ? mb_strtolower($name) : strtolower($name)) : $name;
+        });
         $client->method('buildCommand')->willReturnCallback(function ($name, $callable, $options) use ($client) {
             $cmd = new Command($client, $name, $callable, '', '', '', 0, '', true);
-            $resolved = array_merge(['aliases' => []], is_array($options) ? $options : []);
-            return ['command' => $cmd, 'options' => $resolved];
+
+            return new BuiltCommand($cmd, is_array($options) ? array_merge(['aliases' => []], $options) : ['aliases' => []]);
         });
 
         $parent = new Command($client, 'parent', fn () => null, '', '', '', 0, '', true);
@@ -60,12 +80,16 @@ final class CommandRegistrationTest extends TestCase
         $client = $this->getMockBuilder(MessageCommandClientClass::class)
             ->disableOriginalConstructor()
             ->getMock();
-
         $client->method('getCommandClientOptions')->willReturn(['caseInsensitiveCommands' => false]);
+        $client->method('normalizeCommandName')->willReturnCallback(function ($name) use ($client) {
+            $ci = $client->getCommandClientOptions()['caseInsensitiveCommands'];
+
+            return $ci ? (function_exists('mb_strtolower') ? mb_strtolower($name) : strtolower($name)) : $name;
+        });
         $client->method('buildCommand')->willReturnCallback(function ($name, $callable, $options) use ($client) {
             $cmd = new Command($client, $name, $callable, '', '', '', 0, '', true);
-            $resolved = array_merge(['aliases' => []], is_array($options) ? $options : []);
-            return ['command' => $cmd, 'options' => $resolved];
+
+            return new BuiltCommand($cmd, is_array($options) ? array_merge(['aliases' => []], $options) : ['aliases' => []]);
         });
 
         $parent = new Command($client, 'parent', fn () => null, '', '', '', 0, '', true);
@@ -77,6 +101,3 @@ final class CommandRegistrationTest extends TestCase
         $this->assertInstanceOf(Command::class, $parent->getCommand('FOO'));
     }
 }
-
-
-

--- a/tests/MessageCommandClient/MessageCommandClientTest.php
+++ b/tests/MessageCommandClient/MessageCommandClientTest.php
@@ -20,11 +20,9 @@ final class MessageCommandClientTest extends \DiscordTestCase
     public function testCanRegisterAndRetrieveCommand()
     {
         return wait(function (Discord $discord, $resolve) {
-            $client = getMockMessageCommandClient();
+            $discord->registerCommand('hello', fn () => 'world', ['description' => 'desc']);
 
-            $client->registerCommand('hello', fn () => 'world', ['description' => 'desc']);
-
-            $command = $client->getCommand('hello');
+            $command = $discord->getCommand('hello');
 
             $this->assertInstanceOf(Command::class, $command);
             $this->assertSame('hello', $command->command);
@@ -36,9 +34,7 @@ final class MessageCommandClientTest extends \DiscordTestCase
     public function testBuildCommandCreatesCommandInstance()
     {
         return wait(function (Discord $discord, $resolve) {
-            $client = getMockMessageCommandClient();
-
-            $builtCommand = $client->buildCommand('foo', fn () => 'bar', []);
+            $builtCommand = $discord->buildCommand('foo', fn () => 'bar', []);
 
             $this->assertInstanceOf(Command::class, $builtCommand->command);
             $this->assertSame('foo', $builtCommand->command->command);

--- a/tests/MessageCommandClient/MessageCommandClientTest.php
+++ b/tests/MessageCommandClient/MessageCommandClientTest.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
  */
 
 use Discord\Discord;
-use Discord\MessageCommandClient as MessageCommandClientClass;
 use Discord\MessageCommandClient\Command;
 
 final class MessageCommandClientTest extends \DiscordTestCase

--- a/tests/MessageCommandClient/MessageCommandClientTest.php
+++ b/tests/MessageCommandClient/MessageCommandClientTest.php
@@ -21,9 +21,7 @@ final class MessageCommandClientTest extends \DiscordTestCase
     public function testCanRegisterAndRetrieveCommand()
     {
         return wait(function (Discord $discord, $resolve) {
-            $client = new MessageCommandClientClass([
-                'token' => getenv('DISCORD_TOKEN'),
-            ]);
+            $client = getMockMessageCommandClient();
 
             $client->registerCommand('hello', fn () => 'world', ['description' => 'desc']);
 
@@ -39,9 +37,7 @@ final class MessageCommandClientTest extends \DiscordTestCase
     public function testBuildCommandCreatesCommandInstance()
     {
         return wait(function (Discord $discord, $resolve) {
-            $client = new MessageCommandClientClass([
-                'token' => getenv('DISCORD_TOKEN'),
-            ]);
+            $client = getMockMessageCommandClient();
 
             $builtCommand = $client->buildCommand('foo', fn () => 'bar', []);
 

--- a/tests/MessageCommandClient/MessageCommandClientTest.php
+++ b/tests/MessageCommandClient/MessageCommandClientTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+use Discord\Discord;
+use Discord\MessageCommandClient as MessageCommandClientClass;
+use Discord\MessageCommandClient\Command;
+
+final class MessageCommandClientTest extends \DiscordTestCase
+{
+    public function testCanRegisterAndRetrieveCommand()
+    {
+        return wait(function (Discord $discord, $resolve) {
+            $client = new MessageCommandClientClass([
+                'token' => getenv('DISCORD_TOKEN'),
+            ]);
+
+            $client->registerCommand('hello', fn () => 'world', ['description' => 'desc']);
+
+            $command = $client->getCommand('hello');
+
+            $this->assertInstanceOf(Command::class, $command);
+            $this->assertSame('hello', $command->command);
+
+            $resolve(null);
+        });
+    }
+
+    public function testBuildCommandCreatesCommandInstance()
+    {
+        return wait(function (Discord $discord, $resolve) {
+            $client = new MessageCommandClientClass([
+                'token' => getenv('DISCORD_TOKEN'),
+            ]);
+
+            $result = $client->buildCommand('foo', fn () => 'bar', []);
+
+            $this->assertArrayHasKey('command', $result);
+            $this->assertInstanceOf(Command::class, $result['command']);
+            $this->assertSame('foo', $result['command']->command);
+
+            $resolve(null);
+        });
+    }
+}

--- a/tests/MessageCommandClient/MessageCommandClientTest.php
+++ b/tests/MessageCommandClient/MessageCommandClientTest.php
@@ -2,6 +2,16 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is a part of the DiscordPHP project.
+ *
+ * Copyright (c) 2015-2022 David Cole <david.cole1340@gmail.com>
+ * Copyright (c) 2020-present Valithor Obsidion <valithor@discordphp.org>
+ *
+ * This file is subject to the MIT license that is bundled
+ * with this source code in the LICENSE.md file.
+ */
+
 use Discord\Discord;
 use Discord\MessageCommandClient as MessageCommandClientClass;
 use Discord\MessageCommandClient\Command;
@@ -33,11 +43,10 @@ final class MessageCommandClientTest extends \DiscordTestCase
                 'token' => getenv('DISCORD_TOKEN'),
             ]);
 
-            $result = $client->buildCommand('foo', fn () => 'bar', []);
+            $builtCommand = $client->buildCommand('foo', fn () => 'bar', []);
 
-            $this->assertArrayHasKey('command', $result);
-            $this->assertInstanceOf(Command::class, $result['command']);
-            $this->assertSame('foo', $result['command']->command);
+            $this->assertInstanceOf(Command::class, $builtCommand->command);
+            $this->assertSame('foo', $builtCommand->command->command);
 
             $resolve(null);
         });

--- a/tests/functions.php
+++ b/tests/functions.php
@@ -68,7 +68,7 @@ function wait(callable $callback, float $timeout = TIMEOUT, ?callable $timeoutFn
 
 function getMockDiscord(): Discord
 {
-    return new Discord(['token' => '', 'logger' => new NullLogger()]);
+    return new MessageCommandClient(['token' => '', 'logger' => new NullLogger()]);
 }
 
 function getMockMessageCommandClient(): MessageCommandClient

--- a/tests/functions.php
+++ b/tests/functions.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
  */
 
 use Discord\Discord;
+use Discord\MessageCommandClient;
 use Psr\Log\NullLogger;
 
 const TIMEOUT = 10;
@@ -68,4 +69,9 @@ function wait(callable $callback, float $timeout = TIMEOUT, ?callable $timeoutFn
 function getMockDiscord(): Discord
 {
     return new Discord(['token' => '', 'logger' => new NullLogger()]);
+}
+
+function getMockMessageCommandClient(): MessageCommandClient
+{
+    return new MessageCommandClient(['token' => '', 'logger' => new NullLogger()]);
 }


### PR DESCRIPTION
This pull request introduces a new message-based command system for DiscordPHP, marking the old `DiscordCommandClient` as deprecated and adding a more modular and extensible replacement. The new system centers around the `MessageCommandClient` and includes two new classes: `Command` for representing individual commands (with support for sub-commands, cooldowns, and help) and `CommandRegistry` for managing commands and their aliases.

Key changes:

**Deprecation and Migration:**
- Marked the `DiscordCommandClient` class as deprecated in favor of the new `MessageCommandClient` system.

**New Command System Implementation:**
- Added `Command` class (`src/Discord/MessageCommandClient/Command.php`), which encapsulates the logic for message-based commands, including sub-command registration, cooldown handling, and help generation.
- Added `CommandRegistry` class (`src/Discord/MessageCommandClient/CommandRegistry.php`), which manages the registration, lookup, and aliasing of commands in a case-insensitive or case-sensitive manner.