### PR TITLE
Fix slash command regex apostrophe

### DIFF
--- a/src/Discord/Builders/CommandAttributes.php
+++ b/src/Discord/Builders/CommandAttributes.php
@@ -86,7 +86,7 @@ trait CommandAttributes
             throw new \LengthException('Command name can be only up to 32 characters long.');
         }
 
-        if ($this->type === Command::CHAT_INPUT && preg_match('/^[-_\u{02BC}\p{L}\p{N}\p{sc=Deva}\p{sc=Thai}]{1,32}$/u', $name) === 0) {
+        if ($this->type === Command::CHAT_INPUT && preg_match('/^[-_\x{02BC}\p{L}\p{N}\p{sc=Deva}\p{sc=Thai}]{1,32}$/u', $name) !== 1) {
             throw new \DomainException('Slash command name contains invalid characters.');
         }
 
@@ -116,7 +116,7 @@ trait CommandAttributes
                 throw new \LengthException('Command name can be only up to 32 characters long.');
             }
 
-            if ($this->type === Command::CHAT_INPUT && preg_match('/^[-_\u{02BC}\p{L}\p{N}\p{sc=Deva}\p{sc=Thai}]{1,32}$/u', $name) === 0) {
+            if ($this->type === Command::CHAT_INPUT && preg_match('/^[-_\x{02BC}\p{L}\p{N}\p{sc=Deva}\p{sc=Thai}]{1,32}$/u', $name) !== 1) {
                 throw new \DomainException('Slash command localized name contains invalid characters.');
             }
         }

--- a/src/Discord/Builders/CommandAttributes.php
+++ b/src/Discord/Builders/CommandAttributes.php
@@ -86,7 +86,7 @@ trait CommandAttributes
             throw new \LengthException('Command name can be only up to 32 characters long.');
         }
 
-        if ($this->type === Command::CHAT_INPUT && preg_match('/^[-_\p{L}\p{N}\p{Devanagari}\p{Thai}]{1,32}$/u', $name) === 0) {
+        if ($this->type === Command::CHAT_INPUT && preg_match('/^[-_\u{02BC}\p{L}\p{N}\p{sc=Deva}\p{sc=Thai}]{1,32}$/u', $name) === 0) {
             throw new \DomainException('Slash command name contains invalid characters.');
         }
 
@@ -116,7 +116,7 @@ trait CommandAttributes
                 throw new \LengthException('Command name can be only up to 32 characters long.');
             }
 
-            if ($this->type === Command::CHAT_INPUT && preg_match('/^[-_\p{L}\p{N}\p{Devanagari}\p{Thai}]{1,32}$/u', $name) === 0) {
+            if ($this->type === Command::CHAT_INPUT && preg_match('/^[-_\u{02BC}\p{L}\p{N}\p{sc=Deva}\p{sc=Thai}]{1,32}$/u', $name) === 0) {
                 throw new \DomainException('Slash command localized name contains invalid characters.');
             }
         }

--- a/src/Discord/Parts/Interactions/Command/Option.php
+++ b/src/Discord/Parts/Interactions/Command/Option.php
@@ -134,7 +134,7 @@ class Option extends Part
 
     /**
      * Sets the name of the option.
-     * CHAT_INPUT command option names must match the following regex ^[\w-]{1,32}$ with the unicode flag set.
+     * CHAT_INPUT command option names must match the following regex ^[-_\u02BC\p{L}\p{N}\p{sc=Deva}\p{sc=Thai}]{1,32}$ with the unicode flag set.
      * If there is a lowercase variant of any letters used, you must use those.
      * Characters with no lowercase variants and/or uncased letters are still allowed.
      *
@@ -157,7 +157,7 @@ class Option extends Part
 
     /**
      * Sets the name of the option in another language.
-     * CHAT_INPUT command option names must match the following regex ^[\w-]{1,32}$ with the unicode flag set.
+     * CHAT_INPUT command option names must match the following regex ^[-_\u02BC\p{L}\p{N}\p{sc=Deva}\p{sc=Thai}]{1,32}$ with the unicode flag set.
      * If there is a lowercase variant of any letters used, you must use those.
      * Characters with no lowercase variants and/or uncased letters are still allowed.
      *

--- a/tests/Builders/CommandNameTest.php
+++ b/tests/Builders/CommandNameTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is a part of the DiscordPHP project.
+ *
+ * Copyright (c) 2015-2022 David Cole <david.cole1340@gmail.com>
+ * Copyright (c) 2020-present Valithor Obsidion <valithor@discordphp.org>
+ *
+ * This file is subject to the MIT license that is bundled
+ * with this source code in the LICENSE.md file.
+ */
+
+use Discord\Builders\CommandBuilder;
+use Discord\Discord;
+use Discord\Parts\Interactions\Command\Option;
+
+final class CommandNameTest extends DiscordTestCase
+{
+    public function testChatInputNamesAcceptDiscordCharacters(): void
+    {
+        $discord = $this->createMock(Discord::class);
+
+        foreach (['foo-bar_123', 'fooʼbar', 'कमान्ड', 'คำสั่ง'] as $name) {
+            $this->assertSame($name, CommandBuilder::new()->setName($name)->jsonSerialize()['name']);
+
+            $option = new Option($discord);
+            $this->assertSame($name, $option->setName($name)->name);
+        }
+    }
+
+    public function testChatInputNamesRejectInvalidCharacters(): void
+    {
+        $this->expectException(\DomainException::class);
+        CommandBuilder::new()->setName('foo.bar');
+    }
+
+    public function testOptionNamesRejectInvalidCharacters(): void
+    {
+        $discord = $this->createMock(Discord::class);
+
+        $this->expectException(\DomainException::class);
+        (new Option($discord))->setName('foo.bar');
+    }
+}


### PR DESCRIPTION
https://github.com/discord/discord-api-docs/commit/9287523c46429cfc30a5e46088e4f062ab364537

This pull request updates the validation rules for Discord slash command names and their localizations to allow a broader set of Unicode characters. The main change is to the regular expression used for validating command names, specifically adding support for the modifier letter apostrophe and improving script matching for Devanagari and Thai.

**Validation improvements for command names:**

* The regular expression in `setName` and `setNameLocalization` was updated to allow the modifier letter apostrophe (`\u{02BC}`) and to use Unicode script properties (`\p{sc=Deva}` and `\p{sc=Thai}`) for more accurate support of Devanagari and Thai scripts. (`src/Discord/Builders/CommandAttributes.php`) [[1]](diffhunk://#diff-3eb7dfcca1697e681b65575963ad32d6a46c7adca75b23f77fce4ac890a60025L89-R89) [[2]](diffhunk://#diff-3eb7dfcca1697e681b65575963ad32d6a46c7adca75b23f77fce4ac890a60025L119-R119)https://github.com/discord/discord-api-docs/commit/9287523c46429cfc30a5e46088e4f062ab364537