### PR TITLE
Clean up MessageBuilder class

### DIFF
--- a/src/Discord/Builders/ChannelBuilder.php
+++ b/src/Discord/Builders/ChannelBuilder.php
@@ -16,6 +16,7 @@ namespace Discord\Builders;
 
 use Discord\Http\Exceptions\RequestFailedException;
 use Discord\Parts\Channel\Channel;
+use Discord\Parts\Channel\Forum\Tag;
 use Discord\Parts\Channel\Overwrite;
 use Discord\Parts\Guild\Emoji;
 use Discord\Repository\Guild\ChannelRepository;

--- a/src/Discord/Builders/Components/SelectMenu.php
+++ b/src/Discord/Builders/Components/SelectMenu.php
@@ -155,7 +155,7 @@ abstract class SelectMenu extends Interactive
      *
      * @throws \InvalidArgumentException
      *
-     * @return string
+     * @return self
      */
     public function setType(int $type): self
     {

--- a/src/Discord/Builders/MessageBuilder.php
+++ b/src/Discord/Builders/MessageBuilder.php
@@ -403,7 +403,7 @@ class MessageBuilder extends Builder implements JsonSerializable
      * @param int                           $type               If passing a Message, the type of message reference (0 = DEFAULT/REPLY, 1 = FORWARD).
      * @param ?bool|null                    $fail_if_not_exists Whether to error if the referenced message doesn't exist (default true).
      *
-     * @throws \InvalidArgumentException If the message reference is a forward and the channel_id is null.
+     * @throws \InvalidArgumentException If the message reference is a forward and the channel_id is null, or the bot cannot view the referenced channel.
      *
      * @return self
      *

--- a/src/Discord/Builders/MessageBuilder.php
+++ b/src/Discord/Builders/MessageBuilder.php
@@ -280,7 +280,7 @@ class MessageBuilder extends Builder implements JsonSerializable
     /**
      * Sets the embeds for the message. Clears the existing embeds in the process.
      *
-     * @param Embed[]|array ...$embeds
+     * @param Embed[]|array $embeds
      *
      * @return self
      */
@@ -643,7 +643,7 @@ class MessageBuilder extends Builder implements JsonSerializable
     /**
      * Sets the files to be attached to the message.
      *
-     * @param array $files An array of files to attach.
+     * @param array|null $files An array of files to attach.
      *
      * @return self
      */

--- a/src/Discord/Builders/MessageBuilder.php
+++ b/src/Discord/Builders/MessageBuilder.php
@@ -400,8 +400,8 @@ class MessageBuilder extends Builder implements JsonSerializable
      * Include to make your message a reply or a forward.
      *
      * @param MessageReference|Message|null $message_reference
-     * @param int                           $type               The type of message reference (0 = DEFAULT/REPLY, 1 = FORWARD).
-     * @param bool                          $fail_if_not_exists Whether to error if the referenced message doesn't exist (default true).
+     * @param int                           $type               If passing a Message, the type of message reference (0 = DEFAULT/REPLY, 1 = FORWARD).
+     * @param ?bool|null                    $fail_if_not_exists Whether to error if the referenced message doesn't exist (default true).
      *
      * @throw InvalidArgumentException If the message reference is a forward and the channel_id is null.
      *

--- a/src/Discord/Builders/MessageBuilder.php
+++ b/src/Discord/Builders/MessageBuilder.php
@@ -509,7 +509,7 @@ class MessageBuilder extends Builder implements JsonSerializable
     }
 
     /**
-     * Enforces the component limits and structure for v2 messages.
+     * Enforces the component limits and structure for v1 messages.
      *
      * @param ComponentObject $component
      *

--- a/src/Discord/Builders/MessageBuilder.php
+++ b/src/Discord/Builders/MessageBuilder.php
@@ -407,20 +407,41 @@ class MessageBuilder extends Builder implements JsonSerializable
      * @param int                           $type               The type of message reference (0 = DEFAULT/REPLY, 1 = FORWARD).
      * @param bool                          $fail_if_not_exists Whether to error if the referenced message doesn't exist (default true).
      *
+     * @throw InvalidArgumentException If the message reference is a forward and the channel_id is null.
+     *
      * @return self
      *
      * @since 10.50.0
      */
     public function setMessageReference(MessageReference|Message|null $message_reference = null, int $type = MessageReference::TYPE_DEFAULT, bool $fail_if_not_exists = true): self
     {
-        if ($message_reference instanceof Message) {
-            $message_reference = $this->factory->part(MessageReference::class, [
-                'type' => $type,
-                'message_id' => $message_reference->id,
-                'channel_id' => $message_reference->channel_id,
-                'guild_id' => $message_reference->guild_id,
-                'fail_if_not_exists' => $fail_if_not_exists,
-            ]);
+        if ($message_reference !== null) {
+            if ($message_reference instanceof Message) {
+                $attr = [
+                    'type' => $type,
+                    'fail_if_not_exists' => $fail_if_not_exists,
+                ];
+
+                if ($message_reference->id !== null) {
+                    $attr['message_id'] = $message_reference->id;
+                }
+
+                if ($message_reference->channel_id !== null) {
+                    $attr['channel_id'] = $message_reference->channel_id;
+                }
+
+                if ($message_reference->guild_id !== null) {
+                    $attr['guild_id'] = $message_reference->guild_id;
+                }
+
+                $message_reference = $this->factory->part(MessageReference::class, $attr);
+            }
+
+            if ($type === MessageReference::TYPE_FORWARD) {
+                if ($message_reference->channel_id === null) {
+                    throw new \InvalidArgumentException('Cannot set a forward message reference without a channel_id.');
+                }
+            }
         }
 
         $this->message_reference = $message_reference;

--- a/src/Discord/Builders/MessageBuilder.php
+++ b/src/Discord/Builders/MessageBuilder.php
@@ -105,7 +105,7 @@ class MessageBuilder extends Builder implements JsonSerializable
     /**
      * Attachments to send with this message.
      *
-     * @var Attachment[]
+     * @var array[]
      */
     protected $attachments = [];
 

--- a/src/Discord/Builders/MessageBuilder.php
+++ b/src/Discord/Builders/MessageBuilder.php
@@ -809,8 +809,10 @@ class MessageBuilder extends Builder implements JsonSerializable
 
     /**
      * Returns all the attachments in the builder.
+     * 
+     * The array consists of only the raw attributes of the attachments if they were added as Attachment objects.
      *
-     * @return Attachment[]
+     * @return array[]
      */
     public function getAttachments(): array
     {

--- a/src/Discord/Builders/MessageBuilder.php
+++ b/src/Discord/Builders/MessageBuilder.php
@@ -355,7 +355,7 @@ class MessageBuilder extends Builder implements JsonSerializable
      *
      * @return self
      *
-     * @deprecated v10.50.0 Use `setMessageReference()` instead.
+     * @deprecated 10.50.0 Use `setMessageReference()` instead.
      */
     public function setReplyTo(?Message $message = null): self
     {

--- a/src/Discord/Builders/MessageBuilder.php
+++ b/src/Discord/Builders/MessageBuilder.php
@@ -107,7 +107,7 @@ class MessageBuilder extends Builder implements JsonSerializable
      *
      * @var array[]
      */
-    protected $attachments = [];
+    protected $attachments;
 
     /**
      * Flags to send with this message.
@@ -770,13 +770,13 @@ class MessageBuilder extends Builder implements JsonSerializable
     /**
      * Sets the attachments of the builder. Removes the existing attachments in the process.
      *
-     * @param array|null $attachments An array of attachments to set.
+     * @param array|null $attachments An array of attachments to set, or null to clear the attachments.
      *
      * @return self
      */
     public function setAttachments(?array $attachments = null): self
     {
-        $this->attachments = [];
+        $this->attachments = $attachments;
 
         foreach ($attachments ?? [] as $attachment) {
             $this->addAttachment($attachment);
@@ -816,7 +816,7 @@ class MessageBuilder extends Builder implements JsonSerializable
      */
     public function getAttachments(): array
     {
-        return $this->attachments;
+        return $this->attachments ?? [];
     }
 
     /**
@@ -826,7 +826,7 @@ class MessageBuilder extends Builder implements JsonSerializable
      */
     public function clearAttachments(): self
     {
-        $this->attachments = [];
+        $this->attachments = null;
 
         return $this;
     }
@@ -1225,7 +1225,7 @@ class MessageBuilder extends Builder implements JsonSerializable
             }
         }
 
-        if (! empty($this->attachments)) {
+        if (isset($this->attachments)) {
             $body['attachments'] = $this->attachments;
             $empty = false;
         }

--- a/src/Discord/Builders/MessageBuilder.php
+++ b/src/Discord/Builders/MessageBuilder.php
@@ -435,7 +435,7 @@ class MessageBuilder extends Builder implements JsonSerializable
                 $message_reference = $message_reference->getDiscord()->getFactory()->part(MessageReference::class, $attr);
             }
 
-            if ($type === MessageReference::TYPE_FORWARD) {
+            if ($message_reference->type === MessageReference::TYPE_FORWARD) {
                 if ($message_reference->channel_id === null) {
                     throw new \InvalidArgumentException('Cannot set a forward message reference without a channel_id.');
                 }

--- a/src/Discord/Builders/MessageBuilder.php
+++ b/src/Discord/Builders/MessageBuilder.php
@@ -89,24 +89,6 @@ class MessageBuilder extends Builder implements JsonSerializable
     protected $message_reference;
 
     /**
-     * Message to reply to with this message.
-     *
-     * @var Message|null
-     *
-     * @deprecated 10.50.0 Use `message_reference`
-     */
-    protected $replyTo;
-
-    /**
-     * Message to forward with this message.
-     *
-     * @var Message|null
-     *
-     * @deprecated 10.50.0 Use `message_reference`
-     */
-    protected $forward;
-
-    /**
      * IDs of up to 3 stickers in the server to send in the message.
      *
      * @var string[]
@@ -352,14 +334,13 @@ class MessageBuilder extends Builder implements JsonSerializable
      * Sets this message as a reply to another message. Only used for sending message.
      *
      * @param Message|null $message
+     * @param bool         $fail_if_not_exists Whether to error if the referenced message doesn't exist (default true).
      *
      * @return self
-     *
-     * @deprecated 10.50.0 Use `setMessageReference()` instead.
      */
-    public function setReplyTo(?Message $message = null): self
+    public function setReplyTo(?Message $message = null, ?bool $fail_if_not_exists = null): self
     {
-        $this->replyTo = $message;
+        $this->setMessageReference($message, MessageReference::TYPE_DEFAULT, $fail_if_not_exists);
 
         return $this;
     }
@@ -371,21 +352,26 @@ class MessageBuilder extends Builder implements JsonSerializable
      */
     public function getReplyTo(): ?Message
     {
-        return $this->replyTo ?? null;
+        if (isset($this->message_reference) && $this->message_reference->type === MessageReference::TYPE_DEFAULT) {
+            if ($message = $this->message_reference->message) {
+                return $message;
+            }
+        }
+
+        return null;
     }
 
     /**
      * Sets this message as a forward of another message. Only used for sending message.
      *
      * @param Message|null $message
+     * @param bool         $fail_if_not_exists Whether to error if the referenced message doesn't exist (default true).
      *
      * @return self
-     *
-     * @deprecated 10.50.0 Use `setMessageReference()` instead.
      */
-    public function setForward(?Message $message = null): self
+    public function setForward(?Message $message = null, ?bool $fail_if_not_exists = null): self
     {
-        $this->forward = $message;
+        $this->setMessageReference($message, MessageReference::TYPE_FORWARD, $fail_if_not_exists);
 
         return $this;
     }
@@ -397,7 +383,13 @@ class MessageBuilder extends Builder implements JsonSerializable
      */
     public function getForward(): ?Message
     {
-        return $this->forward ?? null;
+        if (isset($this->message_reference) && $this->message_reference->type === MessageReference::TYPE_FORWARD) {
+            if ($message = $this->message_reference->message) {
+                return $message;
+            }
+        }
+
+        return null;
     }
 
     /**
@@ -413,14 +405,11 @@ class MessageBuilder extends Builder implements JsonSerializable
      *
      * @since 10.50.0
      */
-    public function setMessageReference(MessageReference|Message|null $message_reference = null, int $type = MessageReference::TYPE_DEFAULT, bool $fail_if_not_exists = true): self
+    public function setMessageReference(MessageReference|Message|null $message_reference = null, int $type = MessageReference::TYPE_DEFAULT, ?bool $fail_if_not_exists = null): self
     {
         if ($message_reference !== null) {
             if ($message_reference instanceof Message) {
-                $attr = [
-                    'type' => $type,
-                    'fail_if_not_exists' => $fail_if_not_exists,
-                ];
+                $attr = ['type' => $type];
 
                 if ($message_reference->id !== null) {
                     $attr['message_id'] = $message_reference->id;
@@ -432,6 +421,10 @@ class MessageBuilder extends Builder implements JsonSerializable
 
                 if ($message_reference->guild_id !== null) {
                     $attr['guild_id'] = $message_reference->guild_id;
+                }
+
+                if ($fail_if_not_exists !== null) {
+                    $attr['fail_if_not_exists'] = $fail_if_not_exists;
                 }
 
                 /** @var MessageReference|null $message_reference */
@@ -1162,7 +1155,7 @@ class MessageBuilder extends Builder implements JsonSerializable
     }
 
     /**
-     * @inheritDoc
+     * @inheritDoc 
      */
     public function jsonSerialize(): array
     {
@@ -1203,27 +1196,11 @@ class MessageBuilder extends Builder implements JsonSerializable
             $body['allowed_mentions'] = $this->allowed_mentions;
         }
 
-        if (isset($this->message_reference)) {
+        if ($this->message_reference !== null) {
             $body['message_reference'] = $this->message_reference;
 
+            // If this is a forward type, treat as non-empty (and will later drop other fields)
             if ($this->message_reference->type === Message::REFERENCE_FORWARD) {
-                $empty = false;
-            }
-        } else {
-            if (isset($this->replyTo)) {
-                $body['message_reference'] = [
-                    'message_id' => $this->replyTo->id,
-                    'channel_id' => $this->replyTo->channel_id,
-                ];
-            }
-
-            if (isset($this->forward)) {
-                $body['message_reference'] = [
-                    'type' => Message::REFERENCE_FORWARD,
-                    'message_id' => $this->forward->id,
-                    'channel_id' => $this->forward->channel_id,
-                ];
-
                 $empty = false;
             }
         }
@@ -1275,17 +1252,11 @@ class MessageBuilder extends Builder implements JsonSerializable
             $body['enforce_nonce'] = $this->enforce_nonce;
         }
 
-        // Cannot have additional content when forwarding messages
-        if (isset($this->forward)) {
-            $body = [
-                'message_reference' => [
-                    'type' => Message::REFERENCE_FORWARD,
-                    'message_id' => $this->forward->id,
-                    'channel_id' => $this->forward->channel_id,
-                ],
-            ];
-        } elseif (isset($this->message_reference) && $this->message_reference->type === Message::REFERENCE_FORWARD) {
-            $body = ['message_reference' => $this->message_reference];
+        // Cannot have additional content when forwarding messages: keep only the message_reference
+        if ($this->message_reference !== null) {
+            if ($this->message_reference->type === Message::REFERENCE_FORWARD) {
+                $body = ['message_reference' => $this->message_reference];
+            }
         }
 
         return $body;

--- a/src/Discord/Builders/MessageBuilder.php
+++ b/src/Discord/Builders/MessageBuilder.php
@@ -788,7 +788,7 @@ class MessageBuilder extends Builder implements JsonSerializable
     /**
      * Adds attachment(s) to the builder.
      *
-     * @param Attachment|string|string|int ...$attachments Attachment objects or IDs to add
+     * @param Attachment|string|int ...$attachments Attachment objects or IDs to add
      *
      * @return self
      */

--- a/src/Discord/Builders/MessageBuilder.php
+++ b/src/Discord/Builders/MessageBuilder.php
@@ -337,6 +337,8 @@ class MessageBuilder extends Builder implements JsonSerializable
      * @param bool         $fail_if_not_exists Whether to error if the referenced message doesn't exist (default true).
      *
      * @return self
+     *
+     * @since 10.50.0 Added `fail_if_not_exists` parameter
      */
     public function setReplyTo(?Message $message = null, ?bool $fail_if_not_exists = null): self
     {
@@ -368,6 +370,8 @@ class MessageBuilder extends Builder implements JsonSerializable
      * @param bool         $fail_if_not_exists Whether to error if the referenced message doesn't exist (default true).
      *
      * @return self
+     *
+     * @since 10.50.0 Added `fail_if_not_exists` parameter
      */
     public function setForward(?Message $message = null, ?bool $fail_if_not_exists = null): self
     {
@@ -1155,7 +1159,7 @@ class MessageBuilder extends Builder implements JsonSerializable
     }
 
     /**
-     * @inheritDoc 
+     * @inheritDoc
      */
     public function jsonSerialize(): array
     {

--- a/src/Discord/Builders/MessageBuilder.php
+++ b/src/Discord/Builders/MessageBuilder.php
@@ -123,9 +123,9 @@ class MessageBuilder extends Builder implements JsonSerializable
     /**
      * Attachments to send with this message.
      *
-     * @var Attachment[]|null
+     * @var Attachment[]
      */
-    protected $attachments;
+    protected $attachments = [];
 
     /**
      * Flags to send with this message.
@@ -753,7 +753,7 @@ class MessageBuilder extends Builder implements JsonSerializable
      */
     public function setAttachments(?array $attachments = null): self
     {
-        $this->attachments = null;
+        $this->attachments = [];
 
         foreach ($attachments ?? [] as $attachment) {
             $this->addAttachment($attachment);
@@ -791,7 +791,7 @@ class MessageBuilder extends Builder implements JsonSerializable
      */
     public function getAttachments(): array
     {
-        return $this->attachments ?? [];
+        return $this->attachments;
     }
 
     /**
@@ -1216,7 +1216,7 @@ class MessageBuilder extends Builder implements JsonSerializable
             }
         }
 
-        if (isset($this->attachments)) {
+        if ($this->attachments) {
             $body['attachments'] = $this->attachments;
             $empty = false;
         }

--- a/src/Discord/Builders/MessageBuilder.php
+++ b/src/Discord/Builders/MessageBuilder.php
@@ -521,13 +521,15 @@ class MessageBuilder extends Builder implements JsonSerializable
      *
      * @return int
      */
-    public function countTotalComponents(): int
+    public function countTotalComponents(?array $components = null): int
     {
+        $components = $components ?? $this->components ?? [];
+
         return (int) array_sum(array_map(
-            fn ($component) => (is_array($component) && isset($component['components']) && is_array($component['components']))
+            fn ($component) => is_array($component) && isset($component['components']) && is_array($component['components'])
                 ? 1 + $this->countTotalComponents($component['components'])
                 : 1,
-            $this->components ?? []
+            $components
         ));
     }
 

--- a/src/Discord/Builders/MessageBuilder.php
+++ b/src/Discord/Builders/MessageBuilder.php
@@ -404,16 +404,18 @@ class MessageBuilder extends Builder implements JsonSerializable
      * Include to make your message a reply or a forward.
      *
      * @param MessageReference|Message|null $message_reference
+     * @param int                           $type               The type of message reference (0 = DEFAULT, 1 = FORWARD).
      * @param bool                          $fail_if_not_exists Whether to error if the referenced message doesn't exist (default true).
      *
      * @return self
      *
      * @since 10.50.0
      */
-    public function setMessageReference(MessageReference|Message|null $message_reference = null, bool $fail_if_not_exists = true): self
+    public function setMessageReference(MessageReference|Message|null $message_reference = null, int $type = MessageReference::TYPE_DEFAULT, bool $fail_if_not_exists = true): self
     {
         if ($message_reference instanceof Message) {
             $message_reference = $this->factory->part(MessageReference::class, [
+                'type' => $type,
                 'message_id' => $message_reference->id,
                 'channel_id' => $message_reference->channel_id,
                 'guild_id' => $message_reference->guild_id,

--- a/src/Discord/Builders/MessageBuilder.php
+++ b/src/Discord/Builders/MessageBuilder.php
@@ -24,6 +24,7 @@ use Discord\Http\Exceptions\RequestFailedException;
 use Discord\Parts\Channel\Attachment;
 use Discord\Parts\Channel\Message;
 use Discord\Parts\Channel\Message\AllowedMentions;
+use Discord\Parts\Channel\Message\MessageReference;
 use Discord\Parts\Channel\Message\SharedClientTheme;
 use Discord\Parts\Channel\Poll\PollCreateRequest as Poll;
 use Discord\Parts\Embed\Embed;
@@ -60,25 +61,11 @@ class MessageBuilder extends Builder implements JsonSerializable
     protected $nonce;
 
     /**
-     * Override the default username of the webhook.
-     *
-     * @var string|null
-     */
-    protected $username;
-
-    /**
-     * Override the default avatar of the webhook.
-     *
-     * @var string|null
-     */
-    protected $avatar_url;
-
-    /**
      * Whether the message is text-to-speech.
      *
-     * @var bool
+     * @var bool|null
      */
-    protected $tts = false;
+    protected $tts;
 
     /**
      * Array of embeds to send with the message.
@@ -95,9 +82,18 @@ class MessageBuilder extends Builder implements JsonSerializable
     protected $allowed_mentions;
 
     /**
+     * Include to make your message a reply or a forward
+     * 
+     * @var MessageReference|null
+     */
+    protected $message_reference;
+
+    /**
      * Message to reply to with this message.
      *
      * @var Message|null
+     * 
+     * @deprecated v10.50.0 Use `message_reference`
      */
     protected $replyTo;
 
@@ -105,6 +101,8 @@ class MessageBuilder extends Builder implements JsonSerializable
      * Message to forward with this message.
      *
      * @var Message|null
+     * 
+     * @deprecated v10.50.0 Use `message_reference`
      */
     protected $forward;
 
@@ -130,20 +128,6 @@ class MessageBuilder extends Builder implements JsonSerializable
     protected $attachments;
 
     /**
-     * The poll for the message.
-     *
-     * @var Poll|null
-     */
-    protected $poll;
-
-    /**
-     * Shared client theme for the message.
-     *
-     * @var SharedClientTheme|null
-     */
-    protected $shared_client_theme;
-
-    /**
      * Flags to send with this message.
      *
      * @var int|null
@@ -158,11 +142,39 @@ class MessageBuilder extends Builder implements JsonSerializable
     protected $enforce_nonce;
 
     /**
+     * The poll for the message.
+     *
+     * @var Poll|null
+     */
+    protected $poll;
+
+    /**
+     * Shared client theme for the message.
+     *
+     * @var SharedClientTheme|null
+     */
+    protected $shared_client_theme;
+
+    /**
+     * Override the default username of the webhook.
+     *
+     * @var string|null
+     */
+    protected $username;
+
+    /**
+     * Override the default avatar of the webhook.
+     *
+     * @var string|null
+     */
+    protected $avatar_url;
+
+    /**
      * Creates a new message builder.
      *
      * @return static
      */
-    public static function new(): self
+    public static function new(): static
     {
         return new static();
     }
@@ -242,67 +254,13 @@ class MessageBuilder extends Builder implements JsonSerializable
     }
 
     /**
-     * Override the default username of the webhook. Only used for executing webhook.
-     *
-     * @param string $username New webhook username.
-     *
-     * @throws \LengthException `$username` exceeds 80 characters.
-     *
-     * @return self
-     */
-    public function setUsername(string $username): self
-    {
-        if (poly_strlen($username) > 80) {
-            throw new \LengthException('Username can be only up to 80 characters.');
-        }
-
-        $this->username = $username;
-
-        return $this;
-    }
-
-    /**
-     * Retrieves the username associated with the message, if set.
-     *
-     * @return string|null
-     */
-    public function getUsername(): ?string
-    {
-        return $this->username ?? null;
-    }
-
-    /**
-     * Override the default avatar URL of the webhook. Only used for executing webhook.
-     *
-     * @param string $avatar_url New webhook avatar URL.
-     *
-     * @return self
-     */
-    public function setAvatarUrl(string $avatar_url): self
-    {
-        $this->avatar_url = $avatar_url;
-
-        return $this;
-    }
-
-    /**
-     * Retrieves the avatar URL associated with the webhook. Only used for executing webhook.
-     *
-     * @return string|null
-     */
-    public function getAvatarUrl(): ?string
-    {
-        return $this->avatar_url ?? null;
-    }
-
-    /**
      * Sets the TTS status of the message. Only used for sending message or executing webhook.
      *
-     * @param bool $tts
+     * @param bool|null $tts
      *
      * @return self
      */
-    public function setTts(bool $tts = false): self
+    public function setTts(?bool $tts = null): self
     {
         $this->tts = $tts;
 
@@ -318,6 +276,21 @@ class MessageBuilder extends Builder implements JsonSerializable
     {
         return $this->tts ?? false;
     }
+
+    /**
+     * Sets the embeds for the message. Clears the existing embeds in the process.
+     *
+     * @param Embed[]|array ...$embeds
+     *
+     * @return self
+     */
+    public function setEmbeds(array $embeds): self
+    {
+        $this->embeds = [];
+
+        return $this->addEmbed(...$embeds);
+    }
+
 
     /**
      * Adds an embed to the builder.
@@ -346,27 +319,13 @@ class MessageBuilder extends Builder implements JsonSerializable
     }
 
     /**
-     * Sets the embeds for the message. Clears the existing embeds in the process.
-     *
-     * @param Embed[]|array ...$embeds
-     *
-     * @return self
-     */
-    public function setEmbeds(array $embeds): self
-    {
-        $this->embeds = [];
-
-        return $this->addEmbed(...$embeds);
-    }
-
-    /**
      * Returns all the embeds in the builder.
      *
      * @return array[]|null
      */
     public function getEmbeds(): ?array
     {
-        return $this->embeds;
+        return $this->embeds ?? null;
     }
 
     /**
@@ -396,6 +355,8 @@ class MessageBuilder extends Builder implements JsonSerializable
      * @param Message|null $message
      *
      * @return self
+     * 
+     * @deprecated v10.50.0 Use `setMessageReference()` instead.
      */
     public function setReplyTo(?Message $message = null): self
     {
@@ -420,6 +381,8 @@ class MessageBuilder extends Builder implements JsonSerializable
      * @param Message|null $message
      *
      * @return self
+     * 
+     * @deprecated v10.50.0 Use `setMessageReference()` instead.
      */
     public function setForward(?Message $message = null): self
     {
@@ -439,49 +402,29 @@ class MessageBuilder extends Builder implements JsonSerializable
     }
 
     /**
-     * Validates the total number of components added to the message.
-     *
-     * @throws \OverflowException If the total number of components is 40 or more.
+     * Include to make your message a reply or a forward.
+     * 
+     * @param MessageReference|null $message_reference
+     * 
+     * @return self
+     * 
+     * @since 10.50.0
      */
-    protected function enforceV2Limits(): void
+    public function setMessageReference(?MessageReference $message_reference = null): self
     {
-        if ($this->countTotalComponents() >= 40) {
-            throw new \OverflowException('You can only add 40 components to a v2 message');
-        }
+        $this->message_reference = $message_reference;
+
+        return $this;
     }
 
     /**
-     * Enforces the component limits and structure for v2 messages.
-     *
-     * @param ComponentObject $component
-     *
-     * @throws \OverflowException        If more than 5 components are added.
-     * @throws \InvalidArgumentException If a component is not an ActionRow or is not properly wrapped.
+     * Retrieves the message reference from the builder.
+     * 
+     * @since 10.50.0
      */
-    protected function enforceV1Limits(ComponentObject $component): void
+    public function getMessageReference(): ?MessageReference
     {
-        if (! $component instanceof ActionRow) {
-            throw new \InvalidArgumentException('You can only add action rows as components to v1 messages. Put your other components inside an action row.');
-        }
-
-        if (count($this->components) >= 5) {
-            throw new \OverflowException('You can only add 5 components to a v1 message');
-        }
-    }
-
-    /**
-     * Recursively counts the total number of components, including nested components, in the given array.
-     *
-     * @return int
-     */
-    public function countTotalComponents(): int
-    {
-        return (int) array_sum(array_map(
-            fn ($component) => (is_array($component) && isset($component['components']) && is_array($component['components']))
-                ? 1 + $this->countTotalComponents($component['components'])
-                : 1,
-            $this->components ?? []
-        ));
+        return $this->message_reference ?? null;
     }
 
     /**
@@ -543,6 +486,52 @@ class MessageBuilder extends Builder implements JsonSerializable
     }
 
     /**
+     * Validates the total number of components added to the message.
+     *
+     * @throws \OverflowException If the total number of components is 40 or more.
+     */
+    protected function enforceV2Limits(): void
+    {
+        if ($this->countTotalComponents() >= 40) {
+            throw new \OverflowException('You can only add 40 components to a v2 message');
+        }
+    }
+
+    /**
+     * Enforces the component limits and structure for v2 messages.
+     *
+     * @param ComponentObject $component
+     *
+     * @throws \OverflowException        If more than 5 components are added.
+     * @throws \InvalidArgumentException If a component is not an ActionRow or is not properly wrapped.
+     */
+    protected function enforceV1Limits(ComponentObject $component): void
+    {
+        if (! $component instanceof ActionRow) {
+            throw new \InvalidArgumentException('You can only add action rows as components to v1 messages. Put your other components inside an action row.');
+        }
+
+        if (count($this->components) >= 5) {
+            throw new \OverflowException('You can only add 5 components to a v1 message');
+        }
+    }
+
+    /**
+     * Recursively counts the total number of components, including nested components, in the given array.
+     *
+     * @return int
+     */
+    public function countTotalComponents(): int
+    {
+        return (int) array_sum(array_map(
+            fn ($component) => (is_array($component) && isset($component['components']) && is_array($component['components']))
+                ? 1 + $this->countTotalComponents($component['components'])
+                : 1,
+            $this->components ?? []
+        ));
+    }
+
+    /**
      * Returns all the components in the builder.
      *
      * @return ComponentObject[]
@@ -551,7 +540,25 @@ class MessageBuilder extends Builder implements JsonSerializable
     {
         return $this->components ?? [];
     }
+    
+    /**
+     * Sets the stickers of the builder. Removes the existing stickers in the process.
+     *
+     * @param Sticker[]|string[]|null $stickers New sticker ids.
+     *
+     * @return self
+     */
+    public function setStickers(?array $stickers = []): self
+    {
+        $this->sticker_ids = [];
 
+        foreach ($stickers as $sticker) {
+            $this->addSticker($sticker);
+        }
+
+        return $this;
+    }
+    
     /**
      * Adds a sticker to the builder. Only used for sending message or creating forum thread.
      *
@@ -597,24 +604,6 @@ class MessageBuilder extends Builder implements JsonSerializable
     }
 
     /**
-     * Sets the stickers of the builder. Removes the existing stickers in the process.
-     *
-     * @param Sticker[]|string[] $stickers New sticker ids.
-     *
-     * @return self
-     */
-    public function setStickers(array $stickers): self
-    {
-        $this->sticker_ids = [];
-
-        foreach ($stickers as $sticker) {
-            $this->addSticker($sticker);
-        }
-
-        return $this;
-    }
-
-    /**
      * Returns all the sticker ids in the builder.
      *
      * @return string[]
@@ -622,6 +611,34 @@ class MessageBuilder extends Builder implements JsonSerializable
     public function getStickers(): array
     {
         return $this->sticker_ids;
+    }
+
+    /**
+     * Removes all stickers from the builder.
+     * 
+     * @return self
+     * 
+     * @since 10.50.0
+     */
+    public function clearStickers(): self
+    {
+        $this->sticker_ids = [];
+
+        return $this;
+    }
+
+    /**
+     * Sets the files to be attached to the message.
+     *
+     * @param array $files An array of files to attach.
+     *
+     * @return self
+     */
+    public function setFiles(?array $files = null): self
+    {
+        $this->files = $files;
+
+        return $this;
     }
 
     /**
@@ -643,21 +660,6 @@ class MessageBuilder extends Builder implements JsonSerializable
         }
 
         return $this->addFileFromContent($filename ?? basename($filepath), file_get_contents($filepath));
-    }
-
-    /**
-     * Adds a file attachment to the builder with a given filename and content.
-     *
-     * @param string $filename Name to send the file as.
-     * @param string $content  Content of the file.
-     *
-     * @return self
-     */
-    public function addFileFromContent(string $filename, string $content): self
-    {
-        $this->files[] = [$filename, $content];
-
-        return $this;
     }
 
     /**
@@ -685,15 +687,16 @@ class MessageBuilder extends Builder implements JsonSerializable
     }
 
     /**
-     * Sets the files to be attached to the message.
+     * Adds a file attachment to the builder with a given filename and content.
      *
-     * @param array $files An array of files to attach.
+     * @param string $filename Name to send the file as.
+     * @param string $content  Content of the file.
      *
      * @return self
      */
-    public function setFiles(array $files = []): self
+    public function addFileFromContent(string $filename, string $content): self
     {
-        $this->files = $files;
+        $this->files[] = [$filename, $content];
 
         return $this;
     }
@@ -706,6 +709,44 @@ class MessageBuilder extends Builder implements JsonSerializable
     public function clearFiles(): self
     {
         $this->files = [];
+
+        return $this;
+    }
+
+    /**
+     * JSON-encoded body of non-file params, only for multipart/form-data requests.
+     * 
+     * @throws \RuntimeException If encoding the message to JSON fails.
+     * 
+     * @return string
+     * 
+     * @since 10.50.0
+     */
+    public function getPayloadJson(): string
+    {
+        if (($jsonEncoded = json_encode($this)) === false) {
+            throw new \RuntimeException('Failed to encode message to JSON: '.json_last_error_msg());
+        }
+
+        return $jsonEncoded;
+    }
+
+    /**
+     * Sets the attachments of the builder. Removes the existing attachments in the process.
+     *
+     * @param array|null $attachments An array of attachments to set.
+     *
+     * @return self
+     */
+    public function setAttachments(?array $attachments = null): self
+    {
+        $this->attachments = null;
+
+        if ($attachments !== null) {
+            foreach ($attachments as $attachment) {
+                $this->addAttachment($attachment);
+            }
+        }
 
         return $this;
     }
@@ -755,53 +796,28 @@ class MessageBuilder extends Builder implements JsonSerializable
     }
 
     /**
-     * Sets the poll of the message.
+     * Sets the flags of the message.
+     * Only `SUPPRESS_EMBEDS`, `SUPPRESS_NOTIFICATIONS`, `IS_VOICE_MESSAGE`, and `IS_COMPONENTS_V2` can be set for the Create Message endpoint.
      *
-     * @param Poll|null $poll
+     * @param int $flags
+     *
+     * @since 10.0.0
      *
      * @return self
      */
-    public function setPoll($poll = null): self
+    public function setFlags(int $flags): self
     {
-        $this->poll = $poll;
+        $this->flags = $flags;
 
         return $this;
     }
 
     /**
-     * Returns the poll of the message.
-     *
-     * @return Poll|null
+     * @deprecated 10.0.0 Use MessageBuilder::setFlags()
      */
-    public function getPoll(): ?Poll
+    public function _setFlags(int $flags): self
     {
-        return $this->poll;
-    }
-
-    /**
-     * Sets the shared client theme of the message.
-     *
-     * @since 10.49.0
-     *
-     * @param SharedClientTheme|null $shared_client_theme
-     *
-     * @return self
-     */
-    public function setSharedClientTheme($shared_client_theme = null): self
-    {
-        $this->shared_client_theme = $shared_client_theme;
-
-        return $this;
-    }
-
-    /**
-     * Returns the shared client theme of the message.
-     *
-     * @return SharedClientTheme|null
-     */
-    public function getSharedClientTheme(): ?SharedClientTheme
-    {
-        return $this->shared_client_theme;
+        return $this->setFlags($flags);
     }
 
     /**
@@ -914,23 +930,6 @@ class MessageBuilder extends Builder implements JsonSerializable
     }
 
     /**
-     * Sets the flags of the message.
-     * Only `SUPPRESS_EMBEDS`, `SUPPRESS_NOTIFICATIONS`, `IS_VOICE_MESSAGE`, and `IS_COMPONENTS_V2` can be set for the Create Message endpoint.
-     *
-     * @param int $flags
-     *
-     * @since 10.0.0
-     *
-     * @return self
-     */
-    public function setFlags(int $flags): self
-    {
-        $this->flags = $flags;
-
-        return $this;
-    }
-
-    /**
      * Get the current flags of the message.
      *
      * @return int
@@ -938,14 +937,6 @@ class MessageBuilder extends Builder implements JsonSerializable
     public function getFlags(): int
     {
         return $this->flags ?? 0;
-    }
-
-    /**
-     * @deprecated 10.0.0 Use MessageBuilder::setFlags()
-     */
-    public function _setFlags(int $flags): self
-    {
-        return $this->setFlags($flags);
     }
 
     /**
@@ -972,6 +963,110 @@ class MessageBuilder extends Builder implements JsonSerializable
     public function getEnforceNonce(): ?bool
     {
         return $this->enforce_nonce ?? null;
+    }
+
+    /**
+     * Sets the poll of the message.
+     *
+     * @param Poll|null $poll
+     *
+     * @return self
+     */
+    public function setPoll($poll = null): self
+    {
+        $this->poll = $poll;
+
+        return $this;
+    }
+
+    /**
+     * Returns the poll of the message.
+     *
+     * @return Poll|null
+     */
+    public function getPoll(): ?Poll
+    {
+        return $this->poll;
+    }
+
+    /**
+     * Sets the shared client theme of the message.
+     *
+     * @since 10.49.0
+     *
+     * @param SharedClientTheme|null $shared_client_theme
+     *
+     * @return self
+     */
+    public function setSharedClientTheme($shared_client_theme = null): self
+    {
+        $this->shared_client_theme = $shared_client_theme;
+
+        return $this;
+    }
+
+    /**
+     * Returns the shared client theme of the message.
+     *
+     * @return SharedClientTheme|null
+     */
+    public function getSharedClientTheme(): ?SharedClientTheme
+    {
+        return $this->shared_client_theme;
+    }
+
+    /**
+     * Override the default username of the webhook. Only used for executing webhook.
+     *
+     * @param string $username New webhook username.
+     *
+     * @throws \LengthException `$username` exceeds 80 characters.
+     *
+     * @return self
+     */
+    public function setUsername(string $username): self
+    {
+        if (poly_strlen($username) > 80) {
+            throw new \LengthException('Username can be only up to 80 characters.');
+        }
+
+        $this->username = $username;
+
+        return $this;
+    }
+
+    /**
+     * Retrieves the username associated with the message, if set.
+     *
+     * @return string|null
+     */
+    public function getUsername(): ?string
+    {
+        return $this->username ?? null;
+    }
+
+    /**
+     * Override the default avatar URL of the webhook. Only used for executing webhook.
+     *
+     * @param string $avatar_url New webhook avatar URL.
+     *
+     * @return self
+     */
+    public function setAvatarUrl(string $avatar_url): self
+    {
+        $this->avatar_url = $avatar_url;
+
+        return $this;
+    }
+
+    /**
+     * Retrieves the avatar URL associated with the webhook. Only used for executing webhook.
+     *
+     * @return string|null
+     */
+    public function getAvatarUrl(): ?string
+    {
+        return $this->avatar_url ?? null;
     }
 
     /**
@@ -1002,15 +1097,11 @@ class MessageBuilder extends Builder implements JsonSerializable
     {
         $fields = [];
 
-        if (($jsonEncoded = json_encode($this)) === false) {
-            throw new \RuntimeException('Failed to encode message to JSON: '.json_last_error_msg());
-        }
-
         if ($payload) {
             $fields = [
                 [
                     'name' => 'payload_json',
-                    'content' => $jsonEncoded,
+                    'content' => $this->getPayloadJson(),
                     'headers' => [
                         'Content-Type' => 'application/json',
                     ],
@@ -1056,8 +1147,8 @@ class MessageBuilder extends Builder implements JsonSerializable
             $body['avatar_url'] = $this->avatar_url;
         }
 
-        if ($this->tts) {
-            $body['tts'] = true;
+        if (isset($this->tts)) {
+            $body['tts'] = $this->tts;
         }
 
         if (isset($this->embeds)) {
@@ -1071,21 +1162,29 @@ class MessageBuilder extends Builder implements JsonSerializable
             $body['allowed_mentions'] = $this->allowed_mentions;
         }
 
-        if ($this->replyTo) {
-            $body['message_reference'] = [
-                'message_id' => $this->replyTo->id,
-                'channel_id' => $this->replyTo->channel_id,
-            ];
-        }
+        if (isset($this->message_reference)) {
+            $body['message_reference'] = $this->message_reference;
 
-        if ($this->forward) {
-            $body['message_reference'] = [
-                'type' => Message::REFERENCE_FORWARD,
-                'message_id' => $this->forward->id,
-                'channel_id' => $this->forward->channel_id,
-            ];
+            if ($this->message_reference->type === Message::REFERENCE_FORWARD) {
+                $empty = false;
+            }
+        } else {
+            if (isset($this->replyTo)) {
+                $body['message_reference'] = [
+                    'message_id' => $this->replyTo->id,
+                    'channel_id' => $this->replyTo->channel_id,
+                ];
+            }
 
-            $empty = false;
+            if (isset($this->forward)) {
+                $body['message_reference'] = [
+                    'type' => Message::REFERENCE_FORWARD,
+                    'message_id' => $this->forward->id,
+                    'channel_id' => $this->forward->channel_id,
+                ];
+
+                $empty = false;
+            }
         }
 
         if (isset($this->components)) {

--- a/src/Discord/Builders/MessageBuilder.php
+++ b/src/Discord/Builders/MessageBuilder.php
@@ -434,7 +434,7 @@ class MessageBuilder extends Builder implements JsonSerializable
                     $attr['guild_id'] = $message_reference->guild_id;
                 }
 
-                $message_reference = $this->factory->part(MessageReference::class, $attr);
+                $message_reference = $message_reference->getDiscord()->getFactory()->part(MessageReference::class, $attr);
             }
 
             if ($type === MessageReference::TYPE_FORWARD) {

--- a/src/Discord/Builders/MessageBuilder.php
+++ b/src/Discord/Builders/MessageBuilder.php
@@ -762,7 +762,11 @@ class MessageBuilder extends Builder implements JsonSerializable
      */
     public function setAttachments(?array $attachments = null): self
     {
-        $this->attachments = $attachments;
+        if ($attachments === null) {
+            $this->attachments = null;
+        } else {
+            $this->attachments = [];
+        }
 
         foreach ($attachments ?? [] as $attachment) {
             $this->addAttachment($attachment);

--- a/src/Discord/Builders/MessageBuilder.php
+++ b/src/Discord/Builders/MessageBuilder.php
@@ -403,7 +403,7 @@ class MessageBuilder extends Builder implements JsonSerializable
      * @param int                           $type               If passing a Message, the type of message reference (0 = DEFAULT/REPLY, 1 = FORWARD).
      * @param ?bool|null                    $fail_if_not_exists Whether to error if the referenced message doesn't exist (default true).
      *
-     * @throw InvalidArgumentException If the message reference is a forward and the channel_id is null.
+     * @throws \InvalidArgumentException If the message reference is a forward and the channel_id is null.
      *
      * @return self
      *

--- a/src/Discord/Builders/MessageBuilder.php
+++ b/src/Discord/Builders/MessageBuilder.php
@@ -588,7 +588,7 @@ class MessageBuilder extends Builder implements JsonSerializable
      *
      * @return self
      */
-    public function setStickers(?array $stickers = []): self
+    public function setStickers(?array $stickers = null): self
     {
         $this->sticker_ids = [];
 

--- a/src/Discord/Builders/MessageBuilder.php
+++ b/src/Discord/Builders/MessageBuilder.php
@@ -334,7 +334,7 @@ class MessageBuilder extends Builder implements JsonSerializable
      * Sets this message as a reply to another message. Only used for sending message.
      *
      * @param Message|null $message
-     * @param bool         $fail_if_not_exists Whether to error if the referenced message doesn't exist (default true).
+     * @param ?bool|null   $fail_if_not_exists Whether to error if the referenced message doesn't exist (default true).
      *
      * @return self
      *
@@ -367,7 +367,7 @@ class MessageBuilder extends Builder implements JsonSerializable
      * Sets this message as a forward of another message. Only used for sending message.
      *
      * @param Message|null $message
-     * @param bool         $fail_if_not_exists Whether to error if the referenced message doesn't exist (default true).
+     * @param ?bool|null   $fail_if_not_exists Whether to error if the referenced message doesn't exist (default true).
      *
      * @return self
      *

--- a/src/Discord/Builders/MessageBuilder.php
+++ b/src/Discord/Builders/MessageBuilder.php
@@ -799,7 +799,7 @@ class MessageBuilder extends Builder implements JsonSerializable
 
     /**
      * Returns all the attachments in the builder.
-     * 
+     *
      * The array consists of only the raw attributes of the attachments if they were added as Attachment objects.
      *
      * @return array[]
@@ -1105,7 +1105,7 @@ class MessageBuilder extends Builder implements JsonSerializable
      */
     public function requiresMultipart(): bool
     {
-        return ! empty($this->files);
+        return isset($this->files);
     }
 
     /**

--- a/src/Discord/Builders/MessageBuilder.php
+++ b/src/Discord/Builders/MessageBuilder.php
@@ -1223,7 +1223,7 @@ class MessageBuilder extends Builder implements JsonSerializable
             }
         }
 
-        if ($this->attachments) {
+        if (! empty($this->attachments)) {
             $body['attachments'] = $this->attachments;
             $empty = false;
         }

--- a/src/Discord/Builders/MessageBuilder.php
+++ b/src/Discord/Builders/MessageBuilder.php
@@ -98,9 +98,9 @@ class MessageBuilder extends Builder implements JsonSerializable
     /**
      * Files to send with this message.
      *
-     * @var array[]|null
+     * @var array[]
      */
-    protected $files;
+    protected $files = [];
 
     /**
      * Attachments to send with this message.
@@ -676,7 +676,7 @@ class MessageBuilder extends Builder implements JsonSerializable
      */
     public function setFiles(?array $files = null): self
     {
-        $this->files = $files;
+        $this->files = $files ?? [];
 
         return $this;
     }
@@ -709,10 +709,6 @@ class MessageBuilder extends Builder implements JsonSerializable
      */
     public function numFiles(): int
     {
-        if (! isset($this->files)) {
-            return 0;
-        }
-
         return count($this->files);
     }
 
@@ -723,7 +719,7 @@ class MessageBuilder extends Builder implements JsonSerializable
      */
     public function getFiles(): array
     {
-        return $this->files ?? [];
+        return $this->files;
     }
 
     /**
@@ -1117,7 +1113,7 @@ class MessageBuilder extends Builder implements JsonSerializable
      */
     public function requiresMultipart(): bool
     {
-        return isset($this->files);
+        return ! empty($this->files);
     }
 
     /**

--- a/src/Discord/Builders/MessageBuilder.php
+++ b/src/Discord/Builders/MessageBuilder.php
@@ -755,10 +755,8 @@ class MessageBuilder extends Builder implements JsonSerializable
     {
         $this->attachments = null;
 
-        if ($attachments !== null) {
-            foreach ($attachments as $attachment) {
-                $this->addAttachment($attachment);
-            }
+        foreach ($attachments ?? [] as $attachment) {
+            $this->addAttachment($attachment);
         }
 
         return $this;

--- a/src/Discord/Builders/MessageBuilder.php
+++ b/src/Discord/Builders/MessageBuilder.php
@@ -404,7 +404,7 @@ class MessageBuilder extends Builder implements JsonSerializable
      * Include to make your message a reply or a forward.
      *
      * @param MessageReference|Message|null $message_reference
-     * @param int                           $type               The type of message reference (0 = DEFAULT, 1 = FORWARD).
+     * @param int                           $type               The type of message reference (0 = DEFAULT/REPLY, 1 = FORWARD).
      * @param bool                          $fail_if_not_exists Whether to error if the referenced message doesn't exist (default true).
      *
      * @return self

--- a/src/Discord/Builders/MessageBuilder.php
+++ b/src/Discord/Builders/MessageBuilder.php
@@ -565,7 +565,7 @@ class MessageBuilder extends Builder implements JsonSerializable
     {
         $this->sticker_ids = [];
 
-        foreach ($stickers as $sticker) {
+        foreach ($stickers ?? [] as $sticker) {
             $this->addSticker($sticker);
         }
 

--- a/src/Discord/Builders/MessageBuilder.php
+++ b/src/Discord/Builders/MessageBuilder.php
@@ -654,20 +654,6 @@ class MessageBuilder extends Builder implements JsonSerializable
     }
 
     /**
-     * Removes all stickers from the builder.
-     *
-     * @return self
-     *
-     * @since 10.50.0
-     */
-    public function clearStickers(): self
-    {
-        $this->sticker_ids = [];
-
-        return $this;
-    }
-
-    /**
      * Sets the files to be attached to the message.
      *
      * @param array|null $files An array of files to attach.

--- a/src/Discord/Builders/MessageBuilder.php
+++ b/src/Discord/Builders/MessageBuilder.php
@@ -82,8 +82,8 @@ class MessageBuilder extends Builder implements JsonSerializable
     protected $allowed_mentions;
 
     /**
-     * Include to make your message a reply or a forward
-     * 
+     * Include to make your message a reply or a forward.
+     *
      * @var MessageReference|null
      */
     protected $message_reference;
@@ -92,7 +92,7 @@ class MessageBuilder extends Builder implements JsonSerializable
      * Message to reply to with this message.
      *
      * @var Message|null
-     * 
+     *
      * @deprecated v10.50.0 Use `message_reference`
      */
     protected $replyTo;
@@ -101,7 +101,7 @@ class MessageBuilder extends Builder implements JsonSerializable
      * Message to forward with this message.
      *
      * @var Message|null
-     * 
+     *
      * @deprecated v10.50.0 Use `message_reference`
      */
     protected $forward;
@@ -291,7 +291,6 @@ class MessageBuilder extends Builder implements JsonSerializable
         return $this->addEmbed(...$embeds);
     }
 
-
     /**
      * Adds an embed to the builder.
      *
@@ -355,7 +354,7 @@ class MessageBuilder extends Builder implements JsonSerializable
      * @param Message|null $message
      *
      * @return self
-     * 
+     *
      * @deprecated v10.50.0 Use `setMessageReference()` instead.
      */
     public function setReplyTo(?Message $message = null): self
@@ -381,7 +380,7 @@ class MessageBuilder extends Builder implements JsonSerializable
      * @param Message|null $message
      *
      * @return self
-     * 
+     *
      * @deprecated v10.50.0 Use `setMessageReference()` instead.
      */
     public function setForward(?Message $message = null): self
@@ -403,15 +402,25 @@ class MessageBuilder extends Builder implements JsonSerializable
 
     /**
      * Include to make your message a reply or a forward.
-     * 
-     * @param MessageReference|null $message_reference
-     * 
+     *
+     * @param MessageReference|Message|null $message_reference
+     * @param bool                          $fail_if_not_exists Whether to error if the referenced message doesn't exist (default true).
+     *
      * @return self
-     * 
+     *
      * @since 10.50.0
      */
-    public function setMessageReference(?MessageReference $message_reference = null): self
+    public function setMessageReference(MessageReference|Message|null $message_reference = null, bool $fail_if_not_exists = true): self
     {
+        if ($message_reference instanceof Message) {
+            $message_reference = $this->factory->part(MessageReference::class, [
+                'message_id' => $message_reference->id,
+                'channel_id' => $message_reference->channel_id,
+                'guild_id' => $message_reference->guild_id,
+                'fail_if_not_exists' => $fail_if_not_exists,
+            ]);
+        }
+
         $this->message_reference = $message_reference;
 
         return $this;
@@ -419,7 +428,7 @@ class MessageBuilder extends Builder implements JsonSerializable
 
     /**
      * Retrieves the message reference from the builder.
-     * 
+     *
      * @since 10.50.0
      */
     public function getMessageReference(): ?MessageReference
@@ -617,9 +626,9 @@ class MessageBuilder extends Builder implements JsonSerializable
 
     /**
      * Removes all stickers from the builder.
-     * 
+     *
      * @return self
-     * 
+     *
      * @since 10.50.0
      */
     public function clearStickers(): self
@@ -717,11 +726,11 @@ class MessageBuilder extends Builder implements JsonSerializable
 
     /**
      * JSON-encoded body of non-file params, only for multipart/form-data requests.
-     * 
+     *
      * @throws \RuntimeException If encoding the message to JSON fails.
-     * 
+     *
      * @return string
-     * 
+     *
      * @since 10.50.0
      */
     public function getPayloadJson(): string

--- a/src/Discord/Builders/MessageBuilder.php
+++ b/src/Discord/Builders/MessageBuilder.php
@@ -93,7 +93,7 @@ class MessageBuilder extends Builder implements JsonSerializable
      *
      * @var Message|null
      *
-     * @deprecated v10.50.0 Use `message_reference`
+     * @deprecated 10.50.0 Use `message_reference`
      */
     protected $replyTo;
 
@@ -102,7 +102,7 @@ class MessageBuilder extends Builder implements JsonSerializable
      *
      * @var Message|null
      *
-     * @deprecated v10.50.0 Use `message_reference`
+     * @deprecated 10.50.0 Use `message_reference`
      */
     protected $forward;
 
@@ -381,7 +381,7 @@ class MessageBuilder extends Builder implements JsonSerializable
      *
      * @return self
      *
-     * @deprecated v10.50.0 Use `setMessageReference()` instead.
+     * @deprecated 10.50.0 Use `setMessageReference()` instead.
      */
     public function setForward(?Message $message = null): self
     {

--- a/src/Discord/Builders/MessageBuilder.php
+++ b/src/Discord/Builders/MessageBuilder.php
@@ -434,12 +434,21 @@ class MessageBuilder extends Builder implements JsonSerializable
                     $attr['guild_id'] = $message_reference->guild_id;
                 }
 
+                /** @var MessageReference|null $message_reference */
                 $message_reference = $message_reference->getDiscord()->getFactory()->part(MessageReference::class, $attr);
             }
 
             if ($type === MessageReference::TYPE_FORWARD) {
                 if ($message_reference->channel_id === null) {
                     throw new \InvalidArgumentException('Cannot set a forward message reference without a channel_id.');
+                }
+
+                if ($channel = $message_reference->getDiscord()->getChannel($message_reference->channel_id)) {
+                    if ($botperms = $channel->getBotPermissions()) {
+                        if (! $botperms->view_channel) {
+                            throw new \InvalidArgumentException('Cannot set a forward message reference for a channel the bot cannot view.');
+                        }
+                    }
                 }
             }
         }
@@ -1264,6 +1273,19 @@ class MessageBuilder extends Builder implements JsonSerializable
 
         if (isset($this->enforce_nonce)) {
             $body['enforce_nonce'] = $this->enforce_nonce;
+        }
+
+        // Cannot have additional content when forwarding messages
+        if (isset($this->forward)) {
+            $body = [
+                'message_reference' => [
+                    'type' => Message::REFERENCE_FORWARD,
+                    'message_id' => $this->forward->id,
+                    'channel_id' => $this->forward->channel_id,
+                ],
+            ];
+        } elseif (isset($this->message_reference) && $this->message_reference->type === Message::REFERENCE_FORWARD) {
+            $body = ['message_reference' => $this->message_reference];
         }
 
         return $body;

--- a/src/Discord/Helpers/RegisteredCommand.php
+++ b/src/Discord/Helpers/RegisteredCommand.php
@@ -15,8 +15,11 @@ declare(strict_types=1);
 namespace Discord\Helpers;
 
 use Discord\Discord;
+use Discord\Parts\Interactions\ApplicationCommand;
+use Discord\Parts\Interactions\ApplicationCommandAutocomplete;
 use Discord\Parts\Interactions\Interaction;
 use Discord\Parts\Interactions\Request\Option;
+
 
 /**
  * RegisteredCommand represents a command that has been registered with the

--- a/src/Discord/Helpers/RegisteredCommand.php
+++ b/src/Discord/Helpers/RegisteredCommand.php
@@ -20,7 +20,6 @@ use Discord\Parts\Interactions\ApplicationCommandAutocomplete;
 use Discord\Parts\Interactions\Interaction;
 use Discord\Parts\Interactions\Request\Option;
 
-
 /**
  * RegisteredCommand represents a command that has been registered with the
  * Discord servers and has a handler to handle when the command is triggered.

--- a/src/Discord/Parts/Channel/Attachment.php
+++ b/src/Discord/Parts/Channel/Attachment.php
@@ -27,25 +27,25 @@ use Discord\Parts\User\User;
  *
  * @since 7.0.0
  *
- * @property string            $id                Attachment ID.
- * @property string            $filename          Name of file attached.
- * @property string|null       $title             The title of the file
- * @property string|null       $description       Description for the file.
- * @property string|null       $content_type      The attachment's media type.
- * @property int               $size              Size of file in bytes.
- * @property string            $url               Source url of file.
- * @property string            $proxy_url         A proxied url of file.
- * @property ?int|null         $height            Height of file (if image).
- * @property ?int|null         $width             Width of file (if image).
- * @property ?string|null      $placeholder       Thumbhash placeholder (if image or video).
+ * @property string            $id                  Attachment ID.
+ * @property string            $filename            Name of file attached.
+ * @property string|null       $title               The title of the file
+ * @property string|null       $description         Description for the file.
+ * @property string|null       $content_type        The attachment's media type.
+ * @property int               $size                Size of file in bytes.
+ * @property string            $url                 Source url of file.
+ * @property string            $proxy_url           A proxied url of file.
+ * @property ?int|null         $height              Height of file (if image).
+ * @property ?int|null         $width               Width of file (if image).
+ * @property ?string|null      $placeholder         Thumbhash placeholder (if image or video).
  * @property ?int|null         $placeholder_version Version of the placeholder (if image or video)
- * @property bool|null         $ephemeral         Whether this attachment is ephemeral.
- * @property float|null        $duration_secs     The duration of the audio file (currently for voice messages).
- * @property string|null       $waveform          Base64 encoded bytearray representing a sampled waveform (currently for voice messages).
- * @property int|null          $flags             Attachment flags combined as a bitfield.
- * @property ?User[]|null      $clip_participants Array of user objects. For Clips, array of users who were in the stream.
- * @property ?Carbon|null      $clip_created_at   For Clips, when the clip was created.
- * @property ?Application|null $application       For Clips, the application in the stream, if recognized.
+ * @property bool|null         $ephemeral           Whether this attachment is ephemeral.
+ * @property float|null        $duration_secs       The duration of the audio file (currently for voice messages).
+ * @property string|null       $waveform            Base64 encoded bytearray representing a sampled waveform (currently for voice messages).
+ * @property int|null          $flags               Attachment flags combined as a bitfield.
+ * @property ?User[]|null      $clip_participants   Array of user objects. For Clips, array of users who were in the stream.
+ * @property ?Carbon|null      $clip_created_at     For Clips, when the clip was created.
+ * @property ?Application|null $application         For Clips, the application in the stream, if recognized.
  */
 class Attachment extends Part
 {

--- a/src/Discord/Parts/Channel/Message/MessageReference.php
+++ b/src/Discord/Parts/Channel/Message/MessageReference.php
@@ -17,6 +17,7 @@ namespace Discord\Parts\Channel\Message;
 use Discord\Parts\Channel\Channel;
 use Discord\Parts\Channel\Message;
 use Discord\Parts\Guild\Guild;
+use Discord\Parts\Thread\Thread;
 use Discord\Parts\Part;
 
 /**

--- a/tests/Builders/MessageBuilderTest.php
+++ b/tests/Builders/MessageBuilderTest.php
@@ -19,31 +19,6 @@ use Discord\Parts\Channel\Message\MessageReference;
 
 final class MessageBuilderTest extends DiscordTestCase
 {
-    public function testMessageReferencePartSerialization()
-    {
-        $discord = getMockDiscord();
-        $factory = $discord->getFactory();
-
-        $messageReference = $factory->part(MessageReference::class, [
-            'type' => MessageReference::TYPE_DEFAULT,
-            'message_id' => '111',
-            'channel_id' => '222',
-            'guild_id' => null,
-            'fail_if_not_exists' => true,
-        ], true);
-
-        $builder = MessageBuilder::new();
-        $builder->setMessageReference($messageReference);
-
-        $payload = json_decode($builder->getPayloadJson(), true);
-
-        $this->assertArrayHasKey('message_reference', $payload);
-        $this->assertSame('111', $payload['message_reference']['message_id']);
-        $this->assertSame('222', $payload['message_reference']['channel_id']);
-        $this->assertArrayHasKey('type', $payload['message_reference']);
-        $this->assertSame(MessageReference::TYPE_DEFAULT, $payload['message_reference']['type']);
-    }
-
     public function testSendMessageReplyAndForwardUsingMessageReference()
     {
         return wait(function (Discord $discord, $resolve) {

--- a/tests/Builders/MessageBuilderTest.php
+++ b/tests/Builders/MessageBuilderTest.php
@@ -4,14 +4,20 @@ declare(strict_types=1);
 
 /*
  * This file is a part of the DiscordPHP project.
+ *
+ * Copyright (c) 2015-2022 David Cole <david.cole1340@gmail.com>
+ * Copyright (c) 2020-present Valithor Obsidion <valithor@discordphp.org>
+ *
+ * This file is subject to the MIT license that is bundled
+ * with this source code in the LICENSE.md file.
  */
 
 use Discord\Builders\MessageBuilder;
+use Discord\Discord;
 use Discord\Parts\Channel\Message;
 use Discord\Parts\Channel\Message\MessageReference;
-use PHPUnit\Framework\TestCase;
 
-final class MessageBuilderTest extends TestCase
+final class MessageBuilderTest extends DiscordTestCase
 {
     public function testMessageReferencePartSerialization()
     {
@@ -38,34 +44,45 @@ final class MessageBuilderTest extends TestCase
         $this->assertSame(MessageReference::TYPE_DEFAULT, $payload['message_reference']['type']);
     }
 
-    public function testReplyAndForwardLegacyPaths()
+    public function testSendMessageReplyAndForwardUsingMessageReference()
     {
-        $discord = getMockDiscord();
-        $factory = $discord->getFactory();
+        return wait(function (Discord $discord, $resolve) {
+            // Send an initial message
+            $this->channel()->sendMessage(MessageBuilder::new()->setContent('MessageBuilder integration test'))
+                ->then(function (Message $original) use ($resolve) {
+                    $this->assertInstanceOf(Message::class, $original);
 
-        $message = $factory->part(Message::class, [
-            'id' => '333',
-            'channel_id' => '444',
-        ], true);
+                    $original->getDiscord()->getLogger()->debug('Send a reply using setMessageReference with default type');
 
-        // Reply (legacy setReplyTo) should produce message_reference without a type key
-        $builder = MessageBuilder::new();
-        $builder->setReplyTo($message);
-        $payload = json_decode($builder->getPayloadJson(), true);
+                    $replyBuilder = MessageBuilder::new()
+                        ->setContent('Reply to message')
+                        ->setMessageReference($original, MessageReference::TYPE_DEFAULT, false);
 
-        $this->assertArrayHasKey('message_reference', $payload);
-        $this->assertSame('333', $payload['message_reference']['message_id']);
-        $this->assertSame('444', $payload['message_reference']['channel_id']);
-        $this->assertArrayNotHasKey('type', $payload['message_reference']);
+                    $original->getDiscord()->getLogger()->debug('Reply: '.json_encode($replyBuilder));
 
-        // Forward (legacy setForward) should include the forward type
-        $builder2 = MessageBuilder::new();
-        $builder2->setForward($message);
-        $payload2 = json_decode($builder2->getPayloadJson(), true);
+                    $this->channel()->sendMessage($replyBuilder)
+                        ->then(function (Message $reply) use ($original, $resolve) {
+                            $this->assertNotNull($reply->message_reference);
+                            $this->assertSame($original->id, $reply->message_reference->message_id);
+                            $this->assertSame(MessageReference::TYPE_DEFAULT, $reply->message_reference->type);
 
-        $this->assertArrayHasKey('message_reference', $payload2);
-        $this->assertSame(Message::REFERENCE_FORWARD, $payload2['message_reference']['type']);
-        $this->assertSame('333', $payload2['message_reference']['message_id']);
-        $this->assertSame('444', $payload2['message_reference']['channel_id']);
+                            $original->getDiscord()->getLogger()->debug('Send a forward using setMessageReference with forward type');
+                            $forwardBuilder = MessageBuilder::new()
+                                ->setContent('Forward of message') // Should be dropped
+                                ->setMessageReference($original, MessageReference::TYPE_FORWARD, false);
+
+                            $original->getDiscord()->getLogger()->debug('Forward: '.json_encode($forwardBuilder));
+
+                            $this->channel()->sendMessage($forwardBuilder)
+                                ->then(function (Message $forward) use ($original, $resolve) {
+                                    $this->assertNotNull($forward->message_reference);
+                                    $this->assertSame($original->id, $forward->message_reference->message_id);
+                                    $this->assertSame(MessageReference::TYPE_FORWARD, $forward->message_reference->type);
+
+                                    $resolve(true);
+                                }, $resolve);
+                        }, $resolve);
+                }, $resolve);
+        }, 15);
     }
 }

--- a/tests/Builders/MessageBuilderTest.php
+++ b/tests/Builders/MessageBuilderTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is a part of the DiscordPHP project.
+ */
+
+use Discord\Builders\MessageBuilder;
+use Discord\Parts\Channel\Message;
+use Discord\Parts\Channel\Message\MessageReference;
+use PHPUnit\Framework\TestCase;
+
+final class MessageBuilderTest extends TestCase
+{
+    public function testMessageReferencePartSerialization()
+    {
+        $discord = getMockDiscord();
+        $factory = $discord->getFactory();
+
+        $messageReference = $factory->part(MessageReference::class, [
+            'type' => MessageReference::TYPE_DEFAULT,
+            'message_id' => '111',
+            'channel_id' => '222',
+            'guild_id' => null,
+            'fail_if_not_exists' => true,
+        ], true);
+
+        $builder = MessageBuilder::new();
+        $builder->setMessageReference($messageReference);
+
+        $payload = json_decode($builder->getPayloadJson(), true);
+
+        $this->assertArrayHasKey('message_reference', $payload);
+        $this->assertSame('111', $payload['message_reference']['message_id']);
+        $this->assertSame('222', $payload['message_reference']['channel_id']);
+        $this->assertArrayHasKey('type', $payload['message_reference']);
+        $this->assertSame(MessageReference::TYPE_DEFAULT, $payload['message_reference']['type']);
+    }
+
+    public function testReplyAndForwardLegacyPaths()
+    {
+        $discord = getMockDiscord();
+        $factory = $discord->getFactory();
+
+        $message = $factory->part(Message::class, [
+            'id' => '333',
+            'channel_id' => '444',
+        ], true);
+
+        // Reply (legacy setReplyTo) should produce message_reference without a type key
+        $builder = MessageBuilder::new();
+        $builder->setReplyTo($message);
+        $payload = json_decode($builder->getPayloadJson(), true);
+
+        $this->assertArrayHasKey('message_reference', $payload);
+        $this->assertSame('333', $payload['message_reference']['message_id']);
+        $this->assertSame('444', $payload['message_reference']['channel_id']);
+        $this->assertArrayNotHasKey('type', $payload['message_reference']);
+
+        // Forward (legacy setForward) should include the forward type
+        $builder2 = MessageBuilder::new();
+        $builder2->setForward($message);
+        $payload2 = json_decode($builder2->getPayloadJson(), true);
+
+        $this->assertArrayHasKey('message_reference', $payload2);
+        $this->assertSame(Message::REFERENCE_FORWARD, $payload2['message_reference']['type']);
+        $this->assertSame('333', $payload2['message_reference']['message_id']);
+        $this->assertSame('444', $payload2['message_reference']['channel_id']);
+    }
+}


### PR DESCRIPTION
This PR cleans up and organizes the MessageBuilder class properties and functions to be in line with the official documentation for the [Create Message](https://docs.discord.com/developers/resources/message#create-message) JSON/Form Params.

* Refactored and reorganized `MessageBuilder`, including API cleanup, improved PHPDoc, and annotations.
* Updated `setReplyTo()` / `setForward()` / `getReplyTo()` / `getForward()` to utilize the new `message_reference` varable and methods where appropriate.
* Consolidated sticker, file, attachment, and component APIs, updating the existing multipart payload support to use the new `getPayloadJson()` method.
* Fixed `countTotalComponents()` recursion to correctly count nested components without argument errors.