### PR TITLE
Default parent function

### DIFF
--- a/src/Discord/Parts/PartTrait.php
+++ b/src/Discord/Parts/PartTrait.php
@@ -76,6 +76,21 @@ trait PartTrait
     }
 
     /**
+     * Delete the part with its originating repository.
+     *
+     * @param string|null $reason The reason for the audit log, if supported.
+     *
+     * @throws \Exception             If the part does not support deleting.
+     * @throws NoPermissionsException Missing permission.
+     *
+     * @return PromiseInterface<Part> Resolves with the deleted part.
+     */
+    public function delete(?string $reason = null): PromiseInterface
+    {
+        return reject(new \Exception('This part does not support deleting.'));
+    }
+
+    /**
      * Whether the part is considered partial i.e. missing information which can
      * be fetched from Discord.
      *


### PR DESCRIPTION
This pull request introduces a new method to the `PartTrait` in the Discord library, providing a standardized interface for deleting parts. The method is currently a stub that throws an exception by default, similar to the existing `save` method, indicating that deletion is not supported unless specifically implemented by a subclass.

**New method for part deletion:**

* Added a `delete` method to `PartTrait`, which returns a rejected promise with an exception if deletion is not supported. This creates a consistent interface for deletion operations across parts, similar to the existing `save` method.