### PR TITLE
Timestamp helper class

### DIFF
--- a/src/Discord/Discord.php
+++ b/src/Discord/Discord.php
@@ -122,7 +122,7 @@ class Discord
      *
      * @var string Version.
      */
-    public const VERSION = 'v10.56.5';
+    public const VERSION = 'v10.56.6';
 
     public const REFERRER = 'https://github.com/discord-php/DiscordPHP';
 

--- a/src/Discord/Helpers/Timestamp.php
+++ b/src/Discord/Helpers/Timestamp.php
@@ -88,13 +88,6 @@ class Timestamp extends Part implements Stringable
     ];
 
     /**
-     * The attributes and content.
-     *
-     * @var array
-     */
-    protected $attributes = [];
-
-    /**
      * @param DateTimeInterface|int|string $timestamp A `DateTimeInterface` (e.g. `DateTime`, `Carbon`) or a Unix timestamp in seconds.
      * @param string                       $format    One of the `Timestamp::*` style constants.
      */

--- a/src/Discord/Helpers/Timestamp.php
+++ b/src/Discord/Helpers/Timestamp.php
@@ -32,7 +32,7 @@ use Stringable;
  * @author Valithor Obsidion <valithor@discordphp.org>
  *
  * @property int    $timestamp Unix timestamp (in seconds) that will be displayed.
- * @property string $format    The Discord timestamp style, one of the `Timestamp::*` constants. Defaults to `Timestamp::RELATIVE_TIME`.
+ * @property string $format    The Discord timestamp style, one of the `Timestamp::*` constants. Defaults to `Timestamp::STYLE_SHORT_DATE_TIME`.
  */
 class Timestamp extends Part implements Stringable
 {

--- a/src/Discord/Helpers/Timestamp.php
+++ b/src/Discord/Helpers/Timestamp.php
@@ -91,7 +91,7 @@ class Timestamp extends Part implements Stringable
      * @param DateTimeInterface|int|string $timestamp A `DateTimeInterface` (e.g. `DateTime`, `Carbon`) or a Unix timestamp in seconds.
      * @param string                       $format    One of the `Timestamp::*` style constants.
      */
-    public function __construct($timestamp, string $format = self::STYLE_SHORT_DATE_TIME)
+    public function new($timestamp, string $format = self::STYLE_SHORT_DATE_TIME)
     {
         $this->setTimestampAttribute($timestamp);
         $this->setFormatAttribute($format);

--- a/src/Discord/Helpers/Timestamp.php
+++ b/src/Discord/Helpers/Timestamp.php
@@ -1,0 +1,150 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is a part of the DiscordPHP project.
+ *
+ * Copyright (c) 2015-2022 David Cole <david.cole1340@gmail.com>
+ * Copyright (c) 2020-present Valithor Obsidion <valithor@discordphp.org>
+ *
+ * This file is subject to the MIT license that is bundled
+ * with this source code in the LICENSE.md file.
+ */
+
+namespace Discord\Helpers;
+
+use Discord\Parts\Part;
+
+use DateTimeInterface;
+use InvalidArgumentException;
+use ReflectionClass;
+use Stringable;
+
+/**
+ * Timestamp is a helper class for formatting timestamps in Discord messages.
+ *
+ * https://docs.discord.com/developers/reference#message-formatting
+ *
+ * @since 10.56.6
+ *
+ * @author Valithor Obsidion <valithor@discordphp.org>
+ *
+ * @property int    $timestamp Unix timestamp (in seconds) that will be displayed.
+ * @property string $format    The Discord timestamp style, one of the `Timestamp::*` constants. Defaults to `Timestamp::RELATIVE_TIME`.
+ */
+class Timestamp extends Part implements Stringable
+{
+    /** Short Time, e.g. `16:20`. */
+    public const STYLE_SHORT_TIME = 't';
+
+    /** Long Time, e.g. `16:20:30`. */
+    public const STYLE_LONG_TIME = 'T';
+
+    /** Short Date, e.g. `20/04/2021`. */
+    public const STYLE_SHORT_DATE = 'd';
+
+    /** Long Date, e.g. `April 20, 2021`. */
+    public const STYLE_LONG_DATE = 'D';
+
+    /** Short Date/Time, e.g. `20 April 2021 16:20`. Default. */
+    public const STYLE_SHORT_DATE_TIME = 'f';
+
+    /** Long Date/Time, e.g. `Tuesday, April 20, 2021 16:20`. */
+    public const STYLE_LONG_DATE_TIME = 'F';
+
+    /** Short Date, Short Time, e.g. `20/04/2021, 16:20`. */
+    public const STYLE_SHORT_DATE_SHORT_TIME = 's';
+
+    /** Short Date, Medium Time, e.g. `20/04/2021, 16:20:30`. */
+    public const STYLE_SHORT_DATE_MEDIUM_TIME = 'S';
+
+    /** Relative Time, e.g. `4 years ago`. */
+    public const STYLE_RELATIVE_TIME = 'R';
+
+    /**
+     * All valid Discord timestamp styles.
+     *
+     * @var string[]
+     */
+    public const STYLES = [
+        self::STYLE_SHORT_TIME,
+        self::STYLE_LONG_TIME,
+        self::STYLE_SHORT_DATE,
+        self::STYLE_LONG_DATE,
+        self::STYLE_SHORT_DATE_TIME,
+        self::STYLE_LONG_DATE_TIME,
+        self::STYLE_SHORT_DATE_SHORT_TIME,
+        self::STYLE_SHORT_DATE_MEDIUM_TIME,
+        self::STYLE_RELATIVE_TIME,
+    ];
+
+    /**
+     * @inheritdoc
+     */
+    protected $fillable = [
+        'timestamp',
+        'format',
+    ];
+
+    /**
+     * The attributes and content.
+     *
+     * @var array
+     */
+    protected $attributes = [];
+
+    /**
+     * @param DateTimeInterface|int|string $timestamp A `DateTimeInterface` (e.g. `DateTime`, `Carbon`) or a Unix timestamp in seconds.
+     * @param string                       $format    One of the `Timestamp::*` style constants.
+     */
+    public function __construct($timestamp, string $format = self::STYLE_SHORT_DATE_TIME)
+    {
+        $this->setTimestampAttribute($timestamp);
+        $this->setFormatAttribute($format);
+    }
+
+    /**
+     * Normalizes and sets the `timestamp` attribute from a `DateTimeInterface` or Unix timestamp.
+     *
+     * @param DateTimeInterface|int|string $timestamp
+     */
+    protected function setTimestampAttribute($timestamp): void
+    {
+        if ($timestamp instanceof DateTimeInterface) {
+            $timestamp = $timestamp->getTimestamp();
+        } elseif (! is_numeric($timestamp)) {
+            throw new InvalidArgumentException('Timestamp must be a DateTimeInterface (e.g. DateTime, Carbon) or a Unix timestamp.');
+        }
+
+        $this->attributes['timestamp'] = (int) $timestamp;
+    }
+
+    /**
+     * Sets the `format` attribute, ensuring it is one of the valid Discord timestamp styles.
+     *
+     * @param string $format
+     *
+     * @throws \InvalidArgumentException
+     */
+    protected function setFormatAttribute(string $format): void
+    {
+        $styles = array_values((new ReflectionClass(Timestamp::class))->getConstants());
+
+        if (! in_array($format, $styles, true)) {
+            throw new InvalidArgumentException('Format must be one of the Timestamp styles.');
+        }
+
+        $this->attributes['format'] = $format;
+    }
+
+    /**
+     * Converts the timestamp to Discord's `<t:UNIX_TIMESTAMP:FORMAT>` markdown.
+     *
+     * @link https://discord.com/developers/docs/reference#message-formatting
+     */
+    public function __toString(): string
+    {
+        return sprintf('<t:%d:%s>', $this->timestamp, $this->format);
+    }
+}

--- a/src/Discord/Helpers/Timestamp.php
+++ b/src/Discord/Helpers/Timestamp.php
@@ -92,8 +92,8 @@ class Timestamp implements Stringable
      */
     public function __construct($timestamp, string $format = self::STYLE_SHORT_DATE_TIME)
     {
-        $this->setProperty('timestamp', $timestamp);
-        $this->setProperty('format', $format);
+        $this->setTimestamp($timestamp);
+        $this->setFormat($format);
     }
 
     /**

--- a/src/Discord/Helpers/Timestamp.php
+++ b/src/Discord/Helpers/Timestamp.php
@@ -14,12 +14,8 @@ declare(strict_types=1);
 
 namespace Discord\Helpers;
 
-use Discord\Parts\Part;
-
 use DateTimeInterface;
-use Discord\Discord;
 use InvalidArgumentException;
-use ReflectionClass;
 use Stringable;
 
 /**
@@ -34,8 +30,16 @@ use Stringable;
  * @property int    $timestamp Unix timestamp (in seconds) that will be displayed.
  * @property string $format    The Discord timestamp style, one of the `Timestamp::*` constants. Defaults to `Timestamp::STYLE_SHORT_DATE_TIME`.
  */
-class Timestamp extends Part implements Stringable
+class Timestamp implements Stringable
 {
+    use DynamicPropertyMutatorTrait;
+
+    /** Unix timestamp (in seconds) that will be displayed. */
+    protected int $timestamp;
+
+    /** The Discord timestamp style, one of the `Timestamp::*` constants. Defaults to `Timestamp::STYLE_SHORT_DATE_TIME`. */
+    protected string $format;
+
     /** Short Time, e.g. `16:20`. */
     public const STYLE_SHORT_TIME = 't';
 
@@ -81,27 +85,34 @@ class Timestamp extends Part implements Stringable
     ];
 
     /**
-     * @inheritdoc
+     * Creates a new Timestamp instance.
+     *
+     * @param DateTimeInterface|int|string $timestamp A `DateTimeInterface` (e.g. `DateTime`, `Carbon`) or a Unix timestamp in seconds.
+     * @param string                       $format    One of the `Timestamp::*` style constants.
      */
-    protected $fillable = [
-        'timestamp',
-        'format',
-    ];
+    public function __construct($timestamp, string $format = self::STYLE_SHORT_DATE_TIME)
+    {
+        $this->setProperty('timestamp', $timestamp);
+        $this->setProperty('format', $format);
+    }
 
     /**
      * Creates a new Timestamp instance.
      *
-     * @param Discord                      $discord   The Discord client instance.
      * @param DateTimeInterface|int|string $timestamp A `DateTimeInterface` (e.g. `DateTime`, `Carbon`) or a Unix timestamp in seconds.
      * @param string                       $format    One of the `Timestamp::*` style constants.
      */
-    public static function new(Discord $discord, $timestamp, string $format = self::STYLE_SHORT_DATE_TIME)
+    public static function new($timestamp, string $format = self::STYLE_SHORT_DATE_TIME): self
     {
-        $instance = new self($discord);
-        $instance->timestamp = $timestamp;
-        $instance->format = $format;
+        return new self($timestamp, $format);
+    }
 
-        return $instance;
+    /**
+     * @return int Unix timestamp (in seconds).
+     */
+    protected function getTimestamp(): int
+    {
+        return $this->timestamp;
     }
 
     /**
@@ -109,7 +120,7 @@ class Timestamp extends Part implements Stringable
      *
      * @param DateTimeInterface|int|string $timestamp
      */
-    protected function setTimestampAttribute($timestamp): void
+    protected function setTimestamp($timestamp): void
     {
         if ($timestamp instanceof DateTimeInterface) {
             $timestamp = $timestamp->getTimestamp();
@@ -117,7 +128,15 @@ class Timestamp extends Part implements Stringable
             throw new InvalidArgumentException('Timestamp must be a DateTimeInterface (e.g. DateTime, Carbon) or a Unix timestamp.');
         }
 
-        $this->attributes['timestamp'] = (int) $timestamp;
+        $this->timestamp = (int) $timestamp;
+    }
+
+    /**
+     * @return string One of the `Timestamp::STYLE_*` constants.
+     */
+    protected function getFormat(): string
+    {
+        return $this->format;
     }
 
     /**
@@ -127,15 +146,13 @@ class Timestamp extends Part implements Stringable
      *
      * @throws \InvalidArgumentException
      */
-    protected function setFormatAttribute(string $format): void
+    protected function setFormat(string $format): void
     {
-        $styles = array_values((new ReflectionClass(Timestamp::class))->getConstants());
-
-        if (! in_array($format, $styles, true)) {
+        if (! in_array($format, self::STYLES, true)) {
             throw new InvalidArgumentException('Format must be one of the Timestamp styles.');
         }
 
-        $this->attributes['format'] = $format;
+        $this->format = $format;
     }
 
     /**

--- a/src/Discord/Helpers/Timestamp.php
+++ b/src/Discord/Helpers/Timestamp.php
@@ -17,6 +17,7 @@ namespace Discord\Helpers;
 use Discord\Parts\Part;
 
 use DateTimeInterface;
+use Discord\Discord;
 use InvalidArgumentException;
 use ReflectionClass;
 use Stringable;
@@ -88,13 +89,19 @@ class Timestamp extends Part implements Stringable
     ];
 
     /**
+     * Creates a new Timestamp instance.
+     *
+     * @param Discord                      $discord   The Discord client instance.
      * @param DateTimeInterface|int|string $timestamp A `DateTimeInterface` (e.g. `DateTime`, `Carbon`) or a Unix timestamp in seconds.
      * @param string                       $format    One of the `Timestamp::*` style constants.
      */
-    public function new($timestamp, string $format = self::STYLE_SHORT_DATE_TIME)
+    public static function new(Discord $discord, $timestamp, string $format = self::STYLE_SHORT_DATE_TIME)
     {
-        $this->setTimestampAttribute($timestamp);
-        $this->setFormatAttribute($format);
+        $instance = new self($discord);
+        $instance->timestamp = $timestamp;
+        $instance->format = $format;
+
+        return $instance;
     }
 
     /**

--- a/tests/TimestampTest.php
+++ b/tests/TimestampTest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is a part of the DiscordPHP project.
+ *
+ * Copyright (c) 2015-2022 David Cole <david.cole1340@gmail.com>
+ * Copyright (c) 2020-present Valithor Obsidion <valithor@discordphp.org>
+ *
+ * This file is subject to the MIT license that is bundled
+ * with this source code in the LICENSE.md file.
+ */
+
+use Discord\Helpers\Timestamp;
+
+final class TimestampTest extends DiscordTestCase
+{
+    /**
+     * @covers \Discord\Helpers\Timestamp::__construct
+     * @covers \Discord\Helpers\Timestamp::__toString
+     */
+    public function testCreatesTimestampWithDefaultFormat(): void
+    {
+        $timestamp = new Timestamp(1700000000);
+
+        $this->assertSame(1700000000, $timestamp->timestamp);
+        $this->assertSame(Timestamp::STYLE_SHORT_DATE_TIME, $timestamp->format);
+        $this->assertSame('<t:1700000000:f>', (string) $timestamp);
+    }
+
+    /**
+     * @covers \Discord\Helpers\Timestamp::new
+     */
+    public function testCreatesTimestampWithFactory(): void
+    {
+        $timestamp = Timestamp::new('1700000000', Timestamp::STYLE_RELATIVE_TIME);
+
+        $this->assertSame(1700000000, $timestamp->timestamp);
+        $this->assertSame(Timestamp::STYLE_RELATIVE_TIME, $timestamp->format);
+        $this->assertSame('<t:1700000000:R>', (string) $timestamp);
+    }
+
+    /**
+     * @covers \Discord\Helpers\Timestamp::setTimestamp
+     */
+    public function testNormalizesDateTimeTimestamp(): void
+    {
+        $timestamp = new Timestamp(new DateTimeImmutable('@1700000000'));
+
+        $this->assertSame(1700000000, $timestamp->timestamp);
+    }
+
+    /**
+     * @covers \Discord\Helpers\Timestamp::__set
+     * @covers \Discord\Helpers\Timestamp::setTimestamp
+     * @covers \Discord\Helpers\Timestamp::setFormat
+     */
+    public function testMagicPropertiesCanBeUpdated(): void
+    {
+        $timestamp = new Timestamp(1700000000);
+
+        $timestamp->timestamp = '1700000001';
+        $timestamp->format = Timestamp::STYLE_LONG_DATE_TIME;
+
+        $this->assertSame(1700000001, $timestamp->timestamp);
+        $this->assertSame(Timestamp::STYLE_LONG_DATE_TIME, $timestamp->format);
+        $this->assertSame('<t:1700000001:F>', (string) $timestamp);
+    }
+
+    /**
+     * @covers \Discord\Helpers\Timestamp::setTimestamp
+     */
+    public function testRejectsInvalidTimestamp(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        new Timestamp('not-a-timestamp');
+    }
+
+    /**
+     * @covers \Discord\Helpers\Timestamp::setFormat
+     */
+    public function testRejectsInvalidFormat(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        new Timestamp(1700000000, 'invalid');
+    }
+}


### PR DESCRIPTION
This pull request introduces a new helper class for formatting Discord timestamps and updates the library version. The main addition is the `Timestamp` class, which makes it easier to create properly formatted timestamp strings for Discord messages using various display styles.

**New Feature: Discord Timestamp Formatting**

* Added a new `Timestamp` helper class in `src/Discord/Helpers/Timestamp.php` to simplify generating Discord-formatted timestamps. This class supports multiple display styles (e.g., short time, long date, relative time) and ensures input validation for timestamps and formats. It provides a convenient API for creating and formatting timestamps for Discord messages.

**Version Update**

* Updated the `Discord` class version constant from `v10.56.5` to `v10.56.6` in `src/Discord/Discord.php` to reflect the new release.