### PR TITLE
Add supported file types for FileUpload and CHAT_INPUT commands

### DIFF
--- a/src/Discord/Builders/Components/FileUpload.php
+++ b/src/Discord/Builders/Components/FileUpload.php
@@ -151,6 +151,8 @@ class FileUpload extends Interactive
      * Sets the supported file types for uploaded files. Use image, video, audio, or dot-prefixed extensions like .pdf.
      * 
      * Discord recommends using the provided file groups. If you are specifying only extensions, you must include .jpg for image uploads, and both .mp4 and .mov for video uploads, due to mobile shenanigans.
+     * 
+     * No validation is done to ensure that the file types are valid. You are responsible for checking MIME types and file extensions.
      *
      * @param ?string[] $file_types
      *

--- a/src/Discord/Builders/Components/FileUpload.php
+++ b/src/Discord/Builders/Components/FileUpload.php
@@ -26,6 +26,7 @@ namespace Discord\Builders\Components;
  * @property ?int|null  $min_values Minimum number of files that must be uploaded (defaults to 1); min 0, max 10.
  * @property ?int|null  $max_values Maximum number of files that can be uploaded (defaults to 1); max 10.
  * @property ?bool|null $required   Whether the file upload is required to be filled in a modal (defaults to `true`).
+ * @property ?string[]  $file_types Supported file types for uploaded files.
  */
 class FileUpload extends Interactive
 {
@@ -62,6 +63,13 @@ class FileUpload extends Interactive
     protected $required;
 
     /**
+     * Supported file types for uploaded files.
+     *
+     * @var ?string[]
+     */
+    protected $file_types;
+
+    /**
      * Creates a new file upload.
      *
      * @param string|null $custom_id custom ID of the file upload. If not given, a UUID will be used
@@ -92,7 +100,7 @@ class FileUpload extends Interactive
      *
      * @throws \OutOfRangeException
      *
-     * @return $this
+     * @return self
      */
     public function setMinValues(?int $min_values = null): self
     {
@@ -112,7 +120,7 @@ class FileUpload extends Interactive
      *
      * @throws \OutOfRangeException
      *
-     * @return $this
+     * @return self
      */
     public function setMaxValues(?int $max_values = null): self
     {
@@ -130,11 +138,27 @@ class FileUpload extends Interactive
      *
      * @param bool|null $required
      *
-     * @return $this
+     * @return self
      */
     public function setRequired(?bool $required = null): self
     {
         $this->required = $required;
+
+        return $this;
+    }
+
+    /**
+     * Sets the supported file types for uploaded files. Use image, video, audio, or dot-prefixed extensions like .pdf.
+     * 
+     * Discord recommends using the provided file groups. If you are specifying only extensions, you must include .jpg for image uploads, and both .mp4 and .mov for video uploads, due to mobile shenanigans.
+     *
+     * @param ?string[] $file_types
+     *
+     * @return self
+     */
+    public function setFileTypes(?array $file_types = null): self
+    {
+        $this->file_types = $file_types;
 
         return $this;
     }
@@ -159,6 +183,10 @@ class FileUpload extends Interactive
 
         if (isset($this->required)) {
             $content['required'] = $this->required;
+        }
+
+        if (isset($this->file_types)) {
+            $content['file_types'] = $this->file_types;
         }
 
         if (isset($this->id)) {

--- a/src/Discord/Builders/Components/FileUpload.php
+++ b/src/Discord/Builders/Components/FileUpload.php
@@ -149,14 +149,16 @@ class FileUpload extends Interactive
 
     /**
      * Sets the supported file types for uploaded files. Use image, video, audio, or dot-prefixed extensions like .pdf.
-     * 
+     *
      * Discord recommends using the provided file groups. If you are specifying only extensions, you must include .jpg for image uploads, and both .mp4 and .mov for video uploads, due to mobile shenanigans.
-     * 
+     *
      * No validation is done to ensure that the file types are valid. You are responsible for checking MIME types and file extensions.
      *
      * @param ?string[] $file_types
      *
      * @return self
+     * 
+     * @since 10.49.0
      */
     public function setFileTypes(?array $file_types = null): self
     {

--- a/src/Discord/Parts/Channel/Message/FileUpload.php
+++ b/src/Discord/Parts/Channel/Message/FileUpload.php
@@ -26,9 +26,19 @@ namespace Discord\Parts\Channel\Message;
  * @property ?int|null  $min_values Minimum number of files that must be uploaded (defaults to 1); min 0, max 10.
  * @property ?int|null  $max_values Maximum number of files that can be uploaded (defaults to 1); max 10.
  * @property ?bool|null $required   Whether the file upload is required to be filled in a modal (defaults to true).
+ * @property ?string[]  $file_types Supported file types for uploaded files.
  */
 class FileUpload extends Interactive
 {
+    /** Supported file types. */
+    public const SUPPORTED_FILE_TYPES = ['image', 'video', 'audio'];
+    /** Natively supported image file extensions. Subject to change. */
+    public const SUPPORTED_IMAGE_EXTENSIONS = ['.png', '.gif', '.jpg', '.jpeg', '.jfif', '.webp', '.avif'];
+    /** Natively supported video file extensions. Subject to change. */
+    public const SUPPORTED_VIDEO_EXTENSIONS = ['.mp4', '.mov', '.qt', '.webm'];
+    /** Natively supported audio file extensions. Subject to change. */
+    public const SUPPORTED_AUDIO_EXTENSIONS = ['.mp3', '.m4a', '.wav', '.ogg', '.opus', '.flac'];
+
     /**
      * @inheritDoc
      */
@@ -38,5 +48,6 @@ class FileUpload extends Interactive
         'min_values',
         'max_values',
         'required',
+        'file_types',
     ];
 }

--- a/src/Discord/Parts/Interactions/Command/Option.php
+++ b/src/Discord/Parts/Interactions/Command/Option.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
 namespace Discord\Parts\Interactions\Command;
 
 use Discord\Helpers\ExCollectionInterface;
+use Discord\Parts\Channel\Message\FileUpload;
 use Discord\Parts\Part;
 
 use function Discord\poly_strlen;
@@ -40,6 +41,7 @@ use function Discord\poly_strlen;
  * @property int|null                               $min_length                For option type `STRING`, the minimum allowed length (minimum of `0`, maximum of `6000`).
  * @property int|null                               $max_length                For option type `STRING`, the maximum allowed length (minimum of `1`, maximum of `6000`).
  * @property bool|null                              $autocomplete              Enable autocomplete interactions for this option.
+ * @property string[]|null                          $file_types                If the option is an ATTACHMENT type, the attachment types shown will be restricted to these types. 
  */
 class Option extends Part
 {
@@ -60,6 +62,15 @@ class Option extends Part
     /** Attachment object. */
     public const ATTACHMENT = 11;
 
+    /** Supported file types. */
+    public const SUPPORTED_FILE_TYPES = FileUpload::SUPPORTED_FILE_TYPES;
+    /** Natively supported image file extensions. Subject to change. */
+    public const SUPPORTED_IMAGE_EXTENSIONS = FileUpload::SUPPORTED_IMAGE_EXTENSIONS;
+    /** Natively supported video file extensions. Subject to change. */
+    public const SUPPORTED_VIDEO_EXTENSIONS = FileUpload::SUPPORTED_VIDEO_EXTENSIONS;
+    /** Natively supported audio file extensions. Subject to change. */
+    public const SUPPORTED_AUDIO_EXTENSIONS = FileUpload::SUPPORTED_AUDIO_EXTENSIONS;
+
     /**
      * @inheritDoc
      */
@@ -78,6 +89,7 @@ class Option extends Part
         'min_length',
         'max_length',
         'autocomplete',
+        'file_types',
     ];
 
     /**
@@ -107,7 +119,7 @@ class Option extends Part
      *
      * @throws \InvalidArgumentException `$type` is not 1-11.
      *
-     * @return $this
+     * @return self
      */
     public function setType(int $type): self
     {
@@ -130,7 +142,7 @@ class Option extends Part
      *
      * @throws \LengthException `$name` is more than 32 characters.
      *
-     * @return $this
+     * @return self
      */
     public function setName(string $name): self
     {
@@ -154,7 +166,7 @@ class Option extends Part
      *
      * @throws \LengthException `$name` is more than 32 characters.
      *
-     * @return $this
+     * @return self
      */
     public function setNameLocalization(string $locale, ?string $name): self
     {
@@ -174,7 +186,7 @@ class Option extends Part
      *
      * @throws \LengthException `$description` is more than 100 characters.
      *
-     * @return $this
+     * @return self
      */
     public function setDescription(string $description): self
     {
@@ -195,7 +207,7 @@ class Option extends Part
      *
      * @throws \LengthException `$description` is more than 100 characters.
      *
-     * @return $this
+     * @return self
      */
     public function setDescriptionLocalization(string $locale, ?string $description): self
     {
@@ -213,7 +225,7 @@ class Option extends Part
      *
      * @param bool $required requirement of the option (default false)
      *
-     * @return $this
+     * @return self
      */
     public function setRequired(bool $required = false): self
     {
@@ -227,7 +239,7 @@ class Option extends Part
      *
      * @param array|null $types types of the channel.
      *
-     * @return $this
+     * @return self
      */
     public function setChannelTypes(?array $types): self
     {
@@ -245,7 +257,7 @@ class Option extends Part
      *
      * @throws \OverflowException Command exceeds maximum 25 sub options.
      *
-     * @return $this
+     * @return self
      */
     public function setOptions($options = []): self
     {
@@ -263,7 +275,7 @@ class Option extends Part
      *
      * @throws \OverflowException Command exceeds maximum 25 sub options.
      *
-     * @return $this
+     * @return self
      */
     public function addOptions($options): self
     {
@@ -281,7 +293,7 @@ class Option extends Part
      *
      * @throws \OverflowException Command exceeds maximum 25 sub options.
      *
-     * @return $this
+     * @return self
      */
     public function addOption(Option $option): self
     {
@@ -303,7 +315,7 @@ class Option extends Part
      *
      * @throws \OverflowException Command exceeds maximum 25 choices.
      *
-     * @return $this
+     * @return self
      */
     public function setChoices($choices = []): self
     {
@@ -321,7 +333,7 @@ class Option extends Part
      *
      * @throws \OverflowException Command exceeds maximum 25 choices.
      *
-     * @return $this
+     * @return self
      */
     public function addChoices($choices): self
     {
@@ -339,7 +351,7 @@ class Option extends Part
      *
      * @throws \OverflowException Command exceeds maximum 25 choices.
      *
-     * @return $this
+     * @return self
      */
     public function addChoice(Choice $choice): self
     {
@@ -357,7 +369,7 @@ class Option extends Part
      *
      * @param string|Option $option Option object or name to remove.
      *
-     * @return $this
+     * @return self
      */
     public function removeOption($option): self
     {
@@ -380,7 +392,7 @@ class Option extends Part
      *
      * @param string|Choice $choice Choice object or name to remove.
      *
-     * @return $this
+     * @return self
      */
     public function removeChoice($choice): self
     {
@@ -403,7 +415,7 @@ class Option extends Part
      *
      * @param int|float|null $min_value integer for INTEGER options, double for NUMBER options.
      *
-     * @return $this
+     * @return self
      */
     public function setMinValue($min_value): self
     {
@@ -417,7 +429,7 @@ class Option extends Part
      *
      * @param int|float|null $max_value integer for INTEGER options, double for NUMBER options
      *
-     * @return $this
+     * @return self
      */
     public function setMaxValue($max_value): self
     {
@@ -434,7 +446,7 @@ class Option extends Part
      * @throws \LogicException
      * @throws \LengthException
      *
-     * @return $this
+     * @return self
      */
     public function setMinLength(?int $min_length): self
     {
@@ -459,7 +471,7 @@ class Option extends Part
      * @throws \LogicException
      * @throws \LengthException
      *
-     * @return $this
+     * @return self
      */
     public function setMaxLength(?int $max_length): self
     {
@@ -483,7 +495,7 @@ class Option extends Part
      *
      * @throws \DomainException Command option type is not string/integer/number.
      *
-     * @return $this
+     * @return self
      */
     public function setAutoComplete(?bool $autocomplete): self
     {
@@ -498,6 +510,24 @@ class Option extends Part
         }
 
         $this->autocomplete = $autocomplete;
+
+        return $this;
+    }
+
+    /**
+     * Sets the supported file types for uploaded files. Use image, video, audio, or dot-prefixed extensions like .pdf.
+     * 
+     * Discord recommends using the provided file groups. If you are specifying only extensions, you must include .jpg for image uploads, and both .mp4 and .mov for video uploads, due to mobile shenanigans.
+     * 
+     * No validation is done to ensure that the file types are valid. You are responsible for checking MIME types and file extensions.
+     * 
+     * @param string[]|null $file_types Supported file types for uploaded files.
+     * 
+     * @return self
+     */
+    public function setFileTypes(?array $file_types = null): self
+    {
+        $this->file_types = $file_types;
 
         return $this;
     }

--- a/src/Discord/Parts/Interactions/Command/Option.php
+++ b/src/Discord/Parts/Interactions/Command/Option.php
@@ -41,7 +41,7 @@ use function Discord\poly_strlen;
  * @property int|null                               $min_length                For option type `STRING`, the minimum allowed length (minimum of `0`, maximum of `6000`).
  * @property int|null                               $max_length                For option type `STRING`, the maximum allowed length (minimum of `1`, maximum of `6000`).
  * @property bool|null                              $autocomplete              Enable autocomplete interactions for this option.
- * @property string[]|null                          $file_types                If the option is an ATTACHMENT type, the attachment types shown will be restricted to these types. 
+ * @property string[]|null                          $file_types                If the option is an ATTACHMENT type, the attachment types shown will be restricted to these types.
  */
 class Option extends Part
 {
@@ -251,13 +251,13 @@ class Option extends Part
     /**
      * Sets multiple options to the option.
      *
-     * @since 10.42.0
-     *
      * @param Option[] $options The options.
      *
      * @throws \OverflowException Command exceeds maximum 25 sub options.
      *
      * @return self
+     *
+     * @since 10.42.0
      */
     public function setOptions($options = []): self
     {
@@ -269,13 +269,13 @@ class Option extends Part
     /**
      * Adds multiple options to the option.
      *
-     * @since 10.42.0
-     *
      * @param Option[] $options The options.
      *
      * @throws \OverflowException Command exceeds maximum 25 sub options.
      *
      * @return self
+     *
+     * @since 10.42.0
      */
     public function addOptions($options): self
     {
@@ -309,13 +309,13 @@ class Option extends Part
     /**
      * Sets multiple choices to the option (Only for slash commands).
      *
-     * @since 10.42.0
-     *
      * @param Choice[] $choices The choices.
      *
      * @throws \OverflowException Command exceeds maximum 25 choices.
      *
      * @return self
+     *
+     * @since 10.42.0
      */
     public function setChoices($choices = []): self
     {
@@ -327,13 +327,14 @@ class Option extends Part
     /**
      * Adds multiple choices to the option (Only for slash commands).
      *
-     * @since 10.42.0
      *
      * @param Choice[] $choices The choices.
      *
      * @throws \OverflowException Command exceeds maximum 25 choices.
      *
      * @return self
+     *
+     * @since 10.42.0
      */
     public function addChoices($choices): self
     {
@@ -516,14 +517,16 @@ class Option extends Part
 
     /**
      * Sets the supported file types for uploaded files. Use image, video, audio, or dot-prefixed extensions like .pdf.
-     * 
+     *
      * Discord recommends using the provided file groups. If you are specifying only extensions, you must include .jpg for image uploads, and both .mp4 and .mov for video uploads, due to mobile shenanigans.
-     * 
+     *
      * No validation is done to ensure that the file types are valid. You are responsible for checking MIME types and file extensions.
-     * 
+     *
      * @param string[]|null $file_types Supported file types for uploaded files.
-     * 
+     *
      * @return self
+     *
+     * @since 10.49.0
      */
     public function setFileTypes(?array $file_types = null): self
     {


### PR DESCRIPTION
This pull request adds support for specifying allowed file types for file uploads in both the `FileUpload` component and command `Option` objects. It introduces new properties and methods to define and manage supported file types, and exposes constants for commonly supported file groups and extensions. Additionally, it standardizes return types for several setter methods to improve type consistency.

**File upload type support:**

* Added a `file_types` property and a `setFileTypes()` method to the `FileUpload` component, allowing developers to specify supported file types for uploads. The method includes documentation and usage recommendations, but does not validate file types. (`src/Discord/Builders/Components/FileUpload.php`) [[1]](diffhunk://#diff-29bc23edfde845a1007c76d6e4593192c61bbf6f32e6e9d210db3c80f87acd85R29) [[2]](diffhunk://#diff-29bc23edfde845a1007c76d6e4593192c61bbf6f32e6e9d210db3c80f87acd85R65-R71) [[3]](diffhunk://#diff-29bc23edfde845a1007c76d6e4593192c61bbf6f32e6e9d210db3c80f87acd85R150-R167) [[4]](diffhunk://#diff-29bc23edfde845a1007c76d6e4593192c61bbf6f32e6e9d210db3c80f87acd85R190-R193)
* Updated JSON serialization in `FileUpload` to include the `file_types` property if set. (`src/Discord/Builders/Components/FileUpload.php`)
* Added constants for supported file type groups and extensions (images, videos, audio) to both `FileUpload` and command `Option`, making them easily accessible for validation or UI purposes. (`src/Discord/Parts/Channel/Message/FileUpload.php`, `src/Discord/Parts/Interactions/Command/Option.php`) [[1]](diffhunk://#diff-0256ec8fc96ab3c6d73a4d9b09dfcde1d21ce807c0507c10100ba06ef37d917dR29-R41) [[2]](diffhunk://#diff-8d3fd7ac3b61f14e82887c1cca7585be82c03624351dcf3376cbb23c8c36cd58R65-R73)
* Added a `file_types` property and a `setFileTypes()` method to the command `Option` object, mirroring the changes in `FileUpload` and enabling restriction of attachment types for command options. (`src/Discord/Parts/Interactions/Command/Option.php`) [[1]](diffhunk://#diff-8d3fd7ac3b61f14e82887c1cca7585be82c03624351dcf3376cbb23c8c36cd58R44) [[2]](diffhunk://#diff-8d3fd7ac3b61f14e82887c1cca7585be82c03624351dcf3376cbb23c8c36cd58R92) [[3]](diffhunk://#diff-8d3fd7ac3b61f14e82887c1cca7585be82c03624351dcf3376cbb23c8c36cd58R517-R534)

**Internal consistency:**

* Ensured that the `file_types` property is included in the `$fillable` arrays for both `FileUpload` and `Option`, allowing mass assignment and serialization. (`src/Discord/Parts/Channel/Message/FileUpload.php`, `src/Discord/Parts/Interactions/Command/Option.php`) [[1]](diffhunk://#diff-0256ec8fc96ab3c6d73a4d9b09dfcde1d21ce807c0507c10100ba06ef37d917dR51) [[2]](diffhunk://#diff-8d3fd7ac3b61f14e82887c1cca7585be82c03624351dcf3376cbb23c8c36cd58R92)

These changes make it easier to restrict and document allowed file types for uploads, improve code maintainability, and provide a more consistent developer experience.