### PR TITLE
Implement Identify Part

### DIFF
--- a/src/Discord/Discord.php
+++ b/src/Discord/Discord.php
@@ -26,6 +26,7 @@ use Discord\Http\Endpoint;
 use Discord\Http\Http;
 use Discord\Parts\Channel\Channel;
 use Discord\Parts\Gateway\GetGatewayBot;
+use Discord\Parts\Gateway\Identify;
 use Discord\Parts\Gateway\SessionStartLimit;
 use Discord\Parts\Guild\Guild;
 use Discord\Parts\OAuth\Application;
@@ -1301,7 +1302,7 @@ class Discord
      */
     public function identify(): void
     {
-        $data = [
+        $data = $this->factory->part(Identify::class, [
             'token' => $this->token,
             'properties' => [
                 'os' => PHP_OS,
@@ -1312,37 +1313,37 @@ class Discord
             ],
             'compress' => $this->usePayloadCompression,
             'intents' => $this->options['intents'],
-        ];
+        ]);
 
         if (isset($this->options['large_threshold'])) {
-            $data['large_threshold'] = $this->options['large_threshold'];
+            $data->large_threshold = $this->options['large_threshold'];
         }
 
         if (isset($this->options['shard'])) {
-            $data['shard'] = $this->options['shard'];
+            $data->shard = $this->options['shard'];
         } elseif (isset($this->options['shard_id'], $this->options['num_shards'])) {
-            $data['shard'] = [
+            $data->shard = [
                 (int) $this->options['shard_id'],
                 (int) $this->options['num_shards'],
             ];
         } elseif (isset($this->options['shardId'], $this->options['shardCount'])) {
-            $data['shard'] = [
+            $data->shard = [
                 (int) $this->options['shardId'], // shard_id
                 (int) $this->options['shardCount'], // num_shards
             ];
         }
 
         if (isset($this->options['presence'])) {
-            $data['presence'] = $this->options['presence'];
+            $data->presence = $this->options['presence'];
         }
 
         if (isset($this->options['capabilities']) && $this->options['capabilities']) {
-            $data['capabilities'] = $this->options['capabilities'];
+            $data->capabilities = $this->options['capabilities'];
         }
 
         $payload = Payload::new(
             Op::OP_IDENTIFY,
-            $data,
+            $data->jsonSerialize(),
         );
 
         $this->logger->info('identifying', ['payload' => $payload->__debugInfo()]);


### PR DESCRIPTION
This pull request refactors the `identify()` method in `Discord.php` to use a strongly-typed `Identify` part object instead of a plain array for the identify payload. This change improves code clarity and consistency with the rest of the codebase, and ensures that the payload is properly serialized before being sent.

**Identify payload refactor:**

* The identify payload is now constructed using `$this->factory->part(Identify::class, [...])` instead of a raw array, making it a properly-typed `Identify` part object.
* All additional identify options (`large_threshold`, `shard`, `presence`, `capabilities`) are set as properties on the `Identify` part object rather than as array keys.
* The payload is now serialized with `$data->jsonSerialize()` before being sent, ensuring correct formatting.

**Imports:**

* Added import for `Discord\Parts\Gateway\Identify` to support the new part-based payload construction.